### PR TITLE
feat(appetit): export du Risk Appetite Statement (RAS) en PDF

### DIFF
--- a/scripts/compile-pdf-template.mjs
+++ b/scripts/compile-pdf-template.mjs
@@ -13,6 +13,7 @@ const root = path.dirname(fileURLToPath(import.meta.url)) + '/..'
 const TEMPLATES = [
   { entry: 'src/lib/pdf-template.tsx', out: '.pdf-runtime/pdf-template.cjs' },
   { entry: 'src/lib/carto-pdf-template.tsx', out: '.pdf-runtime/carto-pdf-template.cjs' },
+  { entry: 'src/lib/ras-pdf-template.tsx', out: '.pdf-runtime/ras-pdf-template.cjs' },
 ]
 
 for (const { entry, out } of TEMPLATES) {

--- a/src/__tests__/unit/lib/ras-export.test.ts
+++ b/src/__tests__/unit/lib/ras-export.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { buildRasExport, type RasRiskLite } from '../../../lib/ras-export'
+import { type AppetitConfig } from '../../../lib/appetit'
+
+const labelOf = (code: string) => ({ SI: 'Systèmes d\'information', FRAUDE: 'Fraude' }[code] ?? code)
+
+const cfg: AppetitConfig = { seuilGlobal: 9, parCategorie: { FRAUDE: 4 } }
+
+const risks: RasRiskLite[] = [
+  { intitule: 'Panne SI', taxonomieCode: 'SI', niveauResiduel: 12 },     // 12 > 9 → HORS (écart 3)
+  { intitule: 'Phishing', taxonomieCode: 'SI', niveauResiduel: 6 },      // 6 <= 9 → DANS
+  { intitule: 'Détournement', taxonomieCode: 'FRAUDE', niveauResiduel: 9 }, // 9 > 4 → HORS (écart 5)
+  { intitule: 'Non coté', taxonomieCode: 'SI', niveauResiduel: null },   // INCONNU
+]
+
+describe('buildRasExport', () => {
+  it('expose le seuil global et les seuils par catégorie (avec libellés)', () => {
+    const ras = buildRasExport(risks, cfg, labelOf)
+    expect(ras.seuilGlobal).toBe(9)
+    expect(ras.categories).toEqual([{ code: 'FRAUDE', label: 'Fraude', seuil: 4 }])
+  })
+
+  it('calcule la synthèse et le taux de conformité (dans / évalués)', () => {
+    const ras = buildRasExport(risks, cfg, labelOf)
+    expect(ras.synthese.total).toBe(4)
+    expect(ras.synthese.evalues).toBe(3)
+    expect(ras.synthese.horsAppetit).toBe(2)
+    expect(ras.synthese.dansAppetit).toBe(1)
+    expect(ras.tauxConformite).toBe(33) // 1/3
+  })
+
+  it('liste les dépassements triés par écart décroissant', () => {
+    const ras = buildRasExport(risks, cfg, labelOf)
+    expect(ras.depassements.map(d => d.intitule)).toEqual(['Détournement', 'Panne SI'])
+    expect(ras.depassements[0]).toMatchObject({ categorieLabel: 'Fraude', niveauResiduel: 9, seuil: 4, ecart: 5 })
+  })
+
+  it('taux de conformité à 100 quand aucun risque évaluable (pas de division par zéro)', () => {
+    const ras = buildRasExport([{ intitule: 'x', taxonomieCode: null, niveauResiduel: 5 }], { seuilGlobal: null, parCategorie: {} }, labelOf)
+    expect(ras.synthese.evalues).toBe(0)
+    expect(ras.tauxConformite).toBe(100)
+    expect(ras.depassements).toEqual([])
+  })
+})

--- a/src/app/api/appetit/ras/route.ts
+++ b/src/app/api/appetit/ras/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { getAnalyseScope } from '@/lib/org-context.server'
+import { getOrgConfig } from '@/lib/org-config.server'
+import { type UserRole } from '@/lib/permissions'
+import { niveauRisque } from '@/lib/risk-item'
+import { resolveTaxonomie, taxonomieLabel } from '@/lib/taxonomie'
+import { getT } from '@/lib/i18n'
+import { cleanAppetitConfig } from '@/lib/appetit'
+import { buildRasExport, type RasRiskLite } from '@/lib/ras-export'
+import { auditLog, getClientIp } from '@/lib/logger'
+import { createRequire } from 'node:module'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/appetit/ras — Risk Appetite Statement (RAS) au format PDF.
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  const userId = (session.user as { id: string }).id
+  const instanceRole = ((session.user as { role?: string }).role ?? 'ANALYSTE') as UserRole
+
+  const scope = await getAnalyseScope(userId, instanceRole)
+  const role = scope.role
+  const orgId = scope.activeOrgId
+  if (!orgId) return NextResponse.json({ error: 'Aucune organisation active' }, { status: 400 })
+  // Le RAS relève de la gouvernance : 1ʳᵉ ligne « pure » exclue.
+  if (role === 'LECTEUR' || role === 'METIER') return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  const orgConfig = await getOrgConfig(orgId)
+  if (!orgConfig.registreRisquesActive) return NextResponse.json({ error: 'Module non activé' }, { status: 403 })
+
+  const rows = await prisma.riskItem.findMany({
+    where: { organizationId: orgId },
+    select: { intitule: true, taxonomieCode: true, graviteResiduelle: true, vraisemblanceResiduelle: true },
+  })
+  const risks: RasRiskLite[] = rows.map(r => ({
+    intitule: r.intitule,
+    taxonomieCode: r.taxonomieCode ?? null,
+    niveauResiduel: niveauRisque(r.graviteResiduelle, r.vraisemblanceResiduelle),
+  }))
+
+  const langParam = new URL(req.url).searchParams.get('lang')
+  const locale = ['fr', 'en', 'de', 'es', 'it'].includes(langParam ?? '') ? (langParam as string) : 'fr'
+  const tCat = getT(locale)
+  const trCat = (key: string) => key.split('.').reduce<unknown>((o, k) => (o as Record<string, unknown>)?.[k], tCat) as string ?? ''
+  const taxonomie = resolveTaxonomie(orgConfig.taxonomieRisques)
+  const labelOf = (code: string): string => {
+    const node = taxonomie.find(n => n.code === code)
+    return (node ? taxonomieLabel(node, trCat) : null) ?? code
+  }
+
+  const cfg = cleanAppetitConfig(orgConfig.appetitRisque)
+  const data = buildRasExport(risks, cfg, labelOf)
+
+  await auditLog('ORGANIZATION_CONFIG_UPDATED', {
+    userId, userRole: role, organizationId: orgId, ip: getClientIp(req),
+    details: { scope: 'appetit-ras', action: 'export', format: 'pdf' },
+  })
+
+  const stamp = new Date().toISOString().slice(0, 10)
+  try {
+    const nodeRequire = createRequire(process.cwd() + '/package.json')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { renderRasPDF } = nodeRequire(process.cwd() + '/.pdf-runtime/ras-pdf-template.cjs')
+    const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { nom: true } })
+    const buffer = await renderRasPDF(data, locale, org?.nom ?? '', stamp)
+    return new NextResponse(buffer as unknown as ArrayBuffer, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="acra-ras-${stamp}.pdf"`,
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (err) {
+    console.error('[export ras pdf] génération échouée', err)
+    return NextResponse.json({ error: 'Échec de la génération du PDF' }, { status: 500 })
+  }
+}

--- a/src/components/PilotageGrc.tsx
+++ b/src/components/PilotageGrc.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AlertTriangle, BarChart3 } from 'lucide-react'
+import { AlertTriangle, BarChart3, FileText } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useTranslation } from '@/lib/i18n/context'
@@ -106,7 +106,15 @@ export default function PilotageGrc() {
     <div>
       <div className="flex items-center justify-between mb-1 flex-wrap gap-2">
         <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100"><BarChart3 size={22} className="inline align-[-0.15em] mr-2" aria-hidden="true" /> {p.title}</h1>
-        <span className="text-xs text-gray-400">{p.scope.replace('{n}', String(data.orgCount))}</span>
+        <div className="flex items-center gap-3">
+          {mod.appetit && (
+            <a href={`/api/appetit/ras?lang=${locale}`}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800">
+              <FileText size={15} aria-hidden="true" /> {p.exportRas}
+            </a>
+          )}
+          <span className="text-xs text-gray-400">{p.scope.replace('{n}', String(data.orgCount))}</span>
+        </div>
       </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">{p.subtitle}</p>
 

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1048,6 +1048,7 @@ export const de: Translations = {
     title: 'GRC-Steuerung',
     subtitle: 'Konsolidierte Sicht des Organisationsteilbaums: Risikolage und Fortschritt der Maßnahmenpläne je Einheit.',
     scope: '{n} Organisation(en)',
+    exportRas: 'RAS (PDF)',
     inactive: 'Modul nicht aktiviert.',
     total: 'Risiken',
     eleves: 'Hoch',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1048,6 +1048,7 @@ export const en: Translations = {
     title: 'GRC steering',
     subtitle: 'Consolidated view of the organization subtree: risk posture and action-plan progress per entity.',
     scope: '{n} organization(s)',
+    exportRas: 'RAS (PDF)',
     inactive: 'Module not enabled.',
     total: 'Risks',
     eleves: 'High',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1048,6 +1048,7 @@ export const es: Translations = {
     title: 'Pilotaje GRC',
     subtitle: 'Vista consolidada del subárbol de organizaciones: postura de riesgo y avance de los planes de acción por entidad.',
     scope: '{n} organización(es)',
+    exportRas: 'RAS (PDF)',
     inactive: 'Módulo no activado.',
     total: 'Riesgos',
     eleves: 'Altos',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1071,6 +1071,7 @@ export const fr = {
     title: 'Pilotage GRC',
     subtitle: 'Vue consolidée du sous-arbre d\'organisations : posture de risque et avancement des plans d\'action par entité.',
     scope: '{n} organisation(s)',
+    exportRas: 'RAS (PDF)',
     inactive: 'Module non activé.',
     total: 'Risques',
     eleves: 'Élevés',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1048,6 +1048,7 @@ export const it: Translations = {
     title: 'Pilotaggio GRC',
     subtitle: 'Vista consolidata del sottoalbero di organizzazioni: postura di rischio e avanzamento dei piani d\'azione per entità.',
     scope: '{n} organizzazione/i',
+    exportRas: 'RAS (PDF)',
     inactive: 'Modulo non attivato.',
     total: 'Rischi',
     eleves: 'Alti',

--- a/src/lib/ras-export.ts
+++ b/src/lib/ras-export.ts
@@ -1,0 +1,66 @@
+// ─── Risk Appetite Statement (RAS) — assemblage de la donnée d'export ────────
+// Le RAS est le document de GOUVERNANCE formalisant l'appétit au risque : seuil
+// global + surcharges par catégorie, posture courante (conformité) et liste des
+// dépassements (risques hors appétit). Réutilise le moteur `appetit.ts`. Logique
+// PURE et testée ; l'API et le PDF ne font qu'appliquer cet assemblage.
+
+import {
+  type AppetitConfig, seuilApplicable, evaluerAppetit, synthetiserAppetit, type AppetitSynthese,
+} from './appetit'
+
+export interface RasRiskLite {
+  intitule: string
+  taxonomieCode: string | null
+  niveauResiduel: number | null
+}
+
+export interface RasCategorieSeuil { code: string; label: string; seuil: number }
+export interface RasDepassement {
+  intitule: string
+  categorieLabel: string
+  niveauResiduel: number
+  seuil: number
+  ecart: number
+}
+
+export interface RasExportData {
+  seuilGlobal: number | null
+  categories: RasCategorieSeuil[]
+  synthese: AppetitSynthese
+  /** % de risques évaluables qui sont DANS l'appétit (100 si aucun évaluable). */
+  tauxConformite: number
+  depassements: RasDepassement[]
+}
+
+export function buildRasExport(
+  risks: RasRiskLite[],
+  cfg: AppetitConfig,
+  labelOf: (code: string) => string,
+): RasExportData {
+  const categories: RasCategorieSeuil[] = Object.entries(cfg.parCategorie ?? {})
+    .map(([code, seuil]) => ({ code, label: labelOf(code), seuil }))
+    .sort((a, b) => a.code.localeCompare(b.code))
+
+  const synthese = synthetiserAppetit(
+    risks.map(r => ({ taxonomieCode: r.taxonomieCode, niveauResiduel: r.niveauResiduel })), cfg,
+  )
+
+  const depassements: RasDepassement[] = []
+  for (const r of risks) {
+    const seuil = seuilApplicable(cfg, r.taxonomieCode)
+    if (evaluerAppetit(r.niveauResiduel, seuil) !== 'HORS') continue
+    // HORS ⇒ seuil et niveauResiduel sont non nuls.
+    const niveau = r.niveauResiduel as number
+    const s = seuil as number
+    depassements.push({
+      intitule: r.intitule,
+      categorieLabel: r.taxonomieCode ? labelOf(r.taxonomieCode) : '—',
+      niveauResiduel: niveau, seuil: s, ecart: niveau - s,
+    })
+  }
+  depassements.sort((a, b) => b.ecart - a.ecart || b.niveauResiduel - a.niveauResiduel)
+
+  const tauxConformite = synthese.evalues ? Math.round((synthese.dansAppetit / synthese.evalues) * 100) : 100
+
+  return { seuilGlobal: cfg.seuilGlobal ?? null, categories, synthese, tauxConformite, depassements }
+}

--- a/src/lib/ras-pdf-template.tsx
+++ b/src/lib/ras-pdf-template.tsx
@@ -1,0 +1,153 @@
+/**
+ * ras-pdf-template.tsx — Risk Appetite Statement (RAS), document de gouvernance.
+ *
+ * ⚠️ Mêmes contraintes que pdf-template.tsx :
+ *   • AUCUN Fragment JSX (regrouper via <View>) — sinon « React error #31 » ;
+ *   • jamais de chaîne potentiellement vide comme enfant direct d'un <View>
+ *     (cf. lib/pdf-guards.ts) : toujours coercer les gardes en booléen.
+ * Compilé en CJS autonome par scripts/compile-pdf-template.mjs puis chargé au
+ * RUNTIME par la route d'export (SWC casse le rendu react-pdf).
+ */
+
+import { Document, Page, Text, View, StyleSheet, renderToBuffer } from '@react-pdf/renderer'
+import type { RasExportData } from '@/lib/ras-export'
+import { isNonEmptyText } from '@/lib/pdf-guards'
+
+const COLORS = {
+  primary: '#4338CA',
+  danger: '#DC2626',
+  ok: '#16A34A',
+  border: '#E5E7EB',
+  muted: '#6B7280',
+  headerBg: '#EEF2FF',
+}
+
+const s = StyleSheet.create({
+  page: { padding: 36, fontSize: 9, color: '#111827' },
+  h1: { fontSize: 18, fontWeight: 'bold', color: COLORS.primary, marginBottom: 4 },
+  sub: { fontSize: 9, color: COLORS.muted, marginBottom: 14 },
+  intro: { fontSize: 9, color: '#374151', marginBottom: 12, lineHeight: 1.4 },
+  h2: { fontSize: 12, fontWeight: 'bold', marginTop: 14, marginBottom: 6 },
+  kpiRow: { flexDirection: 'row', marginBottom: 10 },
+  kpi: { flex: 1, borderWidth: 1, borderColor: COLORS.border, borderRadius: 4, padding: 8, marginRight: 6 },
+  kpiLabel: { fontSize: 7, color: COLORS.muted, marginBottom: 2 },
+  kpiValue: { fontSize: 14, fontWeight: 'bold' },
+  statement: { borderWidth: 1, borderColor: COLORS.border, borderRadius: 4, padding: 10, marginBottom: 8 },
+  statementLabel: { fontSize: 8, color: COLORS.muted },
+  statementValue: { fontSize: 16, fontWeight: 'bold', color: COLORS.primary },
+  table: { marginTop: 4 },
+  tr: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: COLORS.border, paddingVertical: 3 },
+  thRow: { flexDirection: 'row', backgroundColor: COLORS.headerBg, paddingVertical: 4 },
+  th: { fontSize: 8, fontWeight: 'bold', paddingHorizontal: 4 },
+  td: { fontSize: 8, paddingHorizontal: 4 },
+  empty: { fontSize: 9, color: COLORS.muted, fontStyle: 'italic', marginTop: 4 },
+  footer: { position: 'absolute', bottom: 20, left: 36, right: 36, fontSize: 7, color: COLORS.muted, textAlign: 'center' },
+})
+
+type Strings = {
+  title: string; subtitle: string; intro: string
+  globalThreshold: string; noThreshold: string; scale: string
+  byCategory: string; colCategory: string; colThreshold: string
+  posture: string; compliance: string; outside: string; inside: string; evaluated: string
+  breaches: string; colRisk: string; colResidual: string; colGap: string; noBreach: string
+  generatedOn: string; approval: string
+}
+
+const STRINGS: Record<string, Strings> = {
+  fr: { title: 'Déclaration d\'appétit au risque', subtitle: 'Risk Appetite Statement — document de gouvernance', intro: 'L\'appétit au risque exprime le niveau de risque résiduel maximum que l\'organisation accepte de supporter dans la poursuite de ses objectifs. Il se décline en un seuil global, surchargé au besoin par catégorie de risque. Tout risque dont le niveau résiduel dépasse le seuil applicable est « hors appétit » et doit faire l\'objet d\'un traitement ou d\'une décision d\'acceptation formelle.', globalThreshold: 'Seuil global d\'appétit', noThreshold: 'Non défini', scale: 'sur l\'échelle de niveau (1-25)', byCategory: 'Seuils par catégorie de risque', colCategory: 'Catégorie', colThreshold: 'Seuil', posture: 'Posture courante', compliance: 'Conformité', outside: 'Hors appétit', inside: 'Dans l\'appétit', evaluated: 'Évalués', breaches: 'Dépassements (risques hors appétit)', colRisk: 'Risque', colResidual: 'Niveau résiduel', colGap: 'Écart', noBreach: 'Aucun dépassement : tous les risques évaluables sont dans l\'appétit défini.', generatedOn: 'Généré le', approval: 'Approuvé par : ____________________   Date : __________' },
+  en: { title: 'Risk Appetite Statement', subtitle: 'Governance document', intro: 'Risk appetite expresses the maximum level of residual risk the organisation is willing to bear in pursuit of its objectives. It is set as a global threshold, overridden where needed per risk category. Any risk whose residual level exceeds the applicable threshold is "outside appetite" and must be treated or formally accepted.', globalThreshold: 'Global appetite threshold', noThreshold: 'Not set', scale: 'on the level scale (1-25)', byCategory: 'Thresholds by risk category', colCategory: 'Category', colThreshold: 'Threshold', posture: 'Current posture', compliance: 'Compliance', outside: 'Outside appetite', inside: 'Within appetite', evaluated: 'Evaluated', breaches: 'Breaches (risks outside appetite)', colRisk: 'Risk', colResidual: 'Residual level', colGap: 'Gap', noBreach: 'No breach: all evaluable risks are within the defined appetite.', generatedOn: 'Generated on', approval: 'Approved by: ____________________   Date: __________' },
+  de: { title: 'Risikoappetit-Erklärung', subtitle: 'Risk Appetite Statement — Governance-Dokument', intro: 'Der Risikoappetit drückt das maximale Restrisiko aus, das die Organisation zur Verfolgung ihrer Ziele zu tragen bereit ist. Er wird als globaler Schwellenwert festgelegt, bei Bedarf pro Risikokategorie überschrieben. Jedes Risiko, dessen Restniveau den anwendbaren Schwellenwert überschreitet, liegt „außerhalb des Appetits" und muss behandelt oder formell akzeptiert werden.', globalThreshold: 'Globaler Appetit-Schwellenwert', noThreshold: 'Nicht gesetzt', scale: 'auf der Niveau-Skala (1-25)', byCategory: 'Schwellenwerte nach Risikokategorie', colCategory: 'Kategorie', colThreshold: 'Schwelle', posture: 'Aktuelle Lage', compliance: 'Konformität', outside: 'Außerhalb', inside: 'Innerhalb', evaluated: 'Bewertet', breaches: 'Überschreitungen (Risiken außerhalb des Appetits)', colRisk: 'Risiko', colResidual: 'Restniveau', colGap: 'Abweichung', noBreach: 'Keine Überschreitung: alle bewertbaren Risiken liegen innerhalb des Appetits.', generatedOn: 'Erstellt am', approval: 'Genehmigt von: ____________________   Datum: __________' },
+  es: { title: 'Declaración de apetito de riesgo', subtitle: 'Risk Appetite Statement — documento de gobernanza', intro: 'El apetito de riesgo expresa el nivel máximo de riesgo residual que la organización acepta soportar en la consecución de sus objetivos. Se define como un umbral global, sustituido cuando es necesario por categoría de riesgo. Todo riesgo cuyo nivel residual supere el umbral aplicable queda «fuera del apetito» y debe tratarse o aceptarse formalmente.', globalThreshold: 'Umbral global de apetito', noThreshold: 'Sin definir', scale: 'en la escala de nivel (1-25)', byCategory: 'Umbrales por categoría de riesgo', colCategory: 'Categoría', colThreshold: 'Umbral', posture: 'Postura actual', compliance: 'Conformidad', outside: 'Fuera del apetito', inside: 'Dentro del apetito', evaluated: 'Evaluados', breaches: 'Superaciones (riesgos fuera del apetito)', colRisk: 'Riesgo', colResidual: 'Nivel residual', colGap: 'Diferencia', noBreach: 'Ninguna superación: todos los riesgos evaluables están dentro del apetito definido.', generatedOn: 'Generado el', approval: 'Aprobado por: ____________________   Fecha: __________' },
+  it: { title: 'Dichiarazione di propensione al rischio', subtitle: 'Risk Appetite Statement — documento di governance', intro: 'La propensione al rischio esprime il livello massimo di rischio residuo che l\'organizzazione accetta di sostenere nel perseguire i propri obiettivi. È definita come una soglia globale, sovrascritta ove necessario per categoria di rischio. Ogni rischio il cui livello residuo supera la soglia applicabile è «fuori propensione» e deve essere trattato o accettato formalmente.', globalThreshold: 'Soglia globale di propensione', noThreshold: 'Non definita', scale: 'sulla scala di livello (1-25)', byCategory: 'Soglie per categoria di rischio', colCategory: 'Categoria', colThreshold: 'Soglia', posture: 'Postura attuale', compliance: 'Conformità', outside: 'Fuori propensione', inside: 'Entro la propensione', evaluated: 'Valutati', breaches: 'Superamenti (rischi fuori propensione)', colRisk: 'Rischio', colResidual: 'Livello residuo', colGap: 'Scarto', noBreach: 'Nessun superamento: tutti i rischi valutabili rientrano nella propensione definita.', generatedOn: 'Generato il', approval: 'Approvato da: ____________________   Data: __________' },
+}
+
+function RasPDF({ data, locale, orgNom, dateStr }: { data: RasExportData; locale: string; orgNom: string; dateStr: string }) {
+  const S = STRINGS[locale] ?? STRINGS.fr
+  const hasCategories = data.categories.length > 0
+  const hasBreaches = data.depassements.length > 0
+  return (
+    <Document>
+      <Page size="A4" style={s.page}>
+        <Text style={s.h1}>{S.title}</Text>
+        <View>
+          <Text style={s.sub}>{isNonEmptyText(orgNom) ? `${orgNom} — ` : ''}{S.subtitle}</Text>
+        </View>
+
+        <Text style={s.intro}>{S.intro}</Text>
+
+        {/* Seuil global */}
+        <View style={s.statement}>
+          <Text style={s.statementLabel}>{S.globalThreshold}</Text>
+          <Text style={s.statementValue}>
+            {data.seuilGlobal == null ? S.noThreshold : `${data.seuilGlobal} / 25`}
+          </Text>
+          <Text style={s.statementLabel}>{S.scale}</Text>
+        </View>
+
+        {/* Seuils par catégorie */}
+        <View wrap={false}>
+          <Text style={s.h2}>{S.byCategory}</Text>
+          {Boolean(hasCategories) && (
+            <View style={s.table}>
+              <View style={s.thRow}>
+                <Text style={[s.th, { width: 360 }]}>{S.colCategory}</Text>
+                <Text style={[s.th, { width: 80, textAlign: 'right' }]}>{S.colThreshold}</Text>
+              </View>
+              {data.categories.map((c, i) => (
+                <View key={`${c.code}-${i}`} style={s.tr}>
+                  <Text style={[s.td, { width: 360 }]}>{isNonEmptyText(c.label) ? c.label : c.code}</Text>
+                  <Text style={[s.td, { width: 80, textAlign: 'right' }]}>{`${c.seuil} / 25`}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+          {Boolean(!hasCategories) && <Text style={s.empty}>—</Text>}
+        </View>
+
+        {/* Posture courante */}
+        <Text style={s.h2}>{S.posture}</Text>
+        <View style={s.kpiRow}>
+          <View style={s.kpi}><Text style={s.kpiLabel}>{S.compliance}</Text><Text style={[s.kpiValue, { color: data.tauxConformite >= 80 ? COLORS.ok : COLORS.danger }]}>{`${data.tauxConformite}%`}</Text></View>
+          <View style={s.kpi}><Text style={s.kpiLabel}>{S.outside}</Text><Text style={[s.kpiValue, { color: data.synthese.horsAppetit > 0 ? COLORS.danger : COLORS.ok }]}>{String(data.synthese.horsAppetit)}</Text></View>
+          <View style={s.kpi}><Text style={s.kpiLabel}>{S.inside}</Text><Text style={s.kpiValue}>{String(data.synthese.dansAppetit)}</Text></View>
+          <View style={s.kpi}><Text style={s.kpiLabel}>{S.evaluated}</Text><Text style={s.kpiValue}>{String(data.synthese.evalues)}</Text></View>
+        </View>
+
+        {/* Dépassements */}
+        <View>
+          <Text style={s.h2}>{S.breaches}</Text>
+          {Boolean(hasBreaches) && (
+            <View style={s.table}>
+              <View style={s.thRow}>
+                <Text style={[s.th, { width: 300 }]}>{S.colRisk}</Text>
+                <Text style={[s.th, { width: 90 }]}>{S.colCategory}</Text>
+                <Text style={[s.th, { width: 60, textAlign: 'right' }]}>{S.colResidual}</Text>
+                <Text style={[s.th, { width: 50, textAlign: 'right' }]}>{S.colGap}</Text>
+              </View>
+              {data.depassements.map((d, i) => (
+                <View key={`d-${i}`} style={s.tr}>
+                  <Text style={[s.td, { width: 300 }]}>{isNonEmptyText(d.intitule) ? d.intitule : '—'}</Text>
+                  <Text style={[s.td, { width: 90 }]}>{isNonEmptyText(d.categorieLabel) ? d.categorieLabel : '—'}</Text>
+                  <Text style={[s.td, { width: 60, textAlign: 'right' }]}>{String(d.niveauResiduel)}</Text>
+                  <Text style={[s.td, { width: 50, textAlign: 'right', color: COLORS.danger }]}>{`+${d.ecart}`}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+          {Boolean(!hasBreaches) && <Text style={s.empty}>{S.noBreach}</Text>}
+        </View>
+
+        <View style={{ marginTop: 24 }}>
+          <Text style={{ fontSize: 8, color: COLORS.muted }}>{S.approval}</Text>
+        </View>
+
+        <Text style={s.footer} fixed>{`ACRA — ${S.generatedOn} ${dateStr}`}</Text>
+      </Page>
+    </Document>
+  )
+}
+
+/** Rend le PDF du RAS. Appelé au runtime depuis la route d'export. */
+export function renderRasPDF(data: RasExportData, locale: string, orgNom: string, dateStr: string): Promise<Buffer> {
+  return renderToBuffer(<RasPDF data={data} locale={locale} orgNom={orgNom} dateStr={dateStr} />)
+}


### PR DESCRIPTION
## Contexte

Production réglementaire de **gouvernance** : le **Risk Appetite Statement (RAS)** formalise l'appétit au risque de l'organisation (attendu des comités et du superviseur). Réutilise le moteur `appetit.ts` — **aucune logique dupliquée**.

## Contenu

- **lib pure** `ras-export.ts` — `buildRasExport` : seuil global + seuils par catégorie (libellés taxonomie), synthèse de posture, **dépassements** (risques hors appétit) triés par écart, taux de conformité (sans division par zéro). **4 tests**.
- **Template PDF** `ras-pdf-template.tsx` — 5 langues, intro pédagogique, tableau des seuils, KPI de posture, tableau des dépassements, bloc d'approbation. Ajouté au compilateur esbuild `.pdf-runtime`. **Rendu vérifié** fr/en/de/es/it + cas vide.
- **API** GET `/api/appetit/ras?lang=` (PDF), gating `registreRisquesActive`, 1ʳᵉ ligne « pure » exclue.
- **UI** bouton « RAS (PDF) » sur le cockpit `/pilotage` quand l'appétit est actif.

## Vérifications
- `tsc --noEmit` ✅ · `vitest` ras-export (4) ✅ · `i18n:check` ✅
- Compilation esbuild du template + **rendu PDF réel** des 5 langues + cas vide ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)