### PR TITLE
feat(reglementaire): rapport annuel de contrôle interne (PDF) + volet résilience TIC

### DIFF
--- a/scripts/compile-pdf-template.mjs
+++ b/scripts/compile-pdf-template.mjs
@@ -16,6 +16,7 @@ const TEMPLATES = [
   { entry: 'src/lib/ras-pdf-template.tsx', out: '.pdf-runtime/ras-pdf-template.cjs' },
   { entry: 'src/lib/soa-pdf-template.tsx', out: '.pdf-runtime/soa-pdf-template.cjs' },
   { entry: 'src/lib/comite-pack-pdf-template.tsx', out: '.pdf-runtime/comite-pack-pdf-template.cjs' },
+  { entry: 'src/lib/rapport-controle-interne-pdf-template.tsx', out: '.pdf-runtime/rapport-controle-interne-pdf-template.cjs' },
 ]
 
 for (const { entry, out } of TEMPLATES) {

--- a/src/__tests__/unit/lib/rapport-controle-interne.test.ts
+++ b/src/__tests__/unit/lib/rapport-controle-interne.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { buildRapportControleInterne, APPRECIATIONS } from '../../../lib/rapport-controle-interne'
+import { type ComiteConsolide, type ComiteModules } from '../../../lib/comite-pack'
+
+const ALL: ComiteModules = { risques: true, appetit: true, incidents: true, controles: true, audit: true, regulateur: true, kri: true, dora: true }
+
+const sain: ComiteConsolide = {
+  risques: { total: 10, eleve: 0, moyen: 2, faible: 8, nonCote: 0 },
+  actions: { total: 5, faits: 5, enRetard: 0, tauxAvancement: 100 },
+  appetit: { horsAppetit: 0, dansAppetit: 10, evalues: 10 },
+  incidents: { total: 3, ouverts: 0, perteNette: 0 },
+  controles: { tauxConformite: 95, anomalies: 0 },
+  audit: { critiques: 0, recosEnRetard: 0 },
+  regulateur: { echues: 0, sous30j: 0 },
+  kri: { enAlerte: 0, critique: 0 },
+  dora: { majeurs: 0, evalues: 2 },
+}
+
+const degrade: ComiteConsolide = {
+  ...sain,
+  actions: { total: 5, faits: 1, enRetard: 3, tauxAvancement: 20 },
+  appetit: { horsAppetit: 4, dansAppetit: 6, evalues: 10 },
+  controles: { tauxConformite: 60, anomalies: 5 },
+  audit: { critiques: 2, recosEnRetard: 1 },
+  regulateur: { echues: 2, sous30j: 1 },
+  kri: { enAlerte: 3, critique: 2 },
+  dora: { majeurs: 1, evalues: 3 },
+}
+
+describe('buildRapportControleInterne', () => {
+  it('regroupe les sections par ligne de défense (1, 2, 3, TIC)', () => {
+    const r = buildRapportControleInterne(sain, ALL)
+    expect(r.groupes.map(g => g.ligne)).toEqual(['1', '2', '3', 'TIC'])
+    const l1 = r.groupes.find(g => g.ligne === '1')!
+    expect(l1.sections.map(s => s.id).sort()).toEqual(['controles', 'incidents', 'risques'])
+    const l3 = r.groupes.find(g => g.ligne === '3')!
+    expect(l3.sections.map(s => s.id)).toEqual(['audit'])
+    const tic = r.groupes.find(g => g.ligne === 'TIC')!
+    expect(tic.sections.map(s => s.id)).toEqual(['dora'])
+  })
+
+  it('omet une ligne de défense sans section active', () => {
+    const r = buildRapportControleInterne(sain, { ...ALL, audit: false })
+    expect(r.groupes.map(g => g.ligne)).toEqual(['1', '2', 'TIC'])
+  })
+
+  it('apprécie SATISFAISANT sans alerte', () => {
+    const r = buildRapportControleInterne(sain, ALL)
+    expect(r.appreciation).toBe('SATISFAISANT')
+    expect(r.highlights.filter(h => h.niveau === 'alerte')).toEqual([])
+  })
+
+  it('apprécie INSUFFISANT quand les alertes s’accumulent', () => {
+    const r = buildRapportControleInterne(degrade, ALL)
+    expect(r.appreciation).toBe('INSUFFISANT')
+    expect(r.highlights.some(h => h.niveau === 'alerte')).toBe(true)
+  })
+
+  it('expose la liste des appréciations', () => {
+    expect(APPRECIATIONS).toEqual(['SATISFAISANT', 'A_RENFORCER', 'INSUFFISANT'])
+  })
+})

--- a/src/app/api/reglementaire/rapport-controle-interne/route.ts
+++ b/src/app/api/reglementaire/rapport-controle-interne/route.ts
@@ -6,13 +6,14 @@ import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
 import { type UserRole } from '@/lib/permissions'
 import { gatherGrcConsolide } from '@/lib/grc-consolide.server'
-import { buildComitePack, COMITE_TYPES, type ComiteType } from '@/lib/comite-pack'
+import { buildRapportControleInterne } from '@/lib/rapport-controle-interne'
 import { auditLog, getClientIp } from '@/lib/logger'
 import { createRequire } from 'node:module'
 
 export const dynamic = 'force-dynamic'
 
-// GET /api/comites/pack?type=RISQUES&lang=fr — dossier de comité (PDF).
+// GET /api/reglementaire/rapport-controle-interne?lang=fr&annee=2026 — PDF du
+// rapport annuel de contrôle interne (3 lignes de défense + résilience TIC).
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions)
   if (!session?.user) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
@@ -23,42 +24,40 @@ export async function GET(req: NextRequest) {
   const role = scope.role
   const orgId = scope.activeOrgId
   if (!orgId) return NextResponse.json({ error: 'Aucune organisation active' }, { status: 400 })
-  // Dossier de gouvernance : 1ʳᵉ ligne « pure » exclue.
   if (role === 'LECTEUR' || role === 'METIER') return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   const cfg = await getOrgConfig(orgId)
   if (!cfg.registreRisquesActive) return NextResponse.json({ error: 'Module non activé' }, { status: 403 })
 
   const { searchParams } = new URL(req.url)
-  const typeParam = (searchParams.get('type') ?? 'RISQUES').toUpperCase()
-  const type: ComiteType = (COMITE_TYPES as readonly string[]).includes(typeParam) ? (typeParam as ComiteType) : 'RISQUES'
   const langParam = searchParams.get('lang')
   const locale = ['fr', 'en', 'de', 'es', 'it'].includes(langParam ?? '') ? (langParam as string) : 'fr'
-
   const now = new Date()
+  const annee = (searchParams.get('annee') ?? '').match(/^\d{4}$/) ? (searchParams.get('annee') as string) : String(now.getFullYear())
+
   const { consolide, modules } = await gatherGrcConsolide(orgId, cfg, now)
-  const pack = buildComitePack(type, consolide, modules)
+  const rapport = buildRapportControleInterne(consolide, modules)
 
   await auditLog('ORGANIZATION_CONFIG_UPDATED', {
     userId, userRole: role, organizationId: orgId, ip: getClientIp(req),
-    details: { scope: 'comite-pack', action: 'export', type, format: 'pdf' },
+    details: { scope: 'rapport-controle-interne', action: 'export', format: 'pdf', annee },
   })
 
   const stamp = now.toISOString().slice(0, 10)
   try {
     const nodeRequire = createRequire(process.cwd() + '/package.json')
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { renderComitePackPDF } = nodeRequire(process.cwd() + '/.pdf-runtime/comite-pack-pdf-template.cjs')
+    const { renderRapportControleInternePDF } = nodeRequire(process.cwd() + '/.pdf-runtime/rapport-controle-interne-pdf-template.cjs')
     const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { nom: true } })
-    const buffer = await renderComitePackPDF(pack, locale, org?.nom ?? '', stamp)
+    const buffer = await renderRapportControleInternePDF(rapport, locale, org?.nom ?? '', annee, stamp)
     return new NextResponse(buffer as unknown as ArrayBuffer, {
       headers: {
         'Content-Type': 'application/pdf',
-        'Content-Disposition': `attachment; filename="acra-comite-${type.toLowerCase()}-${stamp}.pdf"`,
+        'Content-Disposition': `attachment; filename="acra-rapport-controle-interne-${annee}.pdf"`,
         'Cache-Control': 'no-store',
       },
     })
   } catch (err) {
-    console.error('[export comite pack pdf] génération échouée', err)
+    console.error('[export rapport controle interne pdf] génération échouée', err)
     return NextResponse.json({ error: 'Échec de la génération du PDF' }, { status: 500 })
   }
 }

--- a/src/components/PilotageGrc.tsx
+++ b/src/components/PilotageGrc.tsx
@@ -123,6 +123,8 @@ export default function PilotageGrc() {
         <a href={`/api/comites/pack?type=RISQUES&lang=${locale}`} className="px-2.5 py-1 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800">{p.comiteRisques}</a>
         <a href={`/api/comites/pack?type=CONFORMITE&lang=${locale}`} className="px-2.5 py-1 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800">{p.comiteConformite}</a>
         <a href={`/api/comites/pack?type=INCIDENTS&lang=${locale}`} className="px-2.5 py-1 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800">{p.comiteIncidents}</a>
+        <span className="mx-1 text-gray-300 dark:text-gray-600">|</span>
+        <a href={`/api/reglementaire/rapport-controle-interne?lang=${locale}`} className="px-2.5 py-1 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800">{p.rapportControleInterne}</a>
       </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">{p.subtitle}</p>
 

--- a/src/lib/grc-consolide.server.ts
+++ b/src/lib/grc-consolide.server.ts
@@ -1,0 +1,108 @@
+// ─── Consolidation GRC (organisation active) — accès serveur partagé ─────────
+// Rassemble, pour l'organisation active et ses modules ACTIFS, les indicateurs
+// des différents domaines (risques, appétit, incidents, contrôle permanent,
+// audit, suivi régulateur, KRI, DORA) dans la forme canonique `ComiteConsolide`.
+// Point UNIQUE consommé par les dossiers de comité ET le rapport annuel de
+// contrôle interne — évite toute duplication de requêtes/agrégations.
+
+import { prisma } from './prisma'
+import { niveauRisque } from './risk-item'
+import { summarizeActions } from './risk-action'
+import { rollupRisks, type RiskLite } from './grc-rollup'
+import { rollupIncidents, rollupControles, rollupAudit, type CockpitIncident, type CockpitExecution, type CockpitConstat } from './grc-cockpit'
+import { synthetiserAppetit, cleanAppetitConfig, type RiskAppetitLite } from './appetit'
+import { evaluerKri, synthetiserKri, type KriSens } from './kri'
+import { classifierIncident, estEvalueDora, synthetiserDora, type DoraCriteres, type DoraClasse } from './dora'
+import { synthetiserSuiviRegulateur, type ConstatRegulateur } from './suivi-regulateur'
+import { type ComiteConsolide, type ComiteModules } from './comite-pack'
+
+interface OrgConfigLike {
+  incidentsActive: boolean
+  controlePermanentActive: boolean
+  auditInterneActive: boolean
+  kriActive: boolean
+  reglementaireActive: boolean
+  appetitRisque: unknown
+}
+
+export async function gatherGrcConsolide(
+  orgId: string,
+  cfg: OrgConfigLike,
+  now: Date = new Date(),
+): Promise<{ consolide: ComiteConsolide; modules: ComiteModules }> {
+  const withIncidents = cfg.incidentsActive
+  const withControles = cfg.controlePermanentActive
+  const withAudit = cfg.auditInterneActive
+  const withKri = cfg.kriActive
+  const withReglementaire = cfg.reglementaireActive
+  const orgFilter = { organizationId: orgId }
+
+  const [riskRows, actionRows, incidentRows, controleRows, executionRows, missionRows, constatRows, kriRows] = await Promise.all([
+    prisma.riskItem.findMany({ where: orgFilter, select: { organizationId: true, taxonomieCode: true, graviteInherente: true, vraisemblanceInherente: true, graviteResiduelle: true, vraisemblanceResiduelle: true } }),
+    prisma.riskAction.findMany({ where: orgFilter, select: { organizationId: true, statut: true, echeance: true } }),
+    withIncidents ? prisma.incident.findMany({ where: orgFilter, select: { organizationId: true, statut: true, montantBrut: true, recuperations: true, doraCriteres: true } }) : Promise.resolve([]),
+    withControles ? prisma.controle.findMany({ where: { ...orgFilter, actif: true }, select: { organizationId: true } }) : Promise.resolve([]),
+    withControles ? prisma.controleExecution.findMany({ where: orgFilter, select: { organizationId: true, resultat: true, dateRealisation: true } }) : Promise.resolve([]),
+    withAudit ? prisma.auditMission.findMany({ where: orgFilter, select: { organizationId: true } }) : Promise.resolve([]),
+    (withAudit || withReglementaire) ? prisma.auditConstat.findMany({ where: orgFilter, select: { organizationId: true, criticite: true, statut: true, echeance: true, source: true, intitule: true, recommandation: true, responsableAction: true } }) : Promise.resolve([]),
+    withKri ? prisma.kri.findMany({ where: { ...orgFilter, actif: true }, select: { sens: true, seuilAlerte: true, seuilCritique: true, mesures: { orderBy: { dateMesure: 'desc' }, take: 1, select: { valeur: true } } } }) : Promise.resolve([]),
+  ])
+
+  const risks: RiskLite[] = riskRows.map(r => ({
+    organizationId: r.organizationId,
+    niveauInherent: niveauRisque(r.graviteInherente, r.vraisemblanceInherente),
+    niveauResiduel: niveauRisque(r.graviteResiduelle, r.vraisemblanceResiduelle),
+  }))
+
+  const appetit = cleanAppetitConfig(cfg.appetitRisque)
+  const appetitDefini = appetit.seuilGlobal != null || Object.keys(appetit.parCategorie).length > 0
+  const appetitRows: RiskAppetitLite[] = riskRows.map(r => ({ taxonomieCode: r.taxonomieCode, niveauResiduel: niveauRisque(r.graviteResiduelle, r.vraisemblanceResiduelle) }))
+
+  const consolide: ComiteConsolide = { risques: rollupRisks(risks) }
+  const act = summarizeActions(actionRows, now)
+  consolide.actions = { total: act.total, faits: act.faits, enRetard: act.enRetard, tauxAvancement: act.tauxAvancement }
+
+  if (appetitDefini) {
+    const a = synthetiserAppetit(appetitRows, appetit)
+    consolide.appetit = { horsAppetit: a.horsAppetit, dansAppetit: a.dansAppetit, evalues: a.evalues }
+  }
+  if (withIncidents) {
+    const incidents: CockpitIncident[] = incidentRows.map(i => ({ organizationId: i.organizationId, statut: i.statut as CockpitIncident['statut'], montantBrut: i.montantBrut == null ? null : Number(i.montantBrut), recuperations: i.recuperations == null ? null : Number(i.recuperations) }))
+    consolide.incidents = rollupIncidents(incidents)
+  }
+  if (withControles) {
+    const execs: CockpitExecution[] = executionRows.map(e => ({ organizationId: e.organizationId, resultat: e.resultat, dateRealisation: e.dateRealisation }))
+    const cr = rollupControles(controleRows, execs)
+    consolide.controles = { tauxConformite: cr.tauxConformite, anomalies: cr.anomalies }
+  }
+  if (withAudit) {
+    const constats: CockpitConstat[] = constatRows.map(c => ({ organizationId: c.organizationId, criticite: c.criticite, statut: c.statut, echeance: c.echeance }))
+    const au = rollupAudit(missionRows, constats, now)
+    consolide.audit = { critiques: au.critiques, recosEnRetard: au.recosEnRetard }
+  }
+  if (withReglementaire) {
+    const regConstats: ConstatRegulateur[] = constatRows.filter(c => c.source === 'REGULATEUR').map(c => ({ id: '', intitule: c.intitule, description: null, recommandation: c.recommandation, criticite: c.criticite, source: c.source, statut: c.statut, echeance: c.echeance, responsableAction: c.responsableAction, missionIntitule: null }))
+    const sr = synthetiserSuiviRegulateur(regConstats, now)
+    consolide.regulateur = { echues: sr.echues, sous30j: sr.sous30j }
+
+    const classes: DoraClasse[] = []
+    for (const i of incidentRows) {
+      const criteres = (i.doraCriteres ?? {}) as DoraCriteres
+      if (!estEvalueDora(criteres)) continue
+      classes.push(classifierIncident(criteres).classe)
+    }
+    const d = synthetiserDora(classes)
+    consolide.dora = { majeurs: d.majeurs, evalues: d.evalues }
+  }
+  if (withKri) {
+    const statuts = kriRows.map(k => ({ statut: evaluerKri(k.mesures[0]?.valeur ?? null, { sens: k.sens as KriSens, seuilAlerte: k.seuilAlerte, seuilCritique: k.seuilCritique }) }))
+    const k = synthetiserKri(statuts)
+    consolide.kri = { enAlerte: k.enAlerte, critique: k.critique }
+  }
+
+  const modules: ComiteModules = {
+    risques: true, appetit: appetitDefini, incidents: withIncidents, controles: withControles,
+    audit: withAudit, regulateur: withReglementaire, kri: withKri, dora: withReglementaire,
+  }
+  return { consolide, modules }
+}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1053,6 +1053,7 @@ export const de: Translations = {
     comiteRisques: 'Risiken',
     comiteConformite: 'Compliance',
     comiteIncidents: 'Vorfälle',
+    rapportControleInterne: 'Bericht interne Kontrolle',
     inactive: 'Modul nicht aktiviert.',
     total: 'Risiken',
     eleves: 'Hoch',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1053,6 +1053,7 @@ export const en: Translations = {
     comiteRisques: 'Risk',
     comiteConformite: 'Compliance',
     comiteIncidents: 'Incidents',
+    rapportControleInterne: 'Internal control report',
     inactive: 'Module not enabled.',
     total: 'Risks',
     eleves: 'High',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1053,6 +1053,7 @@ export const es: Translations = {
     comiteRisques: 'Riesgos',
     comiteConformite: 'Cumplimiento',
     comiteIncidents: 'Incidentes',
+    rapportControleInterne: 'Informe de control interno',
     inactive: 'Módulo no activado.',
     total: 'Riesgos',
     eleves: 'Altos',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1076,6 +1076,7 @@ export const fr = {
     comiteRisques: 'Risques',
     comiteConformite: 'Conformité',
     comiteIncidents: 'Incidents',
+    rapportControleInterne: 'Rapport de contrôle interne',
     inactive: 'Module non activé.',
     total: 'Risques',
     eleves: 'Élevés',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1053,6 +1053,7 @@ export const it: Translations = {
     comiteRisques: 'Rischi',
     comiteConformite: 'Conformità',
     comiteIncidents: 'Incidenti',
+    rapportControleInterne: 'Relazione controllo interno',
     inactive: 'Modulo non attivato.',
     total: 'Rischi',
     eleves: 'Alti',

--- a/src/lib/rapport-controle-interne-pdf-template.tsx
+++ b/src/lib/rapport-controle-interne-pdf-template.tsx
@@ -1,0 +1,178 @@
+/**
+ * rapport-controle-interne-pdf-template.tsx — Rapport annuel de contrôle interne.
+ *
+ * ⚠️ Mêmes contraintes que pdf-template.tsx (aucun Fragment JSX ; jamais de chaîne
+ * potentiellement vide comme enfant direct d'un <View> — cf. lib/pdf-guards.ts).
+ * Compilé en CJS autonome par scripts/compile-pdf-template.mjs, chargé au RUNTIME.
+ */
+
+import { Document, Page, Text, View, StyleSheet, renderToBuffer } from '@react-pdf/renderer'
+import type { RapportControleInterne, LigneDefense } from '@/lib/rapport-controle-interne'
+import { isNonEmptyText } from '@/lib/pdf-guards'
+
+const COLORS = {
+  primary: '#4338CA', danger: '#DC2626', info: '#2563EB', ok: '#16A34A', warn: '#D97706',
+  border: '#E5E7EB', muted: '#6B7280', headerBg: '#EEF2FF', okBg: '#ECFDF5',
+}
+
+const s = StyleSheet.create({
+  page: { padding: 36, fontSize: 9, color: '#111827' },
+  h1: { fontSize: 18, fontWeight: 'bold', color: COLORS.primary, marginBottom: 4 },
+  sub: { fontSize: 9, color: COLORS.muted, marginBottom: 10 },
+  intro: { fontSize: 8.5, color: '#374151', marginBottom: 10, lineHeight: 1.4 },
+  appBox: { borderWidth: 1, borderRadius: 4, padding: 10, marginBottom: 10 },
+  appLabel: { fontSize: 8, color: COLORS.muted },
+  appValue: { fontSize: 15, fontWeight: 'bold' },
+  h2: { fontSize: 12, fontWeight: 'bold', marginTop: 12, marginBottom: 5, color: COLORS.primary },
+  h3: { fontSize: 10, fontWeight: 'bold', marginTop: 8, marginBottom: 3 },
+  hlBox: { borderWidth: 1, borderColor: COLORS.border, borderRadius: 4, padding: 8, marginBottom: 8 },
+  hlItem: { flexDirection: 'row', marginBottom: 2 },
+  hlDot: { width: 7, fontSize: 10, fontWeight: 'bold' },
+  hlText: { fontSize: 8 },
+  okBox: { backgroundColor: COLORS.okBg, borderWidth: 1, borderColor: '#A7F3D0', borderRadius: 4, padding: 8, marginBottom: 8 },
+  kpiRow: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 2 },
+  kpi: { width: '25%', padding: 3 },
+  kpiInner: { borderWidth: 1, borderColor: COLORS.border, borderRadius: 4, padding: 5 },
+  kpiLabel: { fontSize: 7, color: COLORS.muted, marginBottom: 2 },
+  kpiValue: { fontSize: 12, fontWeight: 'bold' },
+  footer: { position: 'absolute', bottom: 20, left: 36, right: 36, fontSize: 7, color: COLORS.muted, textAlign: 'center' },
+})
+
+type Dict = Record<string, string>
+type Strings = {
+  title: string; subtitle: string; intro: string
+  ligne: Record<LigneDefense, string>
+  appreciationLabel: string; appreciation: Dict
+  section: Dict; metric: Dict; highlight: Dict
+  highlightsTitle: string; noAlert: string; generatedOn: string; approval: string; year: string
+}
+
+const SECTION_FR = { risques: 'Cartographie des risques', appetit: 'Appétit au risque', incidents: 'Incidents & pertes', controles: 'Contrôle permanent', audit: 'Audit interne', regulateur: 'Suivi régulateur', kri: 'Indicateurs clés (KRI)', dora: 'Résilience opérationnelle TIC (DORA)' }
+const METRIC_FR = { total: 'Total', eleve: 'Élevés', moyen: 'Moyens', faible: 'Faibles', nonCote: 'Non cotés', actionsTotal: 'Actions', avancement: 'Avancement', actionsEnRetard: 'Actions en retard', horsAppetit: 'Hors appétit', dansAppetit: 'Dans l\'appétit', evalues: 'Évalués', ouverts: 'Ouverts', perteNette: 'Perte nette (€)', tauxConformite: 'Taux de conformité', anomalies: 'Anomalies', critiques: 'Constats critiques', recosEnRetard: 'Recos en retard', echues: 'Échéances dépassées', sous30j: 'Sous 30 jours', enAlerte: 'En alerte', critique: 'Critiques', majeurs: 'Incidents majeurs' }
+const HL_FR = { horsAppetit: 'risque(s) hors appétit', actionsEnRetard: 'action(s) de traitement en retard', conformiteFaible: '% de conformité du contrôle permanent (sous le seuil)', constatsCritiques: 'constat(s) d\'audit critiques ouverts', regulateurEchu: 'recommandation(s) régulateur échue(s)', kriCritique: 'KRI en zone critique', doraMajeurs: 'incident(s) TIC majeur(s) (DORA)', incidentsOuverts: 'incident(s) opérationnel(s) ouvert(s)' }
+
+const SECTION_EN = { risques: 'Risk map', appetit: 'Risk appetite', incidents: 'Incidents & losses', controles: 'Permanent control', audit: 'Internal audit', regulateur: 'Regulator tracking', kri: 'Key risk indicators (KRI)', dora: 'ICT operational resilience (DORA)' }
+const METRIC_EN = { total: 'Total', eleve: 'High', moyen: 'Medium', faible: 'Low', nonCote: 'Unrated', actionsTotal: 'Actions', avancement: 'Progress', actionsEnRetard: 'Overdue actions', horsAppetit: 'Outside appetite', dansAppetit: 'Within appetite', evalues: 'Evaluated', ouverts: 'Open', perteNette: 'Net loss (€)', tauxConformite: 'Compliance rate', anomalies: 'Anomalies', critiques: 'Critical findings', recosEnRetard: 'Overdue recs', echues: 'Overdue', sous30j: 'Within 30 days', enAlerte: 'In alert', critique: 'Critical', majeurs: 'Major incidents' }
+const HL_EN = { horsAppetit: 'risk(s) outside appetite', actionsEnRetard: 'overdue treatment action(s)', conformiteFaible: '% permanent-control compliance (below threshold)', constatsCritiques: 'open critical audit finding(s)', regulateurEchu: 'overdue regulator recommendation(s)', kriCritique: 'KRI in critical zone', doraMajeurs: 'major ICT incident(s) (DORA)', incidentsOuverts: 'open operational incident(s)' }
+
+const STRINGS: Record<string, Strings> = {
+  fr: {
+    title: 'Rapport annuel de contrôle interne', subtitle: 'Dispositif de maîtrise des risques — synthèse',
+    intro: 'Ce rapport présente l\'état du dispositif de contrôle interne selon le modèle des trois lignes de défense (contrôle permanent de 1ᵉʳ niveau, gestion des risques et conformité de 2ᵉ niveau, audit interne de 3ᵉ niveau), complété d\'un volet de résilience opérationnelle TIC (DORA). Il consolide les indicateurs des modules actifs et formule une appréciation d\'ensemble.',
+    ligne: { '1': '1ʳᵉ ligne de défense — Contrôle permanent (opérationnel)', '2': '2ᵉ ligne de défense — Gestion des risques & conformité', '3': '3ᵉ ligne de défense — Audit interne', TIC: 'Résilience opérationnelle numérique (DORA)' },
+    appreciationLabel: 'Appréciation globale du dispositif', appreciation: { SATISFAISANT: 'Satisfaisant', A_RENFORCER: 'À renforcer', INSUFFISANT: 'Insuffisant' },
+    section: SECTION_FR, metric: METRIC_FR, highlight: HL_FR,
+    highlightsTitle: 'Points d\'attention', noAlert: 'Aucun point d\'alerte : les indicateurs des modules actifs sont dans les seuils.', generatedOn: 'Généré le', approval: 'Approuvé par l\'organe de surveillance : ____________________   Date : __________', year: 'Exercice',
+  },
+  en: {
+    title: 'Annual internal control report', subtitle: 'Risk management framework — summary',
+    intro: 'This report sets out the state of the internal control framework along the three-lines-of-defence model (first-line permanent control, second-line risk management and compliance, third-line internal audit), complemented by an ICT operational resilience section (DORA). It consolidates active-module indicators and states an overall assessment.',
+    ligne: { '1': '1st line of defence — Permanent control (operational)', '2': '2nd line of defence — Risk management & compliance', '3': '3rd line of defence — Internal audit', TIC: 'Digital operational resilience (DORA)' },
+    appreciationLabel: 'Overall assessment of the framework', appreciation: { SATISFAISANT: 'Satisfactory', A_RENFORCER: 'To be strengthened', INSUFFISANT: 'Insufficient' },
+    section: SECTION_EN, metric: METRIC_EN, highlight: HL_EN,
+    highlightsTitle: 'Points of attention', noAlert: 'No alert: active-module indicators are within thresholds.', generatedOn: 'Generated on', approval: 'Approved by the supervisory body: ____________________   Date: __________', year: 'Financial year',
+  },
+  de: {
+    title: 'Jährlicher Bericht über die interne Kontrolle', subtitle: 'Risikomanagement-Rahmenwerk — Zusammenfassung',
+    intro: 'Dieser Bericht stellt den Zustand des internen Kontrollsystems nach dem Modell der drei Verteidigungslinien dar (permanente Kontrolle der 1. Ebene, Risikomanagement und Compliance der 2. Ebene, interne Revision der 3. Ebene), ergänzt um einen Abschnitt zur digitalen operationellen Resilienz (DORA).',
+    ligne: { '1': '1. Verteidigungslinie — Permanente Kontrolle (operativ)', '2': '2. Verteidigungslinie — Risikomanagement & Compliance', '3': '3. Verteidigungslinie — Interne Revision', TIC: 'Digitale operationelle Resilienz (DORA)' },
+    appreciationLabel: 'Gesamtbeurteilung des Systems', appreciation: { SATISFAISANT: 'Zufriedenstellend', A_RENFORCER: 'Zu stärken', INSUFFISANT: 'Unzureichend' },
+    section: SECTION_EN, metric: METRIC_EN, highlight: HL_EN,
+    highlightsTitle: 'Aufmerksamkeitspunkte', noAlert: 'Kein Alarm: die Indikatoren der aktiven Module liegen innerhalb der Schwellen.', generatedOn: 'Erstellt am', approval: 'Vom Aufsichtsorgan genehmigt: ____________________   Datum: __________', year: 'Geschäftsjahr',
+  },
+  es: {
+    title: 'Informe anual de control interno', subtitle: 'Marco de gestión de riesgos — resumen',
+    intro: 'Este informe presenta el estado del marco de control interno según el modelo de las tres líneas de defensa (control permanente de 1ª línea, gestión de riesgos y cumplimiento de 2ª línea, auditoría interna de 3ª línea), completado con un apartado de resiliencia operativa TIC (DORA).',
+    ligne: { '1': '1ª línea de defensa — Control permanente (operativo)', '2': '2ª línea de defensa — Gestión de riesgos y cumplimiento', '3': '3ª línea de defensa — Auditoría interna', TIC: 'Resiliencia operativa digital (DORA)' },
+    appreciationLabel: 'Valoración global del dispositivo', appreciation: { SATISFAISANT: 'Satisfactorio', A_RENFORCER: 'A reforzar', INSUFFISANT: 'Insuficiente' },
+    section: SECTION_EN, metric: METRIC_EN, highlight: HL_EN,
+    highlightsTitle: 'Puntos de atención', noAlert: 'Sin alertas: los indicadores de los módulos activos están dentro de los umbrales.', generatedOn: 'Generado el', approval: 'Aprobado por el órgano de supervisión: ____________________   Fecha: __________', year: 'Ejercicio',
+  },
+  it: {
+    title: 'Relazione annuale sul controllo interno', subtitle: 'Sistema di gestione dei rischi — sintesi',
+    intro: 'La presente relazione illustra lo stato del sistema di controllo interno secondo il modello delle tre linee di difesa (controllo permanente di 1ª linea, gestione dei rischi e conformità di 2ª linea, audit interno di 3ª linea), integrato da una sezione sulla resilienza operativa TIC (DORA).',
+    ligne: { '1': '1ª linea di difesa — Controllo permanente (operativo)', '2': '2ª linea di difesa — Gestione dei rischi e conformità', '3': '3ª linea di difesa — Audit interno', TIC: 'Resilienza operativa digitale (DORA)' },
+    appreciationLabel: 'Valutazione complessiva del dispositivo', appreciation: { SATISFAISANT: 'Soddisfacente', A_RENFORCER: 'Da rafforzare', INSUFFISANT: 'Insufficiente' },
+    section: SECTION_EN, metric: METRIC_EN, highlight: HL_EN,
+    highlightsTitle: 'Punti di attenzione', noAlert: 'Nessuna allerta: gli indicatori dei moduli attivi sono entro le soglie.', generatedOn: 'Generato il', approval: 'Approvato dall\'organo di vigilanza: ____________________   Data: __________', year: 'Esercizio',
+  },
+}
+
+function appColor(a: string): { bg: string; border: string; fg: string } {
+  if (a === 'SATISFAISANT') return { bg: COLORS.okBg, border: '#A7F3D0', fg: COLORS.ok }
+  if (a === 'A_RENFORCER') return { bg: '#FFFBEB', border: '#FDE68A', fg: COLORS.warn }
+  return { bg: '#FEF2F2', border: '#FECACA', fg: COLORS.danger }
+}
+
+function RapportPDF({ rapport, locale, orgNom, annee, dateStr }: { rapport: RapportControleInterne; locale: string; orgNom: string; annee: string; dateStr: string }) {
+  const S = STRINGS[locale] ?? STRINGS.fr
+  const hasHighlights = rapport.highlights.length > 0
+  const app = appColor(rapport.appreciation)
+  return (
+    <Document>
+      <Page size="A4" style={s.page}>
+        <Text style={s.h1}>{S.title}</Text>
+        <View>
+          <Text style={s.sub}>{isNonEmptyText(orgNom) ? `${orgNom} — ` : ''}{S.subtitle}{isNonEmptyText(annee) ? ` — ${S.year} ${annee}` : ''}</Text>
+        </View>
+
+        <Text style={s.intro}>{S.intro}</Text>
+
+        {/* Appréciation globale */}
+        <View style={[s.appBox, { backgroundColor: app.bg, borderColor: app.border }]}>
+          <Text style={s.appLabel}>{S.appreciationLabel}</Text>
+          <Text style={[s.appValue, { color: app.fg }]}>{S.appreciation[rapport.appreciation] ?? rapport.appreciation}</Text>
+        </View>
+
+        {/* Points d'attention */}
+        <Text style={s.h2}>{S.highlightsTitle}</Text>
+        {Boolean(hasHighlights) && (
+          <View style={s.hlBox}>
+            {rapport.highlights.map((h, i) => (
+              <View key={`h-${i}`} style={s.hlItem}>
+                <Text style={[s.hlDot, { color: h.niveau === 'alerte' ? COLORS.danger : COLORS.info }]}>{'•'}</Text>
+                <Text style={s.hlText}>{`${h.value} ${S.highlight[h.key] ?? h.key}`}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+        {Boolean(!hasHighlights) && (
+          <View style={s.okBox}><Text style={[s.hlText, { color: COLORS.ok }]}>{S.noAlert}</Text></View>
+        )}
+
+        {/* Groupes par ligne de défense */}
+        {rapport.groupes.map((g, gi) => (
+          <View key={`g-${gi}`}>
+            <Text style={s.h2}>{S.ligne[g.ligne] ?? g.ligne}</Text>
+            {g.sections.map((sec, si) => (
+              <View key={`s-${gi}-${si}`} wrap={false}>
+                <Text style={s.h3}>{S.section[sec.id] ?? sec.id}</Text>
+                <View style={s.kpiRow}>
+                  {sec.metrics.map((mt, mi) => (
+                    <View key={`m-${gi}-${si}-${mi}`} style={s.kpi}>
+                      <View style={s.kpiInner}>
+                        <Text style={s.kpiLabel}>{S.metric[mt.key] ?? mt.key}</Text>
+                        <Text style={[s.kpiValue, mt.alerte ? { color: COLORS.danger } : {}]}>{String(mt.value)}</Text>
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ))}
+          </View>
+        ))}
+
+        <View style={{ marginTop: 20 }}>
+          <Text style={{ fontSize: 8, color: COLORS.muted }}>{S.approval}</Text>
+        </View>
+
+        <Text style={s.footer} fixed>{`ACRA — ${S.generatedOn} ${dateStr}`}</Text>
+      </Page>
+    </Document>
+  )
+}
+
+/** Rend le PDF du rapport annuel de contrôle interne. Appelé au runtime. */
+export function renderRapportControleInternePDF(rapport: RapportControleInterne, locale: string, orgNom: string, annee: string, dateStr: string): Promise<Buffer> {
+  return renderToBuffer(<RapportPDF rapport={rapport} locale={locale} orgNom={orgNom} annee={annee} dateStr={dateStr} />)
+}

--- a/src/lib/rapport-controle-interne.ts
+++ b/src/lib/rapport-controle-interne.ts
@@ -1,0 +1,54 @@
+// ─── Rapport annuel de contrôle interne ──────────────────────────────────────
+// Structure le rapport annuel (attendu, p. ex. Arrêté du 3 nov. 2014) : une vue
+// par LIGNE DE DÉFENSE (1ʳᵉ : opérationnel/contrôle permanent ; 2ᵉ : gestion des
+// risques/conformité ; 3ᵉ : audit interne) + un volet résilience opérationnelle
+// TIC (DORA), assortie d'une APPRÉCIATION globale du dispositif. Réutilise
+// `buildComitePack` pour la sélection/agrégation des indicateurs. PURE et testée.
+
+import { buildComitePack, type ComiteConsolide, type ComiteModules, type ComiteSection, type ComiteHighlight } from './comite-pack'
+
+export const APPRECIATIONS = ['SATISFAISANT', 'A_RENFORCER', 'INSUFFISANT'] as const
+export type Appreciation = (typeof APPRECIATIONS)[number]
+
+export type LigneDefense = '1' | '2' | '3' | 'TIC'
+
+export interface RapportLigne {
+  ligne: LigneDefense
+  sections: ComiteSection[]
+}
+
+export interface RapportControleInterne {
+  groupes: RapportLigne[]
+  highlights: ComiteHighlight[]
+  appreciation: Appreciation
+}
+
+// Rattachement de chaque domaine à une ligne de défense (modèle des 3 lignes).
+const LIGNE_DE: Record<string, LigneDefense> = {
+  risques: '1', incidents: '1', controles: '1',
+  appetit: '2', kri: '2', regulateur: '2',
+  audit: '3',
+  dora: 'TIC',
+}
+const ORDRE_LIGNES: LigneDefense[] = ['1', '2', '3', 'TIC']
+
+export function buildRapportControleInterne(consolide: ComiteConsolide, modules: ComiteModules): RapportControleInterne {
+  // Vue « tous domaines » : le rapport annuel couvre l'ensemble du dispositif.
+  const pack = buildComitePack('RISQUES', consolide, modules)
+
+  const parLigne = new Map<LigneDefense, ComiteSection[]>()
+  for (const sec of pack.sections) {
+    const ligne = LIGNE_DE[sec.id] ?? '1'
+    const arr = parLigne.get(ligne) ?? []
+    arr.push(sec)
+    parLigne.set(ligne, arr)
+  }
+  const groupes: RapportLigne[] = ORDRE_LIGNES
+    .filter(l => parLigne.has(l))
+    .map(l => ({ ligne: l, sections: parLigne.get(l)! }))
+
+  const alertes = pack.highlights.filter(h => h.niveau === 'alerte').length
+  const appreciation: Appreciation = alertes === 0 ? 'SATISFAISANT' : alertes <= 3 ? 'A_RENFORCER' : 'INSUFFISANT'
+
+  return { groupes, highlights: pack.highlights, appreciation }
+}


### PR DESCRIPTION
## Contexte

Deux besoins de la liste :
- **#8** Rapport annuel de contrôle interne (attendu p. ex. par l'arrêté du 3 nov. 2014).
- **#7** Reporting de résilience opérationnelle (DORA ch. II) — livré ici comme **volet dédié** du rapport (section « Résilience opérationnelle TIC »).

## Contenu

- **Refactor** : extraction de la consolidation GRC de l'org active en helper serveur partagé `grc-consolide.server.ts` (`gatherGrcConsolide`), désormais consommé par **les dossiers de comité ET le rapport annuel** → dédoublonnage des requêtes/agrégations.
- **lib pure** `rapport-controle-interne.ts` — `buildRapportControleInterne` : regroupe les sections par **ligne de défense** (1ʳᵉ contrôle permanent · 2ᵉ risques/conformité · 3ᵉ audit) + volet TIC ; **appréciation** globale `SATISFAISANT / À RENFORCER / INSUFFISANT` selon les alertes. **5 tests**.
- **Template PDF** (5 langues, bandeau d'appréciation coloré, points d'attention, sections par ligne, bloc d'approbation) + compilateur esbuild. **Rendu vérifié** fr/en/de/es/it + niveaux d'appréciation.
- **API** GET `/api/reglementaire/rapport-controle-interne?lang=&annee=` (PDF).
- **UI** : bouton « Rapport de contrôle interne » sur `/pilotage`.

## Note de périmètre
Le format **PPTX** (présentation) demandé pour #8 n'est pas inclus : il nécessite une dépendance de génération distincte. Le livrable PDF couvre le besoin de fond ; le PPTX est un suivi identifié.

## Vérifications
- `tsc --noEmit` ✅ · `vitest` rapport (5) + comite (5) ✅ · `i18n:check` ✅
- Compilation esbuild + **rendu PDF réel** des 5 langues + niveaux d'appréciation ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)