### PR TITLE
fix(rbac): 2ᵉ ligne définit contrôles/KRI/campagnes (#125) + quatre-yeux dérogation (#122)

### DIFF
--- a/src/__tests__/unit/lib/derogation.test.ts
+++ b/src/__tests__/unit/lib/derogation.test.ts
@@ -166,6 +166,13 @@ describe('RBAC dérogations', () => {
     expect(canValiderDerogation(u('RSSI'), d)).toBe(false)
     expect(canValiderDerogation(u('DIRECTION_METIER'), { statut: 'DEMANDEE', demandeurId: 'p' })).toBe(false)
   })
+  it('validation métier : le DEMANDEUR ne peut pas valider sa propre dérogation (quatre-yeux, #122)', () => {
+    // Même quand le demandeur est DIRECTION_METIER (ou admin), l'auto-validation est refusée.
+    expect(canValiderDerogation(u('DIRECTION_METIER', 'porteur'), { statut: 'VALIDATION_METIER', demandeurId: 'porteur' })).toBe(false)
+    expect(canValiderDerogation(u('ADMIN', 'porteur'), { statut: 'VALIDATION_METIER', demandeurId: 'porteur' })).toBe(false)
+    // Un AUTRE valideur métier reste autorisé.
+    expect(canValiderDerogation(u('DIRECTION_METIER', 'autre'), { statut: 'VALIDATION_METIER', demandeurId: 'porteur' })).toBe(true)
+  })
   it('révocation : RSSI/métier/admin, depuis ACTIVE', () => {
     const d = { statut: 'ACTIVE' as const, demandeurId: 'p' }
     expect(canRevoquerDerogation(u('RSSI'), d)).toBe(true)

--- a/src/__tests__/unit/lib/permissions.test.ts
+++ b/src/__tests__/unit/lib/permissions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  peutDefinir2eLigne,
   canCreateAnalyse,
   canAdmin,
   canConfigurer,
@@ -344,6 +345,19 @@ describe('Rôles ajoutés — droits métier', () => {
   it('aucun rôle ajouté ne peut accepter les risques résiduels', () => {
     for (const role of ['CONTROLEUR', 'METIER', 'CONFORMITE', 'DPO'] as const) {
       expect(canAcceptResidualRisks(userWith(role), true)).toBe(false)
+    }
+  })
+})
+
+describe('peutDefinir2eLigne (définition contrôles / KRI / campagnes — #125)', () => {
+  it('autorise les rôles 2ᵉ ligne dédiés (CONTROLEUR, CONFORMITE) en plus de RM/RSSI/admin', () => {
+    for (const role of ['ADMIN', 'SUPER_ADMIN', 'RISK_MANAGER', 'RSSI', 'CONTROLEUR', 'CONFORMITE'] as const) {
+      expect(peutDefinir2eLigne(role)).toBe(true)
+    }
+  })
+  it('refuse les rôles non concernés (1ʳᵉ ligne pure, lecture, 3ᵉ ligne)', () => {
+    for (const role of ['LECTEUR', 'ANALYSTE', 'METIER', 'DPO', 'AUDITEUR', 'DIRECTION_METIER'] as const) {
+      expect(peutDefinir2eLigne(role)).toBe(false)
     }
   })
 })

--- a/src/app/api/campagnes/route.ts
+++ b/src/app/api/campagnes/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import { validateCampagneInput, cleanCampagneInput, avancementCampagne } from '@/lib/campagne'
 import { auditLog, getClientIp } from '@/lib/logger'
 
@@ -12,7 +12,7 @@ export const dynamic = 'force-dynamic'
 
 /** Piloter une campagne relève de la 2ᵉ ligne (risk manager / RSSI / admin). */
 export function peutPiloter(role: UserRole): boolean {
-  return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
+  return peutDefinir2eLigne(role)
 }
 
 async function ctx(session: { user: { id: string; role?: string } }) {

--- a/src/app/api/controles/route.ts
+++ b/src/app/api/controles/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import {
   validateControleInput, cleanControleInput, prochaineEcheance,
   etatEcheance, evaluerEfficacite, type Periodicite,
@@ -15,7 +15,7 @@ export const dynamic = 'force-dynamic'
 
 /** Définir le plan de contrôle relève de la 2ᵉ ligne. */
 export function peutDefinir(role: UserRole): boolean {
-  return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
+  return peutDefinir2eLigne(role)
 }
 
 async function ctx(session: { user: { id: string; role?: string } }) {

--- a/src/app/api/kri/route.ts
+++ b/src/app/api/kri/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import {
   validateKriInput, cleanKriInput, evaluerKri, tendanceKri, synthetiserKri,
   type KriSens, type KriStatut,
@@ -16,7 +16,7 @@ export const dynamic = 'force-dynamic'
 // La DÉFINITION d'un KRI relève de la 2ᵉ ligne (gouvernance) ; la SAISIE des
 // mesures est ouverte à la 1ʳᵉ ligne (cf. mesures/route.ts). L'admin gère aussi.
 export function peutDefinirKri(role: UserRole): boolean {
-  return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
+  return peutDefinir2eLigne(role)
 }
 
 async function ctx(session: { user: { id: string; role?: string } }) {

--- a/src/lib/derogation.ts
+++ b/src/lib/derogation.ts
@@ -214,9 +214,15 @@ export function canDoubleRegardDerogation(user: SessionUser, d: DerogationRbacSo
     && user.id !== d.avisRssiPar && user.id !== d.demandeurId
 }
 
-/** Validation métier : DIRECTION_METIER (ou admin en secours), depuis VALIDATION_METIER. */
+/**
+ * Validation métier : DIRECTION_METIER (ou admin en secours), depuis VALIDATION_METIER.
+ * Le DEMANDEUR ne peut jamais valider sa propre dérogation (séparation des tâches /
+ * quatre-yeux, cohérent avec les gardes avis RSSI et double regard — cf. #122).
+ */
 export function canValiderDerogation(user: SessionUser, d: DerogationRbacSource): boolean {
-  return d.statut === 'VALIDATION_METIER' && (user.role === 'DIRECTION_METIER' || isAdminRole(user.role))
+  return d.statut === 'VALIDATION_METIER'
+    && (user.role === 'DIRECTION_METIER' || isAdminRole(user.role))
+    && user.id !== d.demandeurId
 }
 
 /** Révocation d'une dérogation ACTIVE : RSSI, métier ou admin. */

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -44,6 +44,19 @@ export function isAdminRole(role: UserRole): boolean {
   return role === 'ADMIN' || role === 'SUPER_ADMIN'
 }
 
+/**
+ * Peut DÉFINIR les dispositifs de 2ᵉ ligne de défense (plan de contrôle permanent,
+ * KRI, campagnes de contrôle). En plus de RISK_MANAGER / RSSI / admin, inclut les
+ * rôles DÉDIÉS à la 2ᵉ ligne : CONTROLEUR (« définit et exécute les contrôles
+ * permanents ») et CONFORMITE (pilote les référentiels et la gouvernance associée).
+ * Helper CENTRAL : les 3 modules (controles, kri, campagnes) délèguent ici pour
+ * rester cohérents (cf. correctif #125).
+ */
+export function peutDefinir2eLigne(role: UserRole): boolean {
+  return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
+    || role === 'CONTROLEUR' || role === 'CONFORMITE'
+}
+
 /** L'utilisateur peut créer de nouvelles analyses */
 export function canCreateAnalyse(user: SessionUser): boolean {
   return user.role === 'ANALYSTE' || isAdminRole(user.role)


### PR DESCRIPTION
Deux correctifs RBAC issus de la liste d'améliorations (tâche automatisée).

## #125 — Rôles 2ᵉ ligne exclus de la définition (🟠 Haute)
Les rôles **dédiés** à la 2ᵉ ligne (`CONTROLEUR`, `CONFORMITE`) étaient exclus de la **définition** des contrôles / KRI / campagnes → `POST` renvoyait **403**, alors que `ROLE_DESCRIPTIONS.CONTROLEUR` = *« définit ET exécute les contrôles permanents »* (il pouvait exécuter mais pas définir — incohérence probante).

**Cause** : 3 gates identiques limités à RM/RSSI/admin. **Correctif** : helper **central** `peutDefinir2eLigne` (`permissions.ts`) incluant CONTROLEUR + CONFORMITE ; les 3 routes (`controles`/`kri`/`campagnes`) y délèguent (plus de divergence possible).

## #122 — Auto-validation de dérogation (🔒 sécurité, A01/CWE-863)
`canValiderDerogation` n'excluait **pas le demandeur** → un `DIRECTION_METIER` (ou admin) pouvait **auto-valider sa propre dérogation**, cassant la séparation des tâches. Les gardes *avis RSSI* et *double regard* excluaient déjà le demandeur (asymétrie).

**Correctif** : `&& user.id !== d.demandeurId`.

## Tests
- `peutDefinir2eLigne` : autorise ADMIN/RM/RSSI/CONTROLEUR/CONFORMITE ; refuse LECTEUR/ANALYSTE/METIER/DPO/AUDITEUR/DIRECTION_METIER.
- quatre-yeux : le demandeur (même DIRECTION_METIER/ADMIN) ne peut pas valider ; un autre valideur reste autorisé.
- tsc ✅ · **1171 tests** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)