### PR TITLE
docs(incidents): note UI — qui déclare un incident (ouvert à tous, attendu RM/métiers)

### DIFF
--- a/src/components/IncidentsManager.tsx
+++ b/src/components/IncidentsManager.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Siren } from 'lucide-react'
+import { Siren, Info } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
 import { taxonomieLabel, type TaxonomieNode } from '@/lib/taxonomie'
@@ -225,7 +225,13 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
           {!showDecl && <button onClick={() => { setDecl(EMPTY_DECL); setShowDecl(true) }} className="btn-primary text-sm ml-1.5">{n.declareBtn}</button>}
         </div>
       </div>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">{n.subtitle}</p>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{n.subtitle}</p>
+
+      {/* Note : qui déclare — ouvert à tous, mais attendu des risk managers / métiers gestion d'incident */}
+      <div className="flex items-start gap-2 bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/30 rounded-lg px-3 py-2 mb-5 text-xs text-gray-600 dark:text-gray-300">
+        <Info size={14} className="mt-0.5 shrink-0 text-blue-600 dark:text-blue-300" aria-hidden="true" />
+        <span>{n.declareRolesNote}</span>
+      </div>
 
       {!loading && (
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1117,6 +1117,7 @@ export const de: Translations = {
     promoteHint: 'Aus diesem Vorfall ein Register-Risiko anlegen',
     declareTitle: 'Vorfall melden',
     declareHint: 'Kurzformular: melden Sie, was passiert ist — die Qualifizierung folgt.',
+    declareRolesNote: 'Die Meldung von Vorfällen steht allen Rollen offen, um die Meldung nicht zu behindern. Sie erfolgt normalerweise durch Risikomanager und die für das Vorfall- oder Krisenmanagement zuständigen Teams; Qualifizierung, Behandlung und Nachverfolgung bleiben Aufgabe der 2. Verteidigungslinie.',
     intitulePlaceholder: 'Was ist passiert?',
     descriptionPlaceholder: 'Details (optional)',
     dateSurvenance: 'Eingetreten',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1117,6 +1117,7 @@ export const en: Translations = {
     promoteHint: 'Create a register risk from this incident',
     declareTitle: 'Report an incident',
     declareHint: 'Short form: report what happened, qualification comes later.',
+    declareRolesNote: 'Incident reporting is open to all roles so as not to hinder reporting. It is normally handled by risk managers and the teams in charge of incident or crisis management; qualification, treatment and follow-up remain the responsibility of the 2nd line.',
     intitulePlaceholder: 'What happened?',
     descriptionPlaceholder: 'Details (optional)',
     dateSurvenance: 'Occurred',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1117,6 +1117,7 @@ export const es: Translations = {
     promoteHint: 'Crear un riesgo del registro desde este incidente',
     declareTitle: 'Declarar un incidente',
     declareHint: 'Formulario corto: informe qué ocurrió, la calificación vendrá después.',
+    declareRolesNote: 'La declaración de incidentes está abierta a todos los roles para no frenar la notificación. Normalmente corresponde a los risk managers y a los equipos a cargo de la gestión de incidentes o crisis; la calificación, el tratamiento y el seguimiento siguen siendo responsabilidad de la 2ª línea.',
     intitulePlaceholder: '¿Qué ha ocurrido?',
     descriptionPlaceholder: 'Detalles (opcional)',
     dateSurvenance: 'Ocurrencia',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1140,6 +1140,7 @@ export const fr = {
     promoteHint: 'Créer un risque au registre depuis cet incident',
     declareTitle: 'Déclarer un incident',
     declareHint: 'Formulaire court : signalez ce qui s\'est passé, la qualification viendra ensuite.',
+    declareRolesNote: 'La déclaration d\'incident est ouverte à tous les rôles pour ne pas freiner le signalement. Elle relève normalement des risk managers et des métiers en charge de la gestion d\'incident ou de crise ; la qualification, le traitement et le suivi restent du ressort de la 2ᵉ ligne.',
     intitulePlaceholder: 'Que s\'est-il passé ?',
     descriptionPlaceholder: 'Précisions (facultatif)',
     dateSurvenance: 'Survenance',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1117,6 +1117,7 @@ export const it: Translations = {
     promoteHint: 'Crea un rischio del registro da questo incidente',
     declareTitle: 'Dichiara un incidente',
     declareHint: 'Modulo breve: segnala l\'accaduto, la qualificazione verrà dopo.',
+    declareRolesNote: 'La segnalazione di incidenti è aperta a tutti i ruoli per non ostacolare la segnalazione. Spetta normalmente ai risk manager e ai team responsabili della gestione degli incidenti o delle crisi; qualificazione, trattamento e monitoraggio restano di competenza della 2ª linea.',
     intitulePlaceholder: 'Cosa è accaduto?',
     descriptionPlaceholder: 'Dettagli (facoltativo)',
     dateSurvenance: 'Accadimento',


### PR DESCRIPTION
Suite au test E2E par profil. La déclaration d'incident est **ouverte à tous les rôles** (y compris LECTEUR) pour ne pas freiner le signalement — mais elle relève **normalement des risk managers et des métiers en charge de la gestion d'incident/crise**, la qualification/traitement/suivi restant du ressort de la 2ᵉ ligne. Bandeau d'information ajouté dans le module Incidents (5 langues).