### PR TITLE
fix(rbac): lecture globale cohérente du dispositif pour 2ᵉ/3ᵉ ligne (#126)

### DIFF
--- a/src/__tests__/unit/lib/navigation.test.ts
+++ b/src/__tests__/unit/lib/navigation.test.ts
@@ -76,15 +76,19 @@ describe('buildNav — mode grc (module 2ᵉ/3ᵉ ligne actif)', () => {
     expect(groupIds(m)).toEqual(expect.arrayContaining(['cyber', 'registre', 'controle', 'gouvernance']))
   })
 
-  it('CONTROLEUR (2ᵉ ligne) voit les modules mais pas la gouvernance', () => {
+  it('CONTROLEUR (2ᵉ ligne) voit les modules + le pilotage (lecture globale, #126) mais pas la gouvernance-écriture', () => {
     const m = buildNav('CONTROLEUR', ALL_ON)
     const keys = allKeys(m)
     expect(keys).toContain('controles')
     expect(keys).toContain('audit')
     expect(keys).toContain('cartographie')
+    // Pilotage = cockpit de LECTURE consolidée : désormais exposé (l'API /grc/rollup
+    // le sert déjà) — cohérent avec la lecture globale du dispositif (#126).
+    expect(keys).toContain('pilotage')
+    // Mais pas la gouvernance-écriture ni les données de cartographie.
     expect(keys).not.toContain('conformite')
     expect(keys).not.toContain('derogations')
-    expect(keys).not.toContain('pilotage')
+    expect(keys).not.toContain('processus')
   })
 
   it('METIER (1ʳᵉ ligne) : cyber + incidents seulement, aucun module de gestion', () => {

--- a/src/__tests__/unit/lib/permissions.test.ts
+++ b/src/__tests__/unit/lib/permissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   peutDefinir2eLigne,
+  hasGlobalReadDispositif,
   canCreateAnalyse,
   canAdmin,
   canConfigurer,
@@ -359,5 +360,27 @@ describe('peutDefinir2eLigne (définition contrôles / KRI / campagnes — #125)
     for (const role of ['LECTEUR', 'ANALYSTE', 'METIER', 'DPO', 'AUDITEUR', 'DIRECTION_METIER'] as const) {
       expect(peutDefinir2eLigne(role)).toBe(false)
     }
+  })
+})
+
+describe('hasGlobalReadDispositif + analyseWhereClause (lecture globale — #126)', () => {
+  const GLOBAL = ['ADMIN', 'SUPER_ADMIN', 'RISK_MANAGER', 'RSSI', 'DIRECTION_METIER', 'CONTROLEUR', 'CONFORMITE', 'DPO', 'AUDITEUR'] as const
+  const NON_GLOBAL = ['LECTEUR', 'ANALYSTE', 'METIER'] as const
+
+  it('accorde la lecture globale aux gouvernants + 2ᵉ/3ᵉ ligne (dont AUDITEUR)', () => {
+    for (const role of GLOBAL) expect(hasGlobalReadDispositif(role)).toBe(true)
+    for (const role of NON_GLOBAL) expect(hasGlobalReadDispositif(role)).toBe(false)
+  })
+
+  it('analyseWhereClause : la LISTE est cohérente avec la vue unitaire pour AUDITEUR/CONTROLEUR/CONFORMITE/DPO', () => {
+    // Ces rôles voient désormais les analyses soumises/approuvées/rejetées (pas seulement les leurs).
+    for (const role of ['AUDITEUR', 'CONTROLEUR', 'CONFORMITE', 'DPO'] as const) {
+      const w = analyseWhereClause('u1', role) as { OR?: { statut?: string }[] }
+      const statuts = (w.OR ?? []).map(o => o.statut).filter(Boolean)
+      expect(statuts).toEqual(expect.arrayContaining(['SOUMIS', 'APPROUVE', 'REJETE']))
+    }
+    // ANALYSTE reste limité à ses propres analyses + partagées (pas de statuts globaux).
+    const a = analyseWhereClause('u1', 'ANALYSTE') as { OR?: { statut?: string }[] }
+    expect((a.OR ?? []).some(o => o.statut)).toBe(false)
   })
 })

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -15,7 +15,7 @@
  * ⚠️ Règle d'or : le GATING (qui voit quoi) reste identique au comportement
  * historique — on ne change que la DISPOSITION selon le mode, jamais les droits.
  */
-import { isAdminRole, type UserRole } from './permissions'
+import { isAdminRole, hasGlobalReadDispositif, type UserRole } from './permissions'
 
 /** État effectif des modules GRC optionnels (renvoyé par /api/modules). */
 export interface NavModules {
@@ -64,7 +64,11 @@ export function buildNav(role: UserRole, modules: NavModules): NavModel {
   const firstLineOnly = role === 'LECTEUR' || role === 'METIER'
   const canGovern = isAdmin || role === 'RSSI' || role === 'RISK_MANAGER' || role === 'CONFORMITE' || role === 'DPO'
   const canDerog = canGovern || role === 'DIRECTION_METIER'
-  const canPilotage = canGovern || role === 'DIRECTION_METIER'
+  // Processus (données de cartographie) = gouvernance.
+  const canGererProcessus = canGovern || role === 'DIRECTION_METIER'
+  // Pilotage (cockpit de lecture consolidée) : tous les rôles à lecture globale du
+  // dispositif — dont CONTROLEUR et AUDITEUR, que l'API /grc/rollup sert déjà (#126).
+  const canPilotage = hasGlobalReadDispositif(role)
 
   // Gouvernance (disponible dans les deux modes).
   const gouvernance: NavKey[] = []
@@ -94,7 +98,8 @@ export function buildNav(role: UserRole, modules: NavModules): NavModel {
   if (modules.registre && !firstLineOnly) {
     entries.push(link('cartographie'))
     const registre: NavKey[] = ['registre', 'campagnes']
-    if (canPilotage) registre.push('processus', 'pilotage')
+    if (canGererProcessus) registre.push('processus')
+    if (canPilotage) registre.push('pilotage')
     entries.push(groupOrLink('registre', registre))
   }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -57,6 +57,21 @@ export function peutDefinir2eLigne(role: UserRole): boolean {
     || role === 'CONTROLEUR' || role === 'CONFORMITE'
 }
 
+/**
+ * Lecture GLOBALE (transverse, en lecture seule) du dispositif de risque. Les rôles
+ * de 2ᵉ et 3ᵉ ligne de défense doivent pouvoir CONSULTER l'ensemble du dispositif
+ * (analyses soumises/approuvées, cockpit de pilotage) pour exercer leur mission —
+ * sans droit d'écriture. En plus des gouvernants (admin/RM/RSSI/DIRECTION_METIER) :
+ * CONTROLEUR, CONFORMITE, DPO (2ᵉ ligne) et AUDITEUR (3ᵉ ligne — « lecture globale
+ * sur l'ensemble du dispositif »). Helper CENTRAL : `canViewAnalyse` (vue unitaire),
+ * `analyseWhereClause` (liste) et `buildNav` (pilotage) délèguent ici pour rester
+ * cohérents — corrige l'asymétrie liste↔unitaire (#126). N'accorde AUCUNE écriture.
+ */
+export function hasGlobalReadDispositif(role: UserRole): boolean {
+  return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI' || role === 'DIRECTION_METIER'
+    || role === 'CONTROLEUR' || role === 'CONFORMITE' || role === 'DPO' || role === 'AUDITEUR'
+}
+
 /** L'utilisateur peut créer de nouvelles analyses */
 export function canCreateAnalyse(user: SessionUser): boolean {
   return user.role === 'ANALYSTE' || isAdminRole(user.role)
@@ -118,7 +133,8 @@ function getEffectivePermission(
 
 /** L'utilisateur peut visualiser l'analyse */
 export function canViewAnalyse(user: SessionUser, analyse: AnalyseOwnership): boolean {
-  if (isAdminRole(user.role) || user.role === 'RISK_MANAGER' || user.role === 'RSSI' || user.role === 'DIRECTION_METIER' || user.role === 'CONTROLEUR' || user.role === 'CONFORMITE' || user.role === 'DPO') return true
+  // Lecture globale du dispositif (2ᵉ/3ᵉ ligne + gouvernance) — inclut AUDITEUR (#126).
+  if (hasGlobalReadDispositif(user.role)) return true
   return getEffectivePermission(user, analyse) !== null
 }
 
@@ -222,14 +238,16 @@ export function analyseWhereClause(userId: string, role: UserRole, orgCtx?: OrgS
     // Admin d'organisation : tout son périmètre. SUPER_ADMIN : tout (orgFilter vide).
     return { ...notDeleted, ...orgFilter }
   }
-  if (role === 'RISK_MANAGER' || role === 'RSSI' || role === 'DIRECTION_METIER') {
+  if (hasGlobalReadDispositif(role)) {
+    // Lecture globale du dispositif (gouvernance + 2ᵉ/3ᵉ ligne : CONTROLEUR,
+    // CONFORMITE, DPO, AUDITEUR) : propres + partagées + soumises/approuvées/
+    // rejetées → la LISTE est cohérente avec la vue unitaire (#126). Lecture seule.
     return {
       ...notDeleted,
       ...orgFilter,
       OR: [
         { userId },
         { accesUtilisateurs: { some: { userId } } },
-        // Risk Managers, RSSI et Direction métier voient aussi les analyses soumises/approuvées/rejetées
         { statut: 'SOUMIS'   as const },
         { statut: 'APPROUVE' as const },
         { statut: 'REJETE'   as const },


### PR DESCRIPTION
Correctif de l'amélioration **#126** (remontée par la tâche régulière, même cause racine que #125).

## Problème
- `canViewAnalyse` (vue unitaire) accordait la lecture à CONTROLEUR/CONFORMITE/DPO **mais pas** `analyseWhereClause` (la **liste**) → liste d'analyses quasi vide alors qu'ils peuvent ouvrir n'importe quelle analyse par id (**asymétrie liste↔unitaire**).
- **AUDITEUR** pire : absent des deux, alors que `ROLE_DESCRIPTIONS.AUDITEUR` promet « lecture globale sur l'ensemble du dispositif » → un auditeur 3ᵉ ligne ne pouvait lire **aucune** analyse hors les siennes (contredit sa mission).
- `buildNav` masquait *pilotage* au CONTROLEUR alors que `/api/grc/rollup` le sert déjà.

## Correctif
Helper **central** `hasGlobalReadDispositif(role)` = gouvernance + 2ᵉ/3ᵉ ligne (CONTROLEUR/CONFORMITE/DPO/AUDITEUR), **lecture seule**, consommé de façon cohérente par :
- `canViewAnalyse` (vue unitaire)
- `analyseWhereClause` (liste : propres + partagées + soumises/approuvées/rejetées)
- `buildNav` (entrée *pilotage* ; *processus* découplé, reste gouvernance)

## Tests
tsc ✅ · **1184 tests** ✅ (hasGlobalReadDispositif, cohérence liste↔unitaire AUDITEUR/CONTROLEUR/CONFORMITE/DPO, nav CONTROLEUR voit pilotage).