### PR TITLE
chore(demo): purge du jeu de démonstration (repartir avec des données vides)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ docker compose exec app npx prisma db seed
 # ⚠️ Tests uniquement — changez/supprimez ce compte avant toute mise en production
 ```
 
+#### Jeu de démonstration réaliste (sectoriel) — chargeable puis **purgeable**
+
+Un jeu de données réaliste, ancré sur les menaces publiques (ENISA Threat Landscape),
+peut être chargé pour trois secteurs (banque, assurance, santé) : comptes par rôle,
+politique de sécurité socle (DORA + ISO 27001), incidents classés DORA et **une
+analyse EBIOS RM complète (5 ateliers) par secteur**.
+
+```bash
+docker compose exec app npm run db:seed:demo        # charger le jeu de démonstration
+docker compose exec app npm run db:seed:demo:purge  # le retirer → repartir avec des données vides
+```
+
+La purge est **sûre et idempotente** : elle ne retire QUE les données de démonstration
+(3 organisations sectorielles) et ne touche jamais vos données réelles. Exécutez-la
+avant la mise en production pour démarrer sur une instance vierge.
+
 ---
 
 ## 📦 Installation détaillée

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "db:reset": "prisma migrate reset --force && npm run db:seed",
     "postbuild": "node scripts/clean-standalone-env.mjs",
     "i18n:check": "node scripts/extract-ebios-data-i18n.mjs --check",
-    "db:seed:demo": "tsx prisma/seed-demo-realistic.ts"
+    "db:seed:demo": "tsx prisma/seed-demo-realistic.ts",
+    "db:seed:demo:purge": "tsx prisma/seed-demo-realistic.ts --purge"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/prisma/seed-demo-realistic.ts
+++ b/prisma/seed-demo-realistic.ts
@@ -62,6 +62,42 @@ const SECTEURS: SectorSeed[] = [
   },
 ]
 
+/**
+ * PURGE — retire EXACTEMENT ce que ce seed crée (jeu de démo réaliste), pour
+ * repartir sur une instance vierge après l'installation. Sûr et idempotent :
+ * scopé aux 3 organisations sectorielles de démo, ne touche jamais d'autres orgs.
+ * `npm run db:seed:demo:purge`.
+ */
+async function purge() {
+  console.log('Purge du jeu de démonstration réaliste (ENISA)…')
+  const emails: string[] = []
+  for (const sec of SECTEURS) {
+    const org = await prisma.organization.findFirst({ where: { nom: sec.nom }, select: { id: true } })
+    if (!org) continue
+    const orgId = org.id
+    // Analyses EBIOS (cascade → cadrage/sources/PP/scénarios/risques/mesures)
+    const noms = ANALYSES_EBIOS.filter(a => a.orgNom === sec.nom).map(a => a.nom)
+    if (noms.length) await prisma.analyse.deleteMany({ where: { organizationId: orgId, nom: { in: noms } } })
+    // Incidents (par intitulé exact du seed)
+    await prisma.incident.deleteMany({ where: { organizationId: orgId, intitule: { in: sec.incidents.map(i => i.intitule) } } })
+    // Politique socle sectorielle
+    await prisma.referentiel.deleteMany({ where: { organizationId: orgId, code: sec.codePol } })
+    // Modules réactivables réinitialisés à OFF (données démo désactivées)
+    await prisma.organizationConfig.updateMany({ where: { id: orgId }, data: {
+      registreRisquesActive: false, incidentsActive: false, controlePermanentActive: false,
+      auditInterneActive: false, kriActive: false, reglementaireActive: false,
+    } }).catch(() => {})
+    for (const role of ['RSSI', 'CONTROLEUR', 'AUDITEUR']) emails.push(`${role.toLowerCase()}.${sec.nom.toLowerCase()}@demo.acra`)
+    console.log(`  ✓ ${sec.nom} purgé (analyse EBIOS, incidents, politique, modules réinitialisés)`)
+  }
+  // Comptes de démonstration + adhésions
+  const users = await prisma.user.findMany({ where: { email: { in: emails } }, select: { id: true } })
+  for (const u of users) await prisma.orgMembership.deleteMany({ where: { userId: u.id } })
+  await prisma.user.deleteMany({ where: { email: { in: emails } } })
+  console.log(`  ✓ ${users.length} comptes de démonstration supprimés`)
+  console.log('\nJeu de démonstration purgé — instance prête à démarrer avec des données vides.')
+}
+
 async function main() {
   const hash = await bcrypt.hash(PWD, 10)
   const now = Date.now()
@@ -130,9 +166,11 @@ async function main() {
   for (const spec of ANALYSES_EBIOS) await creerAnalyseEbios(spec)
 
   console.log(`\nComptes de démonstration : rssi.<org>@demo.acra / controleur.<org>@demo.acra / auditeur.<org>@demo.acra — mot de passe ${PWD}`)
+  console.log('Pour repartir vierge après l\'installation : npm run db:seed:demo:purge')
 }
 
-main().catch(e => { console.error(e); process.exit(1) }).finally(() => prisma.$disconnect())
+const action = process.argv.includes('--purge') ? purge : main
+action().catch(e => { console.error(e); process.exit(1) }).finally(() => prisma.$disconnect())
 
 // ─── Analyses EBIOS RM complètes par secteur (5 ateliers) ────────────────────
 // Contenu réaliste ancré sur les menaces sectorielles (ENISA / panoramas ANSSI).


### PR DESCRIPTION
Suite à la demande : *« on peut garder un mode démo avec des données que l'on peut désactiver une fois installé pour partir avec des données vides »*.

## Ce que ça apporte
Le jeu de démonstration réaliste (secteurs banque/assurance/santé — comptes, politique socle DORA+ISO, incidents classés DORA, **analyses EBIOS RM complètes**) devient **purgeable** :

```bash
npm run db:seed:demo         # charger la démo
npm run db:seed:demo:purge   # la retirer → instance vierge
```

## Purge sûre et scopée
`--purge` retire **exactement** ce que le seed crée, pour les 3 organisations sectorielles de démo uniquement :
- analyses EBIOS (cascade → cadrage/sources/PP/scénarios/risques/mesures),
- incidents (par intitulé exact),
- politiques socle (`PSSI-<ORG>`),
- comptes `@demo.acra` + adhésions,
- modules réinitialisés à OFF.

**Ne touche jamais d'autres organisations ni de données réelles.** Idempotent.

## Vérifié
Cycle **seed → purge (0 donnée démo restante) → re-seed (démo restaurée)** propre. `tsc` ✅.

À exécuter avant la mise en production pour démarrer sur une instance vierge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)