### PR TITLE
chore: ignore le dossier local /presentations/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Thumbs.db
 
 # Stockage local des documents (dev)
 .data/
+
+# Présentations locales (non versionnées)
+/presentations/


### PR DESCRIPTION
Ajoute `/presentations/` au `.gitignore` : les supports de présentation (.pptx) restent **locaux**, jamais versionnés ni poussés.