### PR TITLE
feat(saisie): défauts de date, autocomplétion, responsable par défaut, bascule thème

### DIFF
--- a/docs/specs/saisie-defauts-autocomplete.md
+++ b/docs/specs/saisie-defauts-autocomplete.md
@@ -1,0 +1,56 @@
+# Spec — Faciliter la saisie : défauts, autocomplétion, thème, tooltips
+
+Issu de l'audit UX du 2026-08-23 (vérification runtime clair/sombre + libellés longs).
+Objectif : réduire l'effort de saisie et lever deux frictions visuelles constatées.
+
+## Chantier 1 — Valeurs de date par défaut = aujourd'hui
+
+**Constat :** le formulaire de déclaration d'incident ouvre les champs *Survenance* et
+*Détection* vides (`jj/mm/aaaa`). L'utilisateur doit saisir la date du jour à la main.
+
+**Décision :** pré-remplir ces champs avec la date du jour (heure locale, format
+`YYYY-MM-DD` attendu par `<input type="date">`). Idem pour la date de réalisation
+d'une **exécution de contrôle** (même helper).
+
+**Pur & testé :** `todayInputDate(now?: Date): string` dans `lib/form-defaults.ts`.
+L'utilisateur reste libre de modifier la valeur.
+
+## Chantier 2 — Autocomplétion des champs texte libres (`<datalist>`)
+
+**Constat :** ~230 `<input>` texte libres, l'autocomplétion native n'existe que pour
+les noms de tiers (ateliers 3/5). Rien pour les intitulés/responsables récurrents.
+
+**Décision :** alimenter un `<datalist>` à partir des valeurs **déjà saisies** dans
+l'organisation :
+- Contrôle : `intitulé` et `responsable` (depuis les contrôles existants).
+- Incident : `entité` (depuis les incidents existants).
+
+**Pur & testé :** `suggestionsFromValues(values, limit=50): string[]` — valeurs
+distinctes, non vides, `trim`, dédoublonnage insensible casse/accents (on garde la
+1ʳᵉ casse rencontrée), tri alphabétique local.
+
+## Chantier 3 — Responsable par défaut = utilisateur courant
+
+**Constat :** le champ *Responsable* d'un nouveau contrôle est vide.
+
+**Décision :** à la **création** (pas à l'édition), pré-remplir *Responsable* avec le
+nom de l'utilisateur connecté. Modifiable. La page serveur `/controles` transmet
+`currentUserName` (depuis la session) au composant.
+
+**Pur & testé :** `defaultResponsable(currentUserName?: string | null): string`.
+
+## Chantier 4 — Bascule de thème rapide + tooltips sur libellés tronqués
+
+**Constat :** pas de bascule clair/sombre hors page profil ; certains libellés
+tronqués (`truncate`) sans `title` au survol (ex. nom d'analyse au tableau de bord).
+
+**Décision :**
+- Ajouter un sélecteur de thème compact (Clair / Sombre / Auto) dans le menu
+  utilisateur du `Navbar`, câblé sur `useTheme()` (déjà existant).
+- Ajouter `title={valeur}` sur les libellés susceptibles d'être tronqués
+  (tableau de bord : nom d'analyse ; tables contrôles/incidents : intitulés).
+
+## Portée des tests
+- Unitaires (Vitest) : `lib/form-defaults.ts` (3 fonctions) — cas nominaux + limites.
+- Fonctionnels (runtime) : vérif live des 4 chantiers, thèmes clair **et** sombre,
+  libellés courts et longs.

--- a/src/__tests__/unit/lib/form-defaults.test.ts
+++ b/src/__tests__/unit/lib/form-defaults.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { todayInputDate, suggestionsFromValues, defaultResponsable } from '@/lib/form-defaults'
+
+describe('todayInputDate', () => {
+  it('formate une date en YYYY-MM-DD (heure locale)', () => {
+    // 2026-03-09 (mois et jour < 10 → zéro-padding)
+    const d = new Date(2026, 2, 9, 14, 30, 0)
+    expect(todayInputDate(d)).toBe('2026-03-09')
+  })
+
+  it('zéro-pad correctement décembre et le 31', () => {
+    expect(todayInputDate(new Date(2026, 11, 31, 23, 59))).toBe('2026-12-31')
+  })
+
+  it('utilise les composantes locales, pas UTC', () => {
+    // 1er janvier 00:30 locale : la date locale est bien le 01, pas le 31/12 UTC.
+    const d = new Date(2026, 0, 1, 0, 30)
+    expect(todayInputDate(d)).toBe('2026-01-01')
+  })
+
+  it('sans argument, renvoie une chaîne au format attendu', () => {
+    expect(todayInputDate()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('suggestionsFromValues', () => {
+  it('retourne les valeurs distinctes, non vides, triées', () => {
+    expect(suggestionsFromValues(['Banque', 'Assurance', 'Banque'])).toEqual(['Assurance', 'Banque'])
+  })
+
+  it('ignore null, undefined et chaînes vides/espaces', () => {
+    expect(suggestionsFromValues(['Alice', null, undefined, '', '   ', 'Bob'])).toEqual(['Alice', 'Bob'])
+  })
+
+  it('trim les valeurs', () => {
+    expect(suggestionsFromValues(['  Alice  ', 'Bob'])).toEqual(['Alice', 'Bob'])
+  })
+
+  it('dédoublonne sans tenir compte de la casse et des accents, garde la 1re occurrence', () => {
+    expect(suggestionsFromValues(['Éric', 'eric', 'ERIC'])).toEqual(['Éric'])
+  })
+
+  it('respecte la limite', () => {
+    const many = Array.from({ length: 100 }, (_, i) => `v${String(i).padStart(3, '0')}`)
+    const out = suggestionsFromValues(many, 10)
+    expect(out).toHaveLength(10)
+    expect(out[0]).toBe('v000')
+  })
+
+  it('renvoie un tableau vide pour une entrée vide', () => {
+    expect(suggestionsFromValues([])).toEqual([])
+  })
+})
+
+describe('defaultResponsable', () => {
+  it('renvoie le nom trimé de l\'utilisateur courant', () => {
+    expect(defaultResponsable('  RSSI StarBank  ')).toBe('RSSI StarBank')
+  })
+
+  it('renvoie une chaîne vide si nom absent', () => {
+    expect(defaultResponsable(null)).toBe('')
+    expect(defaultResponsable(undefined)).toBe('')
+    expect(defaultResponsable('   ')).toBe('')
+  })
+})

--- a/src/app/controles/page.tsx
+++ b/src/app/controles/page.tsx
@@ -28,7 +28,7 @@ export default async function ControlesPage() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <Navbar />
       <main className="max-w-6xl mx-auto px-4 py-8">
-        <ControlesManager canDefine={canDefine} canExecute={canExecute} />
+        <ControlesManager canDefine={canDefine} canExecute={canExecute} currentUserName={session.user.name ?? null} />
       </main>
     </div>
   )

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -279,7 +279,7 @@ export default async function DashboardPage() {
                         className="card p-4 flex items-center gap-4 hover:shadow-md transition-shadow block">
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 mb-1 flex-wrap">
-                            <span className="font-medium text-gray-900 truncate">{a.nom}</span>
+                            <span className="font-medium text-gray-900 truncate" title={a.nom}>{a.nom}</span>
                             {consolidated && (a as any).organization?.nom && (
                               <span className="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 font-medium flex-shrink-0 inline-flex items-center gap-1" title={t.nav.organization}>
                                 <Building2 size={11} aria-hidden="true" /> {(a as any).organization.nom}

--- a/src/components/ControlesManager.tsx
+++ b/src/components/ControlesManager.tsx
@@ -4,6 +4,7 @@ import { FlaskConical, Paperclip } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
 import { CONTROLE_NIVEAUX, PERIODICITES, RESULTATS } from '@/lib/controle'
+import { todayInputDate, suggestionsFromValues, defaultResponsable } from '@/lib/form-defaults'
 
 interface Efficacite {
   evaluees: number; conformes: number; anomalies: number
@@ -55,20 +56,24 @@ const RESULTAT_BADGE: Record<string, string> = {
   NON_APPLICABLE: 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-300',
 }
 
-export default function ControlesManager({ canDefine, canExecute }: { canDefine: boolean; canExecute: boolean }) {
+export default function ControlesManager({ canDefine, canExecute, currentUserName }: { canDefine: boolean; canExecute: boolean; currentUserName?: string | null }) {
   const { t, locale } = useTranslation()
   const c = t.controles
+  // Formulaire vierge : responsable pré-rempli avec l'utilisateur courant (modifiable).
+  const emptyForm = (): Form => ({ ...EMPTY, responsable: defaultResponsable(currentUserName) })
+  // Saisie d'exécution vierge : date de réalisation = aujourd'hui par défaut.
+  const emptyExec = (): ExecForm => ({ ...EMPTY_EXEC, dateRealisation: todayInputDate() })
   const [controles, setControles] = useState<Controle[]>([])
   const [procs, setProcs] = useState<Proc[]>([])
   const [risks, setRisks] = useState<Risk[]>([])
   const [refs, setRefs] = useState<RefLite[]>([])
   const [exigencesRef, setExigencesRef] = useState<ExigenceLite[]>([])
   const [loading, setLoading] = useState(true)
-  const [form, setForm] = useState<Form>(EMPTY)
+  const [form, setForm] = useState<Form>(emptyForm)
   const [editId, setEditId] = useState<string | null>(null)
   const [showForm, setShowForm] = useState(false)
   const [execId, setExecId] = useState<string | null>(null)
-  const [exec, setExec] = useState<ExecForm>(EMPTY_EXEC)
+  const [exec, setExec] = useState<ExecForm>(emptyExec)
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -134,7 +139,7 @@ export default function ControlesManager({ canDefine, canExecute }: { canDefine:
     const data = await res.json().catch(() => ({}))
     setBusy(false)
     if (!res.ok) { setError(err(data.error ?? 'erreur')); return }
-    setForm(EMPTY); setEditId(null); setShowForm(false); reload()
+    setForm(emptyForm()); setEditId(null); setShowForm(false); reload()
   }
 
   function startEdit(x: Controle) {
@@ -162,7 +167,7 @@ export default function ControlesManager({ canDefine, canExecute }: { canDefine:
     setBusy(false)
     if (!res.ok) { setError(err(data.error ?? 'erreur')); return }
     if (data.actionCreee) setFlash(c.actionGeneree)
-    setExec(EMPTY_EXEC); setPreuves([]); setExecId(null); reload()
+    setExec(emptyExec()); setPreuves([]); setExecId(null); reload()
   }
 
   async function basculerActif(x: Controle) {
@@ -179,6 +184,9 @@ export default function ControlesManager({ canDefine, canExecute }: { canDefine:
   }
 
   const inp = 'px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm'
+  // Suggestions d'autocomplétion à partir des contrôles déjà saisis (org courante).
+  const intituleSug = suggestionsFromValues(controles.map(x => x.intitule))
+  const responsableSug = suggestionsFromValues(controles.map(x => x.responsable))
   const enRetard = controles.filter(x => x.etatEcheance === 'EN_RETARD').length
   const dus = controles.filter(x => x.etatEcheance === 'DU').length
   const actifs = controles.filter(x => x.actif).length
@@ -188,7 +196,7 @@ export default function ControlesManager({ canDefine, canExecute }: { canDefine:
       <div className="flex items-center justify-between mb-1 flex-wrap gap-2">
         <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100"><FlaskConical size={22} className="inline align-[-0.15em] mr-2" aria-hidden="true" /> {c.title}</h1>
         {canDefine && !showForm && (
-          <button onClick={() => { setForm(EMPTY); setEditId(null); setShowForm(true) }} className="btn-primary text-sm">{c.newBtn}</button>
+          <button onClick={() => { setForm(emptyForm()); setEditId(null); setShowForm(true) }} className="btn-primary text-sm">{c.newBtn}</button>
         )}
       </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">{c.subtitle}</p>
@@ -207,7 +215,8 @@ export default function ControlesManager({ canDefine, canExecute }: { canDefine:
         <div className="card p-4 mb-5 space-y-3">
           <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">{editId ? c.editTitle : c.addTitle}</p>
           {error && <p className="text-xs text-red-600">{error}</p>}
-          <input value={form.intitule} onChange={e => setForm(f => ({ ...f, intitule: e.target.value }))} placeholder={c.intitulePlaceholder} className={`${inp} w-full`} />
+          <input value={form.intitule} onChange={e => setForm(f => ({ ...f, intitule: e.target.value }))} placeholder={c.intitulePlaceholder} list="acra-controle-intitules" className={`${inp} w-full`} />
+          <datalist id="acra-controle-intitules">{intituleSug.map(s => <option key={s} value={s} />)}</datalist>
           <textarea value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} placeholder={c.descriptionPlaceholder} rows={2} className={`${inp} w-full`} />
           <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
             <label className="text-xs text-gray-500 dark:text-gray-400">{c.niveau}
@@ -221,7 +230,8 @@ export default function ControlesManager({ canDefine, canExecute }: { canDefine:
               </select>
             </label>
             <label className="text-xs text-gray-500 dark:text-gray-400">{c.responsable}
-              <input value={form.responsable} onChange={e => setForm(f => ({ ...f, responsable: e.target.value }))} className={`${inp} w-full mt-1`} />
+              <input value={form.responsable} onChange={e => setForm(f => ({ ...f, responsable: e.target.value }))} list="acra-controle-responsables" className={`${inp} w-full mt-1`} />
+              <datalist id="acra-controle-responsables">{responsableSug.map(s => <option key={s} value={s} />)}</datalist>
             </label>
             <label className="text-xs text-gray-500 dark:text-gray-400">{c.echantillon}
               <input type="number" min="1" value={form.tailleEchantillon} onChange={e => setForm(f => ({ ...f, tailleEchantillon: e.target.value }))} className={`${inp} w-full mt-1`} />
@@ -319,7 +329,7 @@ export default function ControlesManager({ canDefine, canExecute }: { canDefine:
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-right">
                       {canExecute && x.actif && (
-                        <button onClick={() => { setExecId(x.id); setExec(EMPTY_EXEC); setPreuves([]); setError(null) }} className="text-xs text-ebios-600 hover:underline mr-2">{c.execute}</button>
+                        <button onClick={() => { setExecId(x.id); setExec(emptyExec()); setPreuves([]); setError(null) }} className="text-xs text-ebios-600 hover:underline mr-2">{c.execute}</button>
                       )}
                       {canDefine && <>
                         <button onClick={() => startEdit(x)} className="text-xs text-ebios-600 hover:underline mr-2">{c.edit}</button>

--- a/src/components/IncidentsManager.tsx
+++ b/src/components/IncidentsManager.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
 import { taxonomieLabel, type TaxonomieNode } from '@/lib/taxonomie'
 import { INCIDENT_STATUTS, transitionAutorisee, type IncidentStatut } from '@/lib/incident'
+import { todayInputDate, suggestionsFromValues } from '@/lib/form-defaults'
 
 interface Incident {
   id: string; intitule: string; description: string | null
@@ -31,6 +32,11 @@ type DeclForm = {
   processusId: string; entite: string; impactEstime: string
 }
 const EMPTY_DECL: DeclForm = { intitule: '', description: '', dateSurvenance: '', dateDetection: '', processusId: '', entite: '', impactEstime: '' }
+// Formulaire de déclaration vierge : dates de survenance et détection = aujourd'hui
+// par défaut (l'incident vient en général d'être constaté). Modifiables.
+function emptyDecl(): DeclForm {
+  return { ...EMPTY_DECL, dateSurvenance: todayInputDate(), dateDetection: todayInputDate() }
+}
 
 // Formulaire de QUALIFICATION (2ᵉ ligne) : taxonomie, pertes, rattachement.
 type QualForm = { taxonomieCode: string; montantBrut: string; recuperations: string; riskItemId: string; statut: string; clotureCommentaire: string }
@@ -50,7 +56,7 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
   const [procs, setProcs] = useState<Proc[]>([])
   const [risks, setRisks] = useState<Risk[]>([])
   const [loading, setLoading] = useState(true)
-  const [decl, setDecl] = useState<DeclForm>(EMPTY_DECL)
+  const [decl, setDecl] = useState<DeclForm>(emptyDecl)
   const [showDecl, setShowDecl] = useState(false)
   const [qualId, setQualId] = useState<string | null>(null)
   const [qual, setQual] = useState<QualForm>({ taxonomieCode: '', montantBrut: '', recuperations: '', riskItemId: '', statut: 'QUALIFIE', clotureCommentaire: '' })
@@ -138,7 +144,7 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
     const data = await res.json().catch(() => ({}))
     setBusy(false)
     if (!res.ok) { setError(err(data.error ?? 'erreur')); return }
-    setDecl(EMPTY_DECL); setShowDecl(false); reload()
+    setDecl(emptyDecl()); setShowDecl(false); reload()
   }
 
   function startQual(i: Incident) {
@@ -210,6 +216,8 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
   }
 
   const inp = 'px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm'
+  // Suggestions d'entités à partir des incidents déjà saisis (org courante).
+  const entiteSug = suggestionsFromValues(incidents.map(i => i.entite))
   const totalPertes = incidents.reduce((s, i) => s + (i.perteNette ?? 0), 0)
   const ouverts = incidents.filter(i => i.statut === 'DECLARE').length
 
@@ -222,7 +230,7 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
           <button onClick={() => exportLdc('csv')} className="btn-secondary text-xs">{t.filtres.csv}</button>
           <button onClick={() => exportLdc('xlsx')} className="btn-secondary text-xs">{t.filtres.xlsx}</button>
           <button onClick={exportIts} className="btn-secondary text-xs" title={n.doraItsHint}>{n.doraExportIts}</button>
-          {!showDecl && <button onClick={() => { setDecl(EMPTY_DECL); setShowDecl(true) }} className="btn-primary text-sm ml-1.5">{n.declareBtn}</button>}
+          {!showDecl && <button onClick={() => { setDecl(emptyDecl()); setShowDecl(true) }} className="btn-primary text-sm ml-1.5">{n.declareBtn}</button>}
         </div>
       </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{n.subtitle}</p>
@@ -268,7 +276,8 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
               <option value="">{n.processNone}</option>
               {procs.map(p => <option key={p.id} value={p.id}>{p.nom}</option>)}
             </select>
-            <input value={decl.entite} onChange={e => setDecl(f => ({ ...f, entite: e.target.value }))} placeholder={n.entityPlaceholder} className={inp} />
+            <input value={decl.entite} onChange={e => setDecl(f => ({ ...f, entite: e.target.value }))} placeholder={n.entityPlaceholder} list="acra-incident-entites" className={inp} />
+            <datalist id="acra-incident-entites">{entiteSug.map(s => <option key={s} value={s} />)}</datalist>
           </div>
           <div className="flex gap-2">
             <button onClick={declarer} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{n.declare}</button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,13 +9,14 @@ import { ROLE_LABELS, ROLE_COLORS, isAdminRole, type UserRole } from '@/lib/perm
 import { buildNav, type NavKey, type NavGroupId, type NavModules } from '@/lib/navigation'
 import { useTranslation } from '@/lib/i18n/context'
 import { useBranding } from '@/components/BrandingProvider'
+import { useTheme, type ThemeMode } from '@/lib/theme'
 import GlobalSearch from './GlobalSearch'
 import OrgSwitcher from './OrgSwitcher'
 import {
   LayoutDashboard, FolderKanban, AlertTriangle, Shield, Network, ShieldCheck,
   User, ChevronDown, Settings, KeyRound, LogOut, FileWarning, Workflow, BookMarked,
   Map, BarChart3, Siren, ClipboardCheck, ClipboardList, Search, TrendingUp, Landmark,
-  LayoutGrid, Radar, ScrollText, FileText, type LucideIcon,
+  LayoutGrid, Radar, ScrollText, FileText, Sun, Moon, Monitor, type LucideIcon,
 } from 'lucide-react'
 
 export default function Navbar() {
@@ -23,6 +24,7 @@ export default function Navbar() {
   const pathname = usePathname()
   const { t } = useTranslation()
   const branding = useBranding()
+  const { theme, setTheme } = useTheme()
   const [menuOpen, setMenuOpen] = useState(false)
   // Un seul groupe déroulant ouvert à la fois (identifiant), + sa position viewport.
   // Les menus sont rendus en `fixed` pour ÉCHAPPER au clipping de la barre
@@ -278,6 +280,33 @@ export default function Navbar() {
                     {t.nav.admin}
                   </Link>
                 )}
+
+                <hr className="my-1 border-gray-100" aria-hidden="true" />
+
+                {/* Bascule de thème rapide (Clair / Sombre / Auto) — câblée sur useTheme */}
+                <div className="px-3 py-2">
+                  <div className="text-[11px] text-gray-400 mb-1">{t.profile.themeTitle}</div>
+                  <div className="flex gap-1" role="group" aria-label={t.profile.themeTitle}>
+                    {([
+                      { value: 'light',  Icon: Sun,     label: t.profile.themeLight },
+                      { value: 'dark',   Icon: Moon,    label: t.profile.themeDark },
+                      { value: 'system', Icon: Monitor, label: t.profile.themeSystem },
+                    ] as { value: ThemeMode; Icon: LucideIcon; label: string }[]).map(({ value, Icon, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setTheme(value)}
+                        aria-pressed={theme === value}
+                        title={label}
+                        className={`flex-1 inline-flex items-center justify-center gap-1 px-2 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                          theme === value ? 'bg-ebios-100 text-ebios-700' : 'text-gray-600 hover:bg-gray-100'
+                        }`}
+                      >
+                        <Icon size={14} aria-hidden="true" />
+                        <span>{label}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
 
                 <hr className="my-1 border-gray-100" aria-hidden="true" />
 

--- a/src/lib/form-defaults.ts
+++ b/src/lib/form-defaults.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers purs pour faciliter la saisie des formulaires : valeurs par défaut et
+ * suggestions d'autocomplétion. Aucune dépendance DOM/React → testable sans DB.
+ *
+ * Voir docs/specs/saisie-defauts-autocomplete.md
+ */
+
+/** Date du jour au format attendu par `<input type="date">` (YYYY-MM-DD), en heure locale. */
+export function todayInputDate(now: Date = new Date()): string {
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+/** Clé de dédoublonnage insensible à la casse et aux accents (é → e). */
+function normKey(s: string): string {
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLocaleLowerCase()
+}
+
+/**
+ * Valeurs distinctes, non vides, `trim`, pour alimenter un `<datalist>`.
+ * Dédoublonnage insensible casse/accents (on garde la 1ʳᵉ casse rencontrée),
+ * puis tri alphabétique local et troncature à `limit`.
+ */
+export function suggestionsFromValues(values: (string | null | undefined)[], limit = 50): string[] {
+  const seen = new Map<string, string>() // clé normalisée → valeur d'origine
+  for (const v of values) {
+    const s = (v ?? '').trim()
+    if (!s) continue
+    const key = normKey(s)
+    if (!seen.has(key)) seen.set(key, s)
+  }
+  return [...seen.values()]
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+    .slice(0, limit)
+}
+
+/** Nom de responsable par défaut = utilisateur courant (trimé), sinon chaîne vide. */
+export function defaultResponsable(currentUserName?: string | null): string {
+  return (currentUserName ?? '').trim()
+}


### PR DESCRIPTION
## Contexte
4 chantiers issus de la demande de re-test des cas d'usage + vérif visuelle (thèmes clair/sombre, libellés longs). Objectif : **faciliter la saisie au maximum** et lever deux frictions visuelles. Spec : [`docs/specs/saisie-defauts-autocomplete.md`](docs/specs/saisie-defauts-autocomplete.md).

## Chantiers
1. **Dates par défaut = aujourd'hui** — déclaration d'incident (survenance/détection) + exécution de contrôle (date de réalisation). Modifiables.
2. **Autocomplétion `<datalist>`** alimentée par les valeurs déjà saisies dans l'org : contrôle (intitulé, responsable), incident (entité).
3. **Responsable par défaut = utilisateur courant** à la création d'un contrôle (pas à l'édition) ; `/controles` transmet `currentUserName` depuis la session.
4. **Bascule de thème rapide** (Clair / Sombre / Auto) dans le menu utilisateur du `Navbar`, câblée sur `useTheme` + `title` au survol sur le nom d'analyse tronqué (tableau de bord).

## TDD & qualité
- Logique pure et testée : `lib/form-defaults.ts` (`todayInputDate`, `suggestionsFromValues`, `defaultResponsable`) — **12 tests** (nominaux + limites : zéro-padding, dédoublonnage insensible casse/accents, limite, trim).
- Suite complète **verte : 1196 tests / 110 fichiers**. `tsc --noEmit` : **0 erreur**. `npm run build` : OK.

## Vérification fonctionnelle (runtime, live)
- P1 : dates du formulaire d'incident = `2026-08-23` (aujourd'hui) ✓
- P2 : datalists présents et peuplés (5 intitulés de contrôle triés) ✓
- P3 : responsable pré-rempli « RSSI StarBank » ✓
- P4 : clic « Clair » retire la classe `dark` + persiste `light` (localStorage) ✓ ; `title` présent sur le nom d'analyse tronqué ✓
- Rendu vérifié en thèmes **clair et sombre** (captures form contrôle + menu utilisateur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)