### PR TITLE
fix(rbac): aligner l'UI 2ᵉ ligne sur les gardes d'API + autocomplétion A5

### DIFF
--- a/src/app/campagnes/page.tsx
+++ b/src/app/campagnes/page.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import Navbar from '@/components/Navbar'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
 import CampagnesManager from '@/components/CampagnesManager'
@@ -22,7 +22,8 @@ export default async function CampagnesPage() {
   if (!orgConfig.registreRisquesActive) redirect('/dashboard')
 
   // Piloter (ouvrir/valider/clôturer) = 2ᵉ ligne ; coter = 1ʳᵉ ligne.
-  const canPilot = isAdminRole(userRole) || userRole === 'RISK_MANAGER' || userRole === 'RSSI'
+  // Aligné sur le garde de l'API /api/campagnes (peutDefinir2eLigne).
+  const canPilot = peutDefinir2eLigne(userRole)
   const canCote = userRole !== 'LECTEUR'
 
   return (

--- a/src/app/controles/campagnes/page.tsx
+++ b/src/app/controles/campagnes/page.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import Navbar from '@/components/Navbar'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
 import CampagnesControleManager from '@/components/CampagnesControleManager'
@@ -22,8 +22,9 @@ export default async function CampagnesControlePage() {
   if (!orgConfig.controlePermanentActive) redirect('/dashboard')
 
   // Définition des campagnes = 2ᵉ ligne (pilotage du plan de contrôle).
+  // Aligné sur le garde de l'API /api/controles/campagnes (peutDefinir2eLigne).
   const role = scope.role
-  const canDefine = isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
+  const canDefine = peutDefinir2eLigne(role)
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">

--- a/src/app/controles/page.tsx
+++ b/src/app/controles/page.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import Navbar from '@/components/Navbar'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
 import ControlesManager from '@/components/ControlesManager'
@@ -21,7 +21,8 @@ export default async function ControlesPage() {
   if (!orgConfig.controlePermanentActive) redirect('/dashboard')
 
   // Définir le plan de contrôle = 2ᵉ ligne ; l'exécuter = 1ʳᵉ ligne (tous sauf LECTEUR).
-  const canDefine = isAdminRole(userRole) || userRole === 'RISK_MANAGER' || userRole === 'RSSI'
+  // Aligné sur le garde de l'API POST /api/controles (peutDefinir2eLigne).
+  const canDefine = peutDefinir2eLigne(userRole)
   const canExecute = userRole !== 'LECTEUR'
 
   return (

--- a/src/app/kri/page.tsx
+++ b/src/app/kri/page.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import Navbar from '@/components/Navbar'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
 import KriManager from '@/components/KriManager'
@@ -21,7 +21,8 @@ export default async function KriPage() {
   if (!orgConfig.kriActive) redirect('/dashboard')
 
   // Définition = 2ᵉ ligne (gouvernance) ; saisie de mesure = 1ʳᵉ ligne (tout sauf lecteur).
-  const canDefine = isAdminRole(userRole) || userRole === 'RISK_MANAGER' || userRole === 'RSSI'
+  // Aligné sur le garde de l'API POST /api/kri (peutDefinir2eLigne).
+  const canDefine = peutDefinir2eLigne(userRole)
   const canMeasure = userRole !== 'LECTEUR'
 
   return (

--- a/src/components/RiskActionsPanel.tsx
+++ b/src/components/RiskActionsPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
 import { RISK_ACTION_STATUTS } from '@/lib/risk-action'
+import { suggestionsFromValues } from '@/lib/form-defaults'
 
 export interface ActionsSummary {
   total: number; faits: number; enCours: number; aFaire: number; enRetard: number; tauxAvancement: number
@@ -64,6 +65,10 @@ export default function RiskActionsPanel({ riskId, canEdit, onChange }: { riskId
   }
 
   const inp = 'px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm'
+  // Autocomplétion du responsable à partir des actions déjà saisies sur ce risque.
+  // id scopé par riskId (plusieurs panneaux peuvent coexister sur une même page).
+  const respListId = `acra-riskaction-resp-${riskId}`
+  const responsableSug = suggestionsFromValues(actions.map(x => x.responsable))
 
   return (
     <div>
@@ -77,7 +82,8 @@ export default function RiskActionsPanel({ riskId, canEdit, onChange }: { riskId
           {error && <p className="text-xs text-red-600">{error}</p>}
           <input value={form.intitule} onChange={e => setForm(f => ({ ...f, intitule: e.target.value }))} placeholder={a.intitulePlaceholder} className={`${inp} w-full`} />
           <div className="flex flex-wrap gap-2 items-center">
-            <input value={form.responsable} onChange={e => setForm(f => ({ ...f, responsable: e.target.value }))} placeholder={a.responsablePlaceholder} className={inp} />
+            <input value={form.responsable} onChange={e => setForm(f => ({ ...f, responsable: e.target.value }))} placeholder={a.responsablePlaceholder} list={respListId} className={inp} />
+            <datalist id={respListId}>{responsableSug.map(s => <option key={s} value={s} />)}</datalist>
             <input type="date" value={form.echeance} onChange={e => setForm(f => ({ ...f, echeance: e.target.value }))} className={inp} aria-label={a.echeance} />
             <select value={form.statut} onChange={e => setForm(f => ({ ...f, statut: e.target.value }))} className={inp}>
               {RISK_ACTION_STATUTS.map(s => <option key={s} value={s}>{(a.statuts as Record<string, string>)[s] ?? s}</option>)}
@@ -95,7 +101,7 @@ export default function RiskActionsPanel({ riskId, canEdit, onChange }: { riskId
             {actions.map(x => (
               <li key={x.id} className="flex items-center gap-3 text-sm">
                 <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${STATUT_BADGE[x.statutEffectif] ?? STATUT_BADGE.A_FAIRE}`}>{(a.statuts as Record<string, string>)[x.statutEffectif] ?? x.statutEffectif}</span>
-                <span className="flex-1 text-gray-700 dark:text-gray-200 truncate">{x.intitule}</span>
+                <span className="flex-1 text-gray-700 dark:text-gray-200 truncate" title={x.intitule}>{x.intitule}</span>
                 {x.responsable && <span className="text-xs text-gray-400">{x.responsable}</span>}
                 {x.echeance && <span className="text-xs text-gray-400">{x.echeance.slice(0, 10)}</span>}
                 {canEdit && <>


### PR DESCRIPTION
## Contexte
Suites du chantier saisie (#27). Deux points repérés en passant.

## 1. Incohérence RBAC 2ᵉ ligne (UI ≠ API)
Les rôles **CONTROLEUR** et **CONFORMITE** pouvaient créer via l'API (`peutDefinir2eLigne`) mais **ne voyaient pas les boutons** : les pages recalculaient le droit en dur (`isAdmin | RISK_MANAGER | RSSI`), sans ces deux rôles.

Pages alignées sur `peutDefinir2eLigne` (fonction déjà testée, #125) :
- `/controles` (`canDefine`) — API `POST /api/controles`
- `/kri` (`canDefine`) — API `/api/kri`
- `/campagnes` (`canPilot`) — API `/api/campagnes`
- `/controles/campagnes` (`canDefine`) — API `/api/controles/campagnes`

Laissées inchangées car **déjà cohérentes** avec leur API (garde `isAdmin|RM|RSSI`) : `/reglementaire` (DORA `peutEvaluerDora`), `/incidents` (`peutQualifier`).

## 2. Autocomplétion A5 (plan d'action d'un risque)
`RiskActionsPanel` : `<datalist>` sur le champ **responsable** (valeurs déjà saisies sur ce risque, id scopé par `riskId` pour éviter les collisions) + `title` au survol sur l'intitulé tronqué.

## Qualité
- Contrat garanti par le test existant `peutDefinir2eLigne` (CONTROLEUR/CONFORMITE) — `src/__tests__/unit/lib/permissions.test.ts`.
- `tsc --noEmit` : **0 erreur**. Suite complète : **1196 tests verts**.

## Vérifié live
- Connecté **CONTROLEUR StarBank** : « Nouveau contrôle » ✓, « + Nouveau KRI » ✓, pilotage campagnes ✓ (auparavant masqués).
- A5 : input responsable lié à `datalist#acra-riskaction-resp-<riskId>` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)