### PR TITLE
feat(controle): périodicité hebdomadaire (échéance en jours)

### DIFF
--- a/src/__tests__/unit/lib/controle.test.ts
+++ b/src/__tests__/unit/lib/controle.test.ts
@@ -89,6 +89,11 @@ describe('prochaineEcheance', () => {
   it('borne le jour au dernier jour du mois cible (31 janvier + 1 mois)', () => {
     expect(prochaineEcheance('MENSUEL', '2026-01-31', '2025-01-01').toISOString().slice(0, 10)).toBe('2026-02-28')
   })
+  it('hebdomadaire : dernière exécution + 7 jours (calcul en jours)', () => {
+    expect(prochaineEcheance('HEBDOMADAIRE', '2026-01-15', '2025-01-01').toISOString().slice(0, 10)).toBe('2026-01-22')
+    // franchit la fin de mois sans borner au dernier jour du mois
+    expect(prochaineEcheance('HEBDOMADAIRE', '2026-01-28', '2025-01-01').toISOString().slice(0, 10)).toBe('2026-02-04')
+  })
 })
 
 describe('etatEcheance', () => {
@@ -134,11 +139,11 @@ describe('evaluerEfficacite', () => {
 
 describe('constantes et libellés', () => {
   it('occurrences par an', () => {
-    expect(OCCURRENCES_PAR_AN).toEqual({ MENSUEL: 12, TRIMESTRIEL: 4, SEMESTRIEL: 2, ANNUEL: 1 })
+    expect(OCCURRENCES_PAR_AN).toEqual({ HEBDOMADAIRE: 52, MENSUEL: 12, TRIMESTRIEL: 4, SEMESTRIEL: 2, ANNUEL: 1 })
   })
   it('énumérations', () => {
     expect([...CONTROLE_NIVEAUX]).toEqual(['N1', 'N2'])
-    expect([...PERIODICITES]).toEqual(['MENSUEL', 'TRIMESTRIEL', 'SEMESTRIEL', 'ANNUEL'])
+    expect([...PERIODICITES]).toEqual(['HEBDOMADAIRE', 'MENSUEL', 'TRIMESTRIEL', 'SEMESTRIEL', 'ANNUEL'])
     expect([...RESULTATS]).toEqual(['CONFORME', 'ANOMALIE', 'NON_APPLICABLE'])
   })
   it('libellé du plan d\'action généré sur anomalie', () => {

--- a/src/lib/controle.ts
+++ b/src/lib/controle.ts
@@ -8,7 +8,7 @@
 export const CONTROLE_NIVEAUX = ['N1', 'N2'] as const
 export type ControleNiveau = (typeof CONTROLE_NIVEAUX)[number]
 
-export const PERIODICITES = ['MENSUEL', 'TRIMESTRIEL', 'SEMESTRIEL', 'ANNUEL'] as const
+export const PERIODICITES = ['HEBDOMADAIRE', 'MENSUEL', 'TRIMESTRIEL', 'SEMESTRIEL', 'ANNUEL'] as const
 export type Periodicite = (typeof PERIODICITES)[number]
 
 export const RESULTATS = ['CONFORME', 'ANOMALIE', 'NON_APPLICABLE'] as const
@@ -16,10 +16,12 @@ export type Resultat = (typeof RESULTATS)[number]
 
 /** Nombre d'exécutions attendues par an, par périodicité. */
 export const OCCURRENCES_PAR_AN: Record<Periodicite, number> = {
-  MENSUEL: 12, TRIMESTRIEL: 4, SEMESTRIEL: 2, ANNUEL: 1,
+  HEBDOMADAIRE: 52, MENSUEL: 12, TRIMESTRIEL: 4, SEMESTRIEL: 2, ANNUEL: 1,
 }
 
-const MOIS_PAR_PERIODE: Record<Periodicite, number> = {
+// Périodicités calculées en mois (échéance bornée au dernier jour du mois cible).
+// L'hebdomadaire est traité à part, en jours (cf. prochaineEcheance).
+const MOIS_PAR_PERIODE: Record<Exclude<Periodicite, 'HEBDOMADAIRE'>, number> = {
   MENSUEL: 1, TRIMESTRIEL: 3, SEMESTRIEL: 6, ANNUEL: 12,
 }
 
@@ -163,13 +165,19 @@ function addMonths(d: Date, mois: number): Date {
   return cible
 }
 
+/** Ajoute `jours` jours à une date (UTC). */
+function addDays(d: Date, jours: number): Date {
+  return new Date(d.getTime() + jours * 86_400_000)
+}
+
 /**
  * Prochaine échéance d'un contrôle : dernière exécution + une période, ou la
  * date de création + une période si le contrôle n'a jamais été exécuté.
+ * L'hebdomadaire avance de 7 jours ; les autres périodicités avancent en mois.
  */
 export function prochaineEcheance(periodicite: Periodicite, derniereExecution: Date | string | null, creeLe: Date | string): Date {
   const base = derniereExecution ? new Date(derniereExecution) : new Date(creeLe)
-  return addMonths(base, MOIS_PAR_PERIODE[periodicite])
+  return periodicite === 'HEBDOMADAIRE' ? addDays(base, 7) : addMonths(base, MOIS_PAR_PERIODE[periodicite])
 }
 
 export type EtatEcheance = 'A_VENIR' | 'DU' | 'EN_RETARD'

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1249,6 +1249,7 @@ export const de: Translations = {
       N2: 'Stufe 2',
     },
     periodicites: {
+      HEBDOMADAIRE: 'Wöchentlich',
       MENSUEL: 'Monatlich',
       TRIMESTRIEL: 'Quartalsweise',
       SEMESTRIEL: 'Halbjährlich',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1249,6 +1249,7 @@ export const en: Translations = {
       N2: 'Level 2',
     },
     periodicites: {
+      HEBDOMADAIRE: 'Weekly',
       MENSUEL: 'Monthly',
       TRIMESTRIEL: 'Quarterly',
       SEMESTRIEL: 'Half-yearly',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1249,6 +1249,7 @@ export const es: Translations = {
       N2: 'Nivel 2',
     },
     periodicites: {
+      HEBDOMADAIRE: 'Semanal',
       MENSUEL: 'Mensual',
       TRIMESTRIEL: 'Trimestral',
       SEMESTRIEL: 'Semestral',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1272,6 +1272,7 @@ export const fr = {
       N2: 'Niveau 2',
     },
     periodicites: {
+      HEBDOMADAIRE: 'Hebdomadaire',
       MENSUEL: 'Mensuel',
       TRIMESTRIEL: 'Trimestriel',
       SEMESTRIEL: 'Semestriel',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1249,6 +1249,7 @@ export const it: Translations = {
       N2: 'Livello 2',
     },
     periodicites: {
+      HEBDOMADAIRE: 'Settimanale',
       MENSUEL: 'Mensile',
       TRIMESTRIEL: 'Trimestrale',
       SEMESTRIEL: 'Semestrale',


### PR DESCRIPTION
## Chantier A/3 — Fréquence hebdomadaire
Réponse à « peut-on faire des contrôles hebdomadaires ? » → oui désormais.

- `HEBDOMADAIRE` ajouté aux périodicités (placé avant `MENSUEL`).
- Échéance : l'hebdo avance de **7 jours** (`addDays`) ; les autres périodicités restent en mois (borne au dernier jour du mois cible). `OCCURRENCES_PAR_AN.HEBDOMADAIRE = 52`.
- `MOIS_PAR_PERIODE` typé `Record<Exclude<Periodicite,'HEBDOMADAIRE'>, number>` pour rester exhaustif sans valeur factice.
- i18n 5 langues : Hebdomadaire / Weekly / Wöchentlich / Semanal / Settimanale.

## Qualité
- TDD : +2 cas `prochaineEcheance` hebdo, MAJ des tests `OCCURRENCES_PAR_AN` et `PERIODICITES`.
- `tsc` : 0 erreur · **1197 tests verts**.
- Vérifié live : le sélecteur affiche `Hebdomadaire · Mensuel · Trimestriel · Semestriel · Annuel`.

Suite : B. checklist QCM, C. campagnes récurrentes (PR séparées).

🤖 Generated with [Claude Code](https://claude.com/claude-code)