### PR TITLE
feat(controle): checklist de points à vérifier (résultat déduit OK/KO/NA)

### DIFF
--- a/docs/specs/controle-checklist.md
+++ b/docs/specs/controle-checklist.md
@@ -1,0 +1,43 @@
+# Spec — Checklist (points à vérifier) sur un contrôle
+
+Demande utilisateur : pouvoir définir des « questionnaires QCM » pour les contrôles.
+Niveau retenu : **checklist simple** (liste de points cochés OK/KO/N-A, résultat déduit).
+
+## Modèle
+- `Controle.checklist` : `string[]` de libellés (points à vérifier). Vide ⇒ pas de
+  checklist → l'exécution saisit un **résultat unique** (comportement historique,
+  rétrocompatible).
+- `ControleExecution.checklistResultats` : `[{label, statut: OK|KO|NA, commentaire?}]`.
+  Le `label` est dénormalisé (copié) → l'historique reste lisible même si la
+  checklist du contrôle change ensuite.
+
+## Déduction du résultat (pure, testée)
+`deduireResultatChecklist(resultats)` :
+- checklist vide → `null` (résultat saisi manuellement) ;
+- au moins un **KO** → `ANOMALIE` ;
+- aucun point évalué (que des NA) → `NON_APPLICABLE` ;
+- sinon → `CONFORME`.
+- `anomaliesTrouvees` = nombre de KO ; `tailleTestee` = OK + KO (hors NA).
+
+Côté serveur (`POST /api/controles/[id]/executions`) : quand `checklistResultats`
+est fourni, le résultat global est **déduit** et prime sur toute valeur envoyée.
+Si l'anomalie n'a pas de constat global, un constat est **synthétisé** à partir des
+points KO (traçabilité auditeur). La boucle « anomalie → plan d'action » (si le
+contrôle est rattaché à un risque) reste inchangée.
+
+## Fonctions pures (`lib/controle.ts`)
+- `CHECKLIST_STATUTS = ['OK','KO','NA']`
+- `cleanChecklist(v): string[]` — trim, non vides, dédupliqués, plafond 50.
+- `cleanChecklistResultats(v): ChecklistResultat[]` — label + statut valides,
+  commentaire trimé ou null.
+- `deduireResultatChecklist(resultats): {resultat, anomaliesTrouvees, tailleTestee} | null`.
+
+## UI (`ControlesManager`)
+- Formulaire de définition : éditeur de points (ajouter / éditer / retirer).
+- Formulaire d'exécution : si le contrôle a une checklist, chaque point se cote
+  OK/KO/N-A (+ commentaire), avec un **aperçu du résultat déduit** en direct ;
+  sinon le formulaire classique (résultat/échantillon/anomalies) est conservé.
+
+## Migration
+`20260823120000_controle_checklist` : deux colonnes `JSONB NOT NULL DEFAULT '[]'`.
+Rétrocompatible (contrôles et exécutions existants → checklist vide).

--- a/prisma/migrations/20260823120000_controle_checklist/migration.sql
+++ b/prisma/migrations/20260823120000_controle_checklist/migration.sql
@@ -1,0 +1,3 @@
+-- Checklist (points à vérifier) sur un contrôle + cotation par point à l'exécution
+ALTER TABLE "Controle" ADD COLUMN "checklist" JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE "ControleExecution" ADD COLUMN "checklistResultats" JSONB NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -325,6 +325,10 @@ model Controle {
   referentielCode String?
   exigenceRefs    Json    @default("[]") // string[] des refs d'exigences couvertes
 
+  // Points à vérifier (checklist) : string[] de libellés. Vide = pas de checklist
+  // → l'exécution saisit un résultat unique (rétrocompatible).
+  checklist Json @default("[]")
+
   executions ControleExecution[]
 
   // Anti-doublon de l'alerte d'échéance (comme Derogation.alerteeLe) : remis à
@@ -355,6 +359,8 @@ model ControleExecution {
   anomaliesTrouvees Int?
   // Pièces justificatives en data URL (cf. lib/preuves.ts) : [{nom,mime,taille,dataUrl}]
   preuves           Json     @default("[]")
+  // Cotation des points de la checklist : [{label,statut:OK|KO|NA,commentaire?}]
+  checklistResultats Json    @default("[]")
   executantId       String
 
   createdAt DateTime @default(now())

--- a/src/__tests__/unit/lib/controle.test.ts
+++ b/src/__tests__/unit/lib/controle.test.ts
@@ -3,6 +3,7 @@ import {
   validateControleInput, cleanControleInput, validateExecutionInput, cleanExecutionInput,
   prochaineEcheance, etatEcheance, evaluerEfficacite, libelleActionAnomalie,
   OCCURRENCES_PAR_AN, CONTROLE_NIVEAUX, PERIODICITES, RESULTATS,
+  cleanChecklist, cleanChecklistResultats, deduireResultatChecklist, CHECKLIST_STATUTS,
 } from '@/lib/controle'
 
 describe('validateControleInput', () => {
@@ -137,6 +138,57 @@ describe('evaluerEfficacite', () => {
   })
 })
 
+describe('cleanChecklist (points à vérifier d\'un contrôle)', () => {
+  it('trim, non vides, dédupliqués (insensible espaces), plafonné à 50', () => {
+    expect(cleanChecklist(['  A ', 'B', 'A', ''])).toEqual(['A', 'B'])
+    expect(cleanChecklist('pas un tableau')).toEqual([])
+    expect(cleanChecklist(null)).toEqual([])
+    expect(cleanChecklist(Array.from({ length: 60 }, (_, i) => `p${i}`)).length).toBe(50)
+  })
+  it('accepte des objets {label} comme des chaînes', () => {
+    expect(cleanChecklist([{ label: ' X ' }, 'Y'])).toEqual(['X', 'Y'])
+  })
+})
+
+describe('cleanChecklistResultats', () => {
+  it('garde label + statut valides, commentaire trimé ou null', () => {
+    const r = cleanChecklistResultats([
+      { label: ' Point 1 ', statut: 'OK' },
+      { label: 'P2', statut: 'KO', commentaire: '  souci ' },
+      { label: '', statut: 'OK' },          // label vide → ignoré
+      { label: 'P3', statut: 'BOGUS' },     // statut invalide → ignoré
+    ])
+    expect(r).toEqual([
+      { label: 'Point 1', statut: 'OK', commentaire: null },
+      { label: 'P2', statut: 'KO', commentaire: 'souci' },
+    ])
+  })
+  it('entrée non tableau → []', () => {
+    expect(cleanChecklistResultats(null)).toEqual([])
+  })
+})
+
+describe('deduireResultatChecklist', () => {
+  it('checklist vide → null (résultat saisi manuellement)', () => {
+    expect(deduireResultatChecklist([])).toBeNull()
+  })
+  it('au moins un KO → ANOMALIE, compte les KO, taille = OK+KO', () => {
+    expect(deduireResultatChecklist([
+      { label: 'a', statut: 'OK' }, { label: 'b', statut: 'KO' }, { label: 'c', statut: 'KO' },
+    ])).toEqual({ resultat: 'ANOMALIE', anomaliesTrouvees: 2, tailleTestee: 3 })
+  })
+  it('tous NA → NON_APPLICABLE', () => {
+    expect(deduireResultatChecklist([
+      { label: 'a', statut: 'NA' }, { label: 'b', statut: 'NA' },
+    ])).toEqual({ resultat: 'NON_APPLICABLE', anomaliesTrouvees: 0, tailleTestee: 0 })
+  })
+  it('OK (avec NA) sans KO → CONFORME, taille = OK+KO', () => {
+    expect(deduireResultatChecklist([
+      { label: 'a', statut: 'OK' }, { label: 'b', statut: 'NA' },
+    ])).toEqual({ resultat: 'CONFORME', anomaliesTrouvees: 0, tailleTestee: 1 })
+  })
+})
+
 describe('constantes et libellés', () => {
   it('occurrences par an', () => {
     expect(OCCURRENCES_PAR_AN).toEqual({ HEBDOMADAIRE: 52, MENSUEL: 12, TRIMESTRIEL: 4, SEMESTRIEL: 2, ANNUEL: 1 })
@@ -145,6 +197,7 @@ describe('constantes et libellés', () => {
     expect([...CONTROLE_NIVEAUX]).toEqual(['N1', 'N2'])
     expect([...PERIODICITES]).toEqual(['HEBDOMADAIRE', 'MENSUEL', 'TRIMESTRIEL', 'SEMESTRIEL', 'ANNUEL'])
     expect([...RESULTATS]).toEqual(['CONFORME', 'ANOMALIE', 'NON_APPLICABLE'])
+    expect([...CHECKLIST_STATUTS]).toEqual(['OK', 'KO', 'NA'])
   })
   it('libellé du plan d\'action généré sur anomalie', () => {
     expect(libelleActionAnomalie('Rapprochement bancaire')).toBe("Traiter l'anomalie : Rapprochement bancaire")

--- a/src/app/api/controles/[id]/executions/route.ts
+++ b/src/app/api/controles/[id]/executions/route.ts
@@ -5,7 +5,7 @@ import { prisma } from '@/lib/prisma'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
 import { type UserRole } from '@/lib/permissions'
-import { validateExecutionInput, cleanExecutionInput, libelleActionAnomalie } from '@/lib/controle'
+import { validateExecutionInput, cleanExecutionInput, libelleActionAnomalie, cleanChecklistResultats, deduireResultatChecklist } from '@/lib/controle'
 import { sanitizePreuves } from '@/lib/preuves'
 import { auditLog, getClientIp } from '@/lib/logger'
 
@@ -45,6 +45,23 @@ export async function POST(req: NextRequest, { params }: Params) {
   if (!controle.actif) return NextResponse.json({ error: 'controle_inactif' }, { status: 400 })
 
   const body = await req.json().catch(() => ({}))
+  // Si le contrôle est coté via une checklist, le résultat global est DÉDUIT des
+  // points (anomalie si un KO) et prime sur toute valeur envoyée par le client.
+  const checklistResultats = cleanChecklistResultats(body.checklistResultats)
+  const deduction = deduireResultatChecklist(checklistResultats)
+  if (deduction) {
+    body.resultat = deduction.resultat
+    body.tailleTestee = deduction.tailleTestee
+    body.anomaliesTrouvees = deduction.anomaliesTrouvees
+    // Constat auto à partir des points KO si aucun constat global n'est fourni
+    // (préserve la piste d'audit exigée pour une anomalie).
+    if (deduction.resultat === 'ANOMALIE' && !(typeof body.constat === 'string' && body.constat.trim())) {
+      body.constat = checklistResultats
+        .filter(r => r.statut === 'KO')
+        .map(r => (r.commentaire ? `${r.label} : ${r.commentaire}` : r.label))
+        .join(' ; ')
+    }
+  }
   const erreur = validateExecutionInput(body)
   if (erreur) return NextResponse.json({ error: erreur }, { status: 400 })
   const data = cleanExecutionInput(body)
@@ -57,6 +74,7 @@ export async function POST(req: NextRequest, { params }: Params) {
       data: {
         ...data, controleId: id, organizationId: controle.organizationId,
         executantId: userId, preuves: preuves as unknown as object,
+        checklistResultats: checklistResultats as unknown as object,
       },
     })
     // Nouvelle exécution ⇒ nouvelle période : l'alerte d'échéance peut repartir.

--- a/src/app/api/controles/route.ts
+++ b/src/app/api/controles/route.ts
@@ -42,7 +42,7 @@ export async function GET() {
     include: {
       processus: { select: { nom: true } },
       riskItem: { select: { intitule: true } },
-      executions: { orderBy: { dateRealisation: 'desc' }, select: { id: true, resultat: true, dateRealisation: true, constat: true, preuves: true } },
+      executions: { orderBy: { dateRealisation: 'desc' }, select: { id: true, resultat: true, dateRealisation: true, constat: true, preuves: true, checklistResultats: true } },
     },
   })
 

--- a/src/components/ControlesManager.tsx
+++ b/src/components/ControlesManager.tsx
@@ -3,7 +3,7 @@
 import { FlaskConical, Paperclip } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
-import { CONTROLE_NIVEAUX, PERIODICITES, RESULTATS } from '@/lib/controle'
+import { CONTROLE_NIVEAUX, PERIODICITES, RESULTATS, deduireResultatChecklist } from '@/lib/controle'
 import { todayInputDate, suggestionsFromValues, defaultResponsable } from '@/lib/form-defaults'
 
 interface Efficacite {
@@ -13,7 +13,9 @@ interface Efficacite {
   vraisemblanceSuggeree: number | null
 }
 interface Preuve { nom: string; mime: string; taille: number; dataUrl: string }
-interface Execution { id: string; resultat: string; dateRealisation: string; constat: string | null; preuves: Preuve[] }
+type ChecklistStatut = 'OK' | 'KO' | 'NA'
+interface ChecklistResultat { label: string; statut: ChecklistStatut; commentaire?: string | null }
+interface Execution { id: string; resultat: string; dateRealisation: string; constat: string | null; preuves: Preuve[]; checklistResultats?: ChecklistResultat[] }
 interface Controle {
   id: string; intitule: string; description: string | null
   niveau: string; periodicite: string; responsable: string | null
@@ -21,6 +23,7 @@ interface Controle {
   riskItemId: string | null; riskItemIntitule: string | null
   processusId: string | null; processusNom: string | null
   referentielCode: string | null; exigenceRefs: string[]
+  checklist: string[]
   derniereExecution: string | null; prochaineEcheance: string
   etatEcheance: 'A_VENIR' | 'DU' | 'EN_RETARD' | null
   efficacite: Efficacite; executions: Execution[]; nbExecutions: number
@@ -33,12 +36,12 @@ type ExigenceLite = { ref: string; nom: string }
 type Form = {
   intitule: string; description: string; niveau: string; periodicite: string
   responsable: string; riskItemId: string; processusId: string; tailleEchantillon: string
-  referentielCode: string; exigenceRefs: string[]
+  referentielCode: string; exigenceRefs: string[]; checklist: string[]
 }
-const EMPTY: Form = { intitule: '', description: '', niveau: 'N1', periodicite: 'TRIMESTRIEL', responsable: '', riskItemId: '', processusId: '', tailleEchantillon: '', referentielCode: '', exigenceRefs: [] }
+const EMPTY: Form = { intitule: '', description: '', niveau: 'N1', periodicite: 'TRIMESTRIEL', responsable: '', riskItemId: '', processusId: '', tailleEchantillon: '', referentielCode: '', exigenceRefs: [], checklist: [] }
 
-type ExecForm = { resultat: string; dateRealisation: string; constat: string; tailleTestee: string; anomaliesTrouvees: string }
-const EMPTY_EXEC: ExecForm = { resultat: 'CONFORME', dateRealisation: '', constat: '', tailleTestee: '', anomaliesTrouvees: '' }
+type ExecForm = { resultat: string; dateRealisation: string; constat: string; tailleTestee: string; anomaliesTrouvees: string; checklist: ChecklistResultat[] }
+const EMPTY_EXEC: ExecForm = { resultat: 'CONFORME', dateRealisation: '', constat: '', tailleTestee: '', anomaliesTrouvees: '', checklist: [] }
 
 const ECHEANCE_BADGE: Record<string, string> = {
   A_VENIR: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
@@ -54,6 +57,11 @@ const RESULTAT_BADGE: Record<string, string> = {
   CONFORME: 'bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-300',
   ANOMALIE: 'bg-red-100 text-red-800 dark:bg-red-500/20 dark:text-red-300',
   NON_APPLICABLE: 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-300',
+}
+const CHECK_BADGE: Record<string, string> = {
+  OK: 'bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-300',
+  KO: 'bg-red-100 text-red-800 dark:bg-red-500/20 dark:text-red-300',
+  NA: 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-200',
 }
 
 export default function ControlesManager({ canDefine, canExecute, currentUserName }: { canDefine: boolean; canExecute: boolean; currentUserName?: string | null }) {
@@ -132,6 +140,7 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
       riskItemId: form.riskItemId || null, processusId: form.processusId || null,
       tailleEchantillon: form.tailleEchantillon || null,
       referentielCode: form.referentielCode || null, exigenceRefs: form.exigenceRefs,
+      checklist: form.checklist,
     }
     const res = await fetch(editId ? `/api/controles/${editId}` : '/api/controles', {
       method: editId ? 'PATCH' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
@@ -149,6 +158,7 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
       responsable: x.responsable ?? '', riskItemId: x.riskItemId ?? '', processusId: x.processusId ?? '',
       tailleEchantillon: x.tailleEchantillon?.toString() ?? '',
       referentielCode: x.referentielCode ?? '', exigenceRefs: x.exigenceRefs ?? [],
+      checklist: x.checklist ?? [],
     })
   }
 
@@ -157,9 +167,11 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
     const res = await fetch(`/api/controles/${x.id}/executions`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
+        // Si le contrôle a une checklist, le serveur DÉDUIT le résultat des points.
         resultat: exec.resultat, dateRealisation: exec.dateRealisation || null,
         constat: exec.constat || null, tailleTestee: exec.tailleTestee || null,
         anomaliesTrouvees: exec.anomaliesTrouvees || null,
+        checklistResultats: exec.checklist.length ? exec.checklist : undefined,
         preuves,
       }),
     })
@@ -271,6 +283,21 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
               </div>
             )}
           </div>
+          {/* Checklist : points à vérifier (facultatif). À l'exécution, chacun est coté
+              OK/KO/NA et le résultat global se déduit. */}
+          <div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">{c.checklist} <span className="text-gray-400">— {c.checklistHint}</span></div>
+            <div className="space-y-1.5">
+              {form.checklist.map((point, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <span className="text-xs text-gray-400 w-5 text-right">{i + 1}.</span>
+                  <input value={point} onChange={e => setForm(f => ({ ...f, checklist: f.checklist.map((p, j) => j === i ? e.target.value : p) }))} placeholder={c.checklistPlaceholder} className={`${inp} flex-1`} />
+                  <button type="button" onClick={() => setForm(f => ({ ...f, checklist: f.checklist.filter((_, j) => j !== i) }))} className="text-xs text-red-500 hover:underline">{c.retirer}</button>
+                </div>
+              ))}
+              <button type="button" onClick={() => setForm(f => ({ ...f, checklist: [...f.checklist, ''] }))} className="text-xs text-ebios-600 hover:underline">+ {c.checklistAdd}</button>
+            </div>
+          </div>
           <div className="flex gap-2">
             <button onClick={submit} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{editId ? c.save : c.add}</button>
             <button onClick={() => { setShowForm(false); setEditId(null); setError(null) }} className="text-sm text-gray-500 hover:text-gray-700">{c.cancel}</button>
@@ -329,7 +356,7 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-right">
                       {canExecute && x.actif && (
-                        <button onClick={() => { setExecId(x.id); setExec(emptyExec()); setPreuves([]); setError(null) }} className="text-xs text-ebios-600 hover:underline mr-2">{c.execute}</button>
+                        <button onClick={() => { setExecId(x.id); setExec({ ...emptyExec(), checklist: (x.checklist ?? []).map(label => ({ label, statut: 'OK' as ChecklistStatut, commentaire: '' })) }); setPreuves([]); setError(null) }} className="text-xs text-ebios-600 hover:underline mr-2">{c.execute}</button>
                       )}
                       {canDefine && <>
                         <button onClick={() => startEdit(x)} className="text-xs text-ebios-600 hover:underline mr-2">{c.edit}</button>
@@ -374,22 +401,55 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
                       <td colSpan={6} className="px-4 py-4 space-y-2">
                         <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">{c.executeTitle} — {x.intitule}</p>
                         {error && <p className="text-xs text-red-600">{error}</p>}
-                        <div className="flex flex-wrap gap-2 items-end">
-                          <label className="text-xs text-gray-500 dark:text-gray-400">{c.resultat}
-                            <select value={exec.resultat} onChange={e => setExec(f => ({ ...f, resultat: e.target.value }))} className={`${inp} block mt-1`}>
-                              {RESULTATS.map(rr => <option key={rr} value={rr}>{lbl(c.resultats, rr)}</option>)}
-                            </select>
-                          </label>
-                          <label className="text-xs text-gray-500 dark:text-gray-400">{c.dateRealisation}
-                            <input type="date" value={exec.dateRealisation} onChange={e => setExec(f => ({ ...f, dateRealisation: e.target.value }))} className={`${inp} block mt-1`} />
-                          </label>
-                          <label className="text-xs text-gray-500 dark:text-gray-400">{c.tailleTestee}
-                            <input type="number" min="0" value={exec.tailleTestee} onChange={e => setExec(f => ({ ...f, tailleTestee: e.target.value }))} className={`${inp} block mt-1 w-24`} />
-                          </label>
-                          <label className="text-xs text-gray-500 dark:text-gray-400">{c.anomaliesTrouvees}
-                            <input type="number" min="0" value={exec.anomaliesTrouvees} onChange={e => setExec(f => ({ ...f, anomaliesTrouvees: e.target.value }))} className={`${inp} block mt-1 w-24`} />
-                          </label>
-                        </div>
+                        {exec.checklist.length > 0 ? (
+                          // Cotation par point : le résultat global est déduit (aperçu affiché).
+                          <div className="space-y-1.5">
+                            <div className="flex flex-wrap items-end gap-3">
+                              <label className="text-xs text-gray-500 dark:text-gray-400">{c.dateRealisation}
+                                <input type="date" value={exec.dateRealisation} onChange={e => setExec(f => ({ ...f, dateRealisation: e.target.value }))} className={`${inp} block mt-1`} />
+                              </label>
+                              {(() => { const d = deduireResultatChecklist(exec.checklist); return d && (
+                                <span className="text-xs text-gray-500 dark:text-gray-400 pb-1.5">{c.resultatDeduit} :{' '}
+                                  <span className={`text-[11px] px-2 py-0.5 rounded-full font-medium ${RESULTAT_BADGE[d.resultat]}`}>{lbl(c.resultats, d.resultat)}</span>
+                                </span>
+                              )})()}
+                            </div>
+                            <div className="border border-gray-200 dark:border-gray-700 rounded-lg divide-y divide-gray-100 dark:divide-gray-800">
+                              {exec.checklist.map((pt, i) => (
+                                <div key={i} className="flex flex-wrap items-center gap-2 px-3 py-1.5">
+                                  <span className="text-xs text-gray-700 dark:text-gray-200 flex-1 min-w-[160px]" title={pt.label}>{pt.label}</span>
+                                  <div className="flex gap-1">
+                                    {(['OK', 'KO', 'NA'] as ChecklistStatut[]).map(st => (
+                                      <button key={st} type="button"
+                                        onClick={() => setExec(f => ({ ...f, checklist: f.checklist.map((p, j) => j === i ? { ...p, statut: st } : p) }))}
+                                        className={`text-[11px] px-2 py-0.5 rounded-full font-medium ${pt.statut === st ? CHECK_BADGE[st] : 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500'}`}>
+                                        {lbl(c.checklistStatuts, st)}
+                                      </button>
+                                    ))}
+                                  </div>
+                                  <input value={pt.commentaire ?? ''} onChange={e => setExec(f => ({ ...f, checklist: f.checklist.map((p, j) => j === i ? { ...p, commentaire: e.target.value } : p) }))} placeholder={c.checklistComment} className={`${inp} text-xs flex-1 min-w-[140px]`} />
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex flex-wrap gap-2 items-end">
+                            <label className="text-xs text-gray-500 dark:text-gray-400">{c.resultat}
+                              <select value={exec.resultat} onChange={e => setExec(f => ({ ...f, resultat: e.target.value }))} className={`${inp} block mt-1`}>
+                                {RESULTATS.map(rr => <option key={rr} value={rr}>{lbl(c.resultats, rr)}</option>)}
+                              </select>
+                            </label>
+                            <label className="text-xs text-gray-500 dark:text-gray-400">{c.dateRealisation}
+                              <input type="date" value={exec.dateRealisation} onChange={e => setExec(f => ({ ...f, dateRealisation: e.target.value }))} className={`${inp} block mt-1`} />
+                            </label>
+                            <label className="text-xs text-gray-500 dark:text-gray-400">{c.tailleTestee}
+                              <input type="number" min="0" value={exec.tailleTestee} onChange={e => setExec(f => ({ ...f, tailleTestee: e.target.value }))} className={`${inp} block mt-1 w-24`} />
+                            </label>
+                            <label className="text-xs text-gray-500 dark:text-gray-400">{c.anomaliesTrouvees}
+                              <input type="number" min="0" value={exec.anomaliesTrouvees} onChange={e => setExec(f => ({ ...f, anomaliesTrouvees: e.target.value }))} className={`${inp} block mt-1 w-24`} />
+                            </label>
+                          </div>
+                        )}
                         <textarea value={exec.constat} onChange={e => setExec(f => ({ ...f, constat: e.target.value }))} placeholder={c.constatPlaceholder} rows={2} className={`${inp} w-full`} />
                         <div>
                           <label className="text-xs text-gray-500 dark:text-gray-400">{c.preuves}

--- a/src/lib/controle.ts
+++ b/src/lib/controle.ts
@@ -14,6 +14,76 @@ export type Periodicite = (typeof PERIODICITES)[number]
 export const RESULTATS = ['CONFORME', 'ANOMALIE', 'NON_APPLICABLE'] as const
 export type Resultat = (typeof RESULTATS)[number]
 
+// ─── Checklist (points à vérifier) ───────────────────────────────────────────
+// Un contrôle peut porter une liste de points à vérifier. À l'exécution, chaque
+// point est coté OK / KO / NA, et le résultat global se DÉDUIT (anomalie si un KO).
+export const CHECKLIST_STATUTS = ['OK', 'KO', 'NA'] as const
+export type ChecklistStatut = (typeof CHECKLIST_STATUTS)[number]
+
+/** Résultat d'un point à l'exécution (label dénormalisé → l'historique reste lisible). */
+export interface ChecklistResultat {
+  label: string
+  statut: ChecklistStatut
+  commentaire?: string | null
+}
+
+const CHECKLIST_MAX = 50
+
+/** Normalise la checklist d'un contrôle : libellés trim, non vides, dédupliqués, plafonnés. */
+export function cleanChecklist(v: unknown): string[] {
+  if (!Array.isArray(v)) return []
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const x of v) {
+    const label = typeof x === 'string'
+      ? x.trim()
+      : (x && typeof x === 'object' && typeof (x as { label?: unknown }).label === 'string'
+        ? String((x as { label: string }).label).trim() : '')
+    if (!label || seen.has(label)) continue
+    seen.add(label)
+    out.push(label)
+    if (out.length >= CHECKLIST_MAX) break
+  }
+  return out
+}
+
+/** Normalise les résultats de checklist d'une exécution (label + statut valides). */
+export function cleanChecklistResultats(v: unknown): ChecklistResultat[] {
+  if (!Array.isArray(v)) return []
+  const out: ChecklistResultat[] = []
+  for (const x of v) {
+    if (!x || typeof x !== 'object') continue
+    const o = x as { label?: unknown; statut?: unknown; commentaire?: unknown }
+    const label = typeof o.label === 'string' ? o.label.trim() : ''
+    if (!label) continue
+    if (!CHECKLIST_STATUTS.includes(o.statut as ChecklistStatut)) continue
+    const commentaire = typeof o.commentaire === 'string' && o.commentaire.trim() ? o.commentaire.trim() : null
+    out.push({ label, statut: o.statut as ChecklistStatut, commentaire })
+    if (out.length >= CHECKLIST_MAX) break
+  }
+  return out
+}
+
+export interface DeductionChecklist {
+  resultat: Resultat
+  anomaliesTrouvees: number
+  tailleTestee: number
+}
+
+/**
+ * Déduit le résultat global d'une exécution à partir des cotations de checklist :
+ * ANOMALIE si au moins un KO ; NON_APPLICABLE si aucun point évalué (que des NA) ;
+ * sinon CONFORME. `tailleTestee` = points effectivement évalués (OK + KO).
+ * Retourne null si la checklist est vide (le résultat est alors saisi manuellement).
+ */
+export function deduireResultatChecklist(resultats: ChecklistResultat[]): DeductionChecklist | null {
+  if (!resultats || resultats.length === 0) return null
+  const ko = resultats.filter(r => r.statut === 'KO').length
+  const ok = resultats.filter(r => r.statut === 'OK').length
+  const resultat: Resultat = ko > 0 ? 'ANOMALIE' : (ok === 0 ? 'NON_APPLICABLE' : 'CONFORME')
+  return { resultat, anomaliesTrouvees: ko, tailleTestee: ok + ko }
+}
+
 /** Nombre d'exécutions attendues par an, par périodicité. */
 export const OCCURRENCES_PAR_AN: Record<Periodicite, number> = {
   HEBDOMADAIRE: 52, MENSUEL: 12, TRIMESTRIEL: 4, SEMESTRIEL: 2, ANNUEL: 1,
@@ -39,6 +109,7 @@ export interface ControleInput {
   actif?: unknown
   referentielCode?: unknown
   exigenceRefs?: unknown
+  checklist?: unknown
 }
 
 export interface CleanControle {
@@ -53,6 +124,7 @@ export interface CleanControle {
   actif: boolean
   referentielCode: string | null
   exigenceRefs: string[]
+  checklist: string[]
 }
 
 /** Normalise une liste de refs d'exigences : chaînes non vides, dédupliquées. */
@@ -101,6 +173,7 @@ export function cleanControleInput(body: ControleInput): CleanControle {
     actif: body.actif === undefined ? true : body.actif !== false,
     referentielCode: txt(body.referentielCode),
     exigenceRefs: cleanExigenceRefs(body.exigenceRefs),
+    checklist: cleanChecklist(body.checklist),
   }
 }
 

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1260,6 +1260,13 @@ export const de: Translations = {
       ANOMALIE: 'Abweichung',
       NON_APPLICABLE: 'Nicht anwendbar',
     },
+    checklist: 'Prüfpunkte',
+    checklistHint: 'optional; bei der Durchführung mit OK/KO/N/A bewertet, Ergebnis wird abgeleitet',
+    checklistAdd: 'Punkt hinzufügen',
+    checklistPlaceholder: 'Prüfpunkt…',
+    checklistComment: 'Kommentar (optional)',
+    resultatDeduit: 'Abgeleitetes Ergebnis',
+    checklistStatuts: { OK: 'OK', KO: 'KO', NA: 'N/A' },
     etats: {
       A_VENIR: 'Bevorstehend',
       DU: 'Fällig',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1260,6 +1260,13 @@ export const en: Translations = {
       ANOMALIE: 'Anomaly',
       NON_APPLICABLE: 'Not applicable',
     },
+    checklist: 'Checklist items',
+    checklistHint: 'optional; rated OK/KO/N/A at execution, the result is derived',
+    checklistAdd: 'Add an item',
+    checklistPlaceholder: 'Checklist item…',
+    checklistComment: 'Comment (optional)',
+    resultatDeduit: 'Derived result',
+    checklistStatuts: { OK: 'OK', KO: 'KO', NA: 'N/A' },
     etats: {
       A_VENIR: 'Upcoming',
       DU: 'Due',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1260,6 +1260,13 @@ export const es: Translations = {
       ANOMALIE: 'Anomalía',
       NON_APPLICABLE: 'No aplicable',
     },
+    checklist: 'Puntos a verificar',
+    checklistHint: 'opcional; calificados OK/KO/N/A en la ejecución, el resultado se deduce',
+    checklistAdd: 'Añadir un punto',
+    checklistPlaceholder: 'Punto a verificar…',
+    checklistComment: 'Comentario (opcional)',
+    resultatDeduit: 'Resultado deducido',
+    checklistStatuts: { OK: 'OK', KO: 'KO', NA: 'N/A' },
     etats: {
       A_VENIR: 'Próximo',
       DU: 'Vencido',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1283,6 +1283,13 @@ export const fr = {
       ANOMALIE: 'Anomalie',
       NON_APPLICABLE: 'Non applicable',
     },
+    checklist: 'Points à vérifier',
+    checklistHint: 'facultatif ; cotés OK/KO/N/A à l’exécution, le résultat se déduit',
+    checklistAdd: 'Ajouter un point',
+    checklistPlaceholder: 'Point à vérifier…',
+    checklistComment: 'Commentaire (facultatif)',
+    resultatDeduit: 'Résultat déduit',
+    checklistStatuts: { OK: 'OK', KO: 'KO', NA: 'N/A' },
     etats: {
       A_VENIR: 'À venir',
       DU: 'Dû',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1260,6 +1260,13 @@ export const it: Translations = {
       ANOMALIE: 'Anomalia',
       NON_APPLICABLE: 'Non applicabile',
     },
+    checklist: 'Punti da verificare',
+    checklistHint: 'facoltativo; valutati OK/KO/N/A all’esecuzione, il risultato si deduce',
+    checklistAdd: 'Aggiungi un punto',
+    checklistPlaceholder: 'Punto da verificare…',
+    checklistComment: 'Commento (facoltativo)',
+    resultatDeduit: 'Risultato dedotto',
+    checklistStatuts: { OK: 'OK', KO: 'KO', NA: 'N/A' },
     etats: {
       A_VENIR: 'In arrivo',
       DU: 'Dovuto',


### PR DESCRIPTION
## Chantier B/3 — Checklist QCM pour les contrôles
Réponse à « peut-on définir des questionnaires QCM pour les contrôles ? » → checklist simple.

Un contrôle peut porter une **liste de points à vérifier**. À l'exécution, chaque point est coté **OK / KO / N-A** (+ commentaire), et le **résultat global se déduit** :
- au moins un KO → `ANOMALIE` ; aucun point évalué (que des NA) → `NON_APPLICABLE` ; sinon `CONFORME` ;
- `anomaliesTrouvees` = nb de KO ; `tailleTestee` = OK + KO.

**Rétrocompatible** : checklist vide → saisie du résultat unique (comportement actuel).

## Modèle & migration
- `Controle.checklist` (`string[]`) et `ControleExecution.checklistResultats` (`[{label,statut,commentaire}]`), JSONB `DEFAULT '[]'` — migration `20260823120000_controle_checklist`. Label dénormalisé dans l'exécution → historique lisible même si la checklist change.

## Fonctions pures (`lib/controle.ts`, testées)
`cleanChecklist`, `cleanChecklistResultats`, `deduireResultatChecklist`, `CHECKLIST_STATUTS`.

## Serveur
`POST /api/controles/[id]/executions` : quand la checklist est cotée, le résultat est **déduit** (prime sur le client) ; si l'anomalie n'a pas de constat, il est **synthétisé** à partir des points KO (traçabilité). Boucle « anomalie → plan d'action » inchangée.

## UI
Éditeur de points au formulaire de définition ; cotation par point avec **aperçu du résultat déduit en direct** au formulaire d'exécution.

## Qualité
- TDD : +8 tests. `tsc` 0 erreur · **1205 tests verts**.
- Vérifié live (API + DB + UI) : checklist nettoyée (blancs/doublons retirés), résultat déduit `ANOMALIE`, constat auto « Revue des comptes dormants : 3 comptes non revus », aperçu live OK→Anomalie.

Voir [`docs/specs/controle-checklist.md`](docs/specs/controle-checklist.md). Suite : C. campagnes récurrentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)