### PR TITLE
feat(controle): contrôle du contrôle (N2→N1) + indépendance de l'exécutant

### DIFF
--- a/docs/specs/controle-n2-supervision.md
+++ b/docs/specs/controle-n2-supervision.md
@@ -1,0 +1,32 @@
+# Spec — Contrôle du contrôle (N2→N1) + indépendance
+
+Renforcement du contrôle permanent 2ᵉ niveau (bancaire, arrêté ACPR 3 nov. 2014).
+
+## Contrôle du contrôle (N2→N1)
+Un contrôle **N2** peut **superviser** un ou plusieurs contrôles **N1** : le N2
+vérifie la bonne exécution et l'efficacité des contrôles de 1ʳᵉ ligne.
+
+- `Controle.superviseIds` (Json `string[]`) : identifiants des contrôles N1
+  supervisés. Lien logique (pas de FK) — tolérant aux suppressions.
+- Formulaire (niveau N2 uniquement) : liste à cocher des contrôles N1, avec
+  leur efficacité observée en aperçu.
+- Détail du contrôle : rappel des N1 supervisés + leur taux de conformité.
+
+## Indépendance de l'exécutant (séparation des fonctions)
+- `ControleExecution.independant` (Boolean?) : l'exécutant atteste être
+  indépendant de la 1ʳᵉ ligne. Case à cocher à l'exécution (contrôle N2).
+- Affiché en badge « Indépendant » dans l'historique des exécutions.
+
+## Pur & testé (`lib/controle.ts`)
+- `cleanControleInput` nettoie `superviseIds` (dédup, chaînes non vides).
+- `cleanExecutionInput` normalise `independant` (booléen ou null).
+
+## Migration
+`20260823140000_controle_supervision_independance` :
+`Controle.superviseIds JSONB DEFAULT '[]'`, `ControleExecution.independant BOOLEAN`.
+Rétrocompatible.
+
+## Vérifié (runtime)
+Création N1 + N2 (superviseIds=[N1]) ; exécution N2 avec independant=true ;
+relecture : superviseIds et independant persistés (201). Formulaire N2 affiche la
+liste des N1 à superviser.

--- a/prisma/migrations/20260823140000_controle_supervision_independance/migration.sql
+++ b/prisma/migrations/20260823140000_controle_supervision_independance/migration.sql
@@ -1,0 +1,3 @@
+-- Contrôle du contrôle (N2→N1) + indépendance de l'exécutant
+ALTER TABLE "Controle" ADD COLUMN "superviseIds" JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE "ControleExecution" ADD COLUMN "independant" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -329,6 +329,11 @@ model Controle {
   // → l'exécution saisit un résultat unique (rétrocompatible).
   checklist Json @default("[]")
 
+  // Contrôle du contrôle : identifiants des contrôles (N1) supervisés par ce
+  // contrôle (typiquement N2). string[] — vide = contrôle direct. Lien logique
+  // (pas de FK, pour rester simple et tolérant aux suppressions).
+  superviseIds Json @default("[]")
+
   executions ControleExecution[]
 
   // Anti-doublon de l'alerte d'échéance (comme Derogation.alerteeLe) : remis à
@@ -361,6 +366,9 @@ model ControleExecution {
   preuves           Json     @default("[]")
   // Cotation des points de la checklist : [{label,statut:OK|KO|NA,commentaire?}]
   checklistResultats Json    @default("[]")
+  // Indépendance de l'exécutant vis-à-vis de la 1ʳᵉ ligne (séparation des
+  // fonctions, contrôle N2). null = non renseigné.
+  independant       Boolean?
   executantId       String
 
   createdAt DateTime @default(now())

--- a/src/__tests__/unit/lib/controle.test.ts
+++ b/src/__tests__/unit/lib/controle.test.ts
@@ -41,6 +41,10 @@ describe('cleanControleInput', () => {
   it('actif explicitement désactivable', () => {
     expect(cleanControleInput({ intitule: 'X', actif: false }).actif).toBe(false)
   })
+  it('superviseIds (contrôle du contrôle N2→N1) : nettoyés et dédupliqués', () => {
+    expect(cleanControleInput({ intitule: 'X', superviseIds: ['a', 'a', ' b ', 3, ''] }).superviseIds).toEqual(['a', 'b'])
+    expect(cleanControleInput({ intitule: 'X' }).superviseIds).toEqual([])
+  })
 })
 
 describe('validateExecutionInput', () => {
@@ -75,6 +79,11 @@ describe('cleanExecutionInput', () => {
     expect(c.constat).toBe('écart')
     expect(c.tailleTestee).toBe(30)
     expect(c.anomaliesTrouvees).toBe(2)
+  })
+  it('indépendance de l\'exécutant : booléen ou null', () => {
+    expect(cleanExecutionInput({ resultat: 'CONFORME', independant: true }).independant).toBe(true)
+    expect(cleanExecutionInput({ resultat: 'CONFORME', independant: false }).independant).toBe(false)
+    expect(cleanExecutionInput({ resultat: 'CONFORME' }).independant).toBeNull()
   })
 })
 

--- a/src/app/api/controles/route.ts
+++ b/src/app/api/controles/route.ts
@@ -42,7 +42,7 @@ export async function GET() {
     include: {
       processus: { select: { nom: true } },
       riskItem: { select: { intitule: true } },
-      executions: { orderBy: { dateRealisation: 'desc' }, select: { id: true, resultat: true, dateRealisation: true, constat: true, preuves: true, checklistResultats: true } },
+      executions: { orderBy: { dateRealisation: 'desc' }, select: { id: true, resultat: true, dateRealisation: true, constat: true, preuves: true, checklistResultats: true, independant: true } },
     },
   })
 

--- a/src/components/ControlesManager.tsx
+++ b/src/components/ControlesManager.tsx
@@ -15,7 +15,7 @@ interface Efficacite {
 interface Preuve { nom: string; mime: string; taille: number; dataUrl: string }
 type ChecklistStatut = 'OK' | 'KO' | 'NA'
 interface ChecklistResultat { label: string; statut: ChecklistStatut; commentaire?: string | null }
-interface Execution { id: string; resultat: string; dateRealisation: string; constat: string | null; preuves: Preuve[]; checklistResultats?: ChecklistResultat[] }
+interface Execution { id: string; resultat: string; dateRealisation: string; constat: string | null; preuves: Preuve[]; checklistResultats?: ChecklistResultat[]; independant?: boolean | null }
 interface Controle {
   id: string; intitule: string; description: string | null
   niveau: string; periodicite: string; responsable: string | null
@@ -23,7 +23,7 @@ interface Controle {
   riskItemId: string | null; riskItemIntitule: string | null
   processusId: string | null; processusNom: string | null
   referentielCode: string | null; exigenceRefs: string[]
-  checklist: string[]
+  checklist: string[]; superviseIds: string[]
   derniereExecution: string | null; prochaineEcheance: string
   etatEcheance: 'A_VENIR' | 'DU' | 'EN_RETARD' | null
   efficacite: Efficacite; executions: Execution[]; nbExecutions: number
@@ -36,12 +36,12 @@ type ExigenceLite = { ref: string; nom: string }
 type Form = {
   intitule: string; description: string; niveau: string; periodicite: string
   responsable: string; riskItemId: string; processusId: string; tailleEchantillon: string
-  referentielCode: string; exigenceRefs: string[]; checklist: string[]
+  referentielCode: string; exigenceRefs: string[]; checklist: string[]; superviseIds: string[]
 }
-const EMPTY: Form = { intitule: '', description: '', niveau: 'N1', periodicite: 'TRIMESTRIEL', responsable: '', riskItemId: '', processusId: '', tailleEchantillon: '', referentielCode: '', exigenceRefs: [], checklist: [] }
+const EMPTY: Form = { intitule: '', description: '', niveau: 'N1', periodicite: 'TRIMESTRIEL', responsable: '', riskItemId: '', processusId: '', tailleEchantillon: '', referentielCode: '', exigenceRefs: [], checklist: [], superviseIds: [] }
 
-type ExecForm = { resultat: string; dateRealisation: string; constat: string; tailleTestee: string; anomaliesTrouvees: string; checklist: ChecklistResultat[] }
-const EMPTY_EXEC: ExecForm = { resultat: 'CONFORME', dateRealisation: '', constat: '', tailleTestee: '', anomaliesTrouvees: '', checklist: [] }
+type ExecForm = { resultat: string; dateRealisation: string; constat: string; tailleTestee: string; anomaliesTrouvees: string; checklist: ChecklistResultat[]; independant: boolean }
+const EMPTY_EXEC: ExecForm = { resultat: 'CONFORME', dateRealisation: '', constat: '', tailleTestee: '', anomaliesTrouvees: '', checklist: [], independant: false }
 
 const ECHEANCE_BADGE: Record<string, string> = {
   A_VENIR: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
@@ -142,6 +142,7 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
       tailleEchantillon: form.tailleEchantillon || null,
       referentielCode: form.referentielCode || null, exigenceRefs: form.exigenceRefs,
       checklist: form.checklist,
+      superviseIds: form.niveau === 'N2' ? form.superviseIds : [],
     }
     const res = await fetch(editId ? `/api/controles/${editId}` : '/api/controles', {
       method: editId ? 'PATCH' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
@@ -159,7 +160,7 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
       responsable: x.responsable ?? '', riskItemId: x.riskItemId ?? '', processusId: x.processusId ?? '',
       tailleEchantillon: x.tailleEchantillon?.toString() ?? '',
       referentielCode: x.referentielCode ?? '', exigenceRefs: x.exigenceRefs ?? [],
-      checklist: x.checklist ?? [],
+      checklist: x.checklist ?? [], superviseIds: x.superviseIds ?? [],
     })
   }
 
@@ -173,6 +174,7 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
         constat: exec.constat || null, tailleTestee: exec.tailleTestee || null,
         anomaliesTrouvees: exec.anomaliesTrouvees || null,
         checklistResultats: exec.checklist.length ? exec.checklist : undefined,
+        independant: x.niveau === 'N2' ? exec.independant : undefined,
         preuves,
       }),
     })
@@ -286,6 +288,27 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
               </div>
             )}
           </div>
+          {/* Contrôle du contrôle : un contrôle N2 supervise des contrôles N1 (2ᵉ ligne
+              qui vérifie la bonne exécution et l'efficacité de la 1ʳᵉ ligne). */}
+          {form.niveau === 'N2' && (
+            <div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">{c.supervise} <span className="text-gray-400">— {c.superviseHint}</span> ({form.superviseIds.length})</div>
+              {controles.filter(x => x.niveau === 'N1' && x.id !== editId).length === 0
+                ? <div className="text-xs text-gray-400">{c.superviseVide}</div>
+                : (
+                  <div className="max-h-32 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded-lg divide-y divide-gray-100 dark:divide-gray-800">
+                    {controles.filter(x => x.niveau === 'N1' && x.id !== editId).map(n1 => (
+                      <label key={n1.id} className="flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800">
+                        <input type="checkbox" checked={form.superviseIds.includes(n1.id)}
+                          onChange={() => setForm(f => ({ ...f, superviseIds: f.superviseIds.includes(n1.id) ? f.superviseIds.filter(i => i !== n1.id) : [...f.superviseIds, n1.id] }))} />
+                        <span className="text-gray-700 dark:text-gray-200 truncate" title={n1.intitule}>{n1.intitule}</span>
+                        {n1.efficacite.efficacite && <span className={`ml-auto text-[10px] px-1.5 py-0.5 rounded-full font-medium ${EFF_BADGE[n1.efficacite.efficacite]}`}>{n1.efficacite.tauxConformite}%</span>}
+                      </label>
+                    ))}
+                  </div>
+                )}
+            </div>
+          )}
           {/* Checklist : points à vérifier (facultatif). À l'exécution, chacun est coté
               OK/KO/NA et le résultat global se déduit. */}
           <div>
@@ -417,11 +440,28 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
                             </span>
                           )}
                         </p>
+                        {/* Contrôle du contrôle : contrôles N1 supervisés + leur efficacité */}
+                        {x.superviseIds?.length > 0 && (
+                          <div className="mb-2 text-xs">
+                            <span className="text-gray-500 dark:text-gray-400">{c.superviseListe} : </span>
+                            {x.superviseIds.map(id => {
+                              const n1 = controles.find(ct => ct.id === id)
+                              if (!n1) return null
+                              return (
+                                <span key={id} className="inline-flex items-center gap-1 mr-2">
+                                  <span className="text-gray-700 dark:text-gray-200">{n1.intitule}</span>
+                                  {n1.efficacite.efficacite && <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${EFF_BADGE[n1.efficacite.efficacite]}`}>{n1.efficacite.tauxConformite}%</span>}
+                                </span>
+                              )
+                            })}
+                          </div>
+                        )}
                         <ul className="space-y-1">
                           {x.executions.map(e => (
                             <li key={e.id} className="flex items-center gap-2 text-xs">
                               <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${RESULTAT_BADGE[e.resultat]}`}>{lbl(c.resultats, e.resultat)}</span>
                               <span className="text-gray-400">{jour(e.dateRealisation)}</span>
+                              {e.independant === true && <span className="text-[10px] px-1.5 py-0.5 rounded-full font-medium bg-ebios-100 text-ebios-700 dark:bg-ebios-500/15 dark:text-ebios-300" title={c.independantHint}>{c.independantBadge}</span>}
                               {e.constat && <span className="text-gray-600 dark:text-gray-300 truncate">{e.constat}</span>}
                               {e.preuves?.length > 0 && <span className="text-gray-400"><Paperclip size={15} className="inline align-[-0.15em] mr-1.5" aria-hidden="true" /> {e.preuves.length}</span>}
                             </li>
@@ -502,6 +542,13 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
                             </ul>
                           )}
                         </div>
+                        {/* Indépendance de l'exécutant (séparation des fonctions) — contrôle N2 */}
+                        {x.niveau === 'N2' && (
+                          <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                            <input type="checkbox" checked={exec.independant} onChange={e => setExec(f => ({ ...f, independant: e.target.checked }))} />
+                            {c.independantLabel}
+                          </label>
+                        )}
                         <div className="flex gap-2">
                           <button onClick={() => enregistrerExec(x)} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{c.save}</button>
                           <button onClick={() => { setExecId(null); setError(null) }} className="text-sm text-gray-500 hover:text-gray-700">{c.cancel}</button>

--- a/src/lib/controle.ts
+++ b/src/lib/controle.ts
@@ -138,6 +138,7 @@ export interface ControleInput {
   referentielCode?: unknown
   exigenceRefs?: unknown
   checklist?: unknown
+  superviseIds?: unknown
 }
 
 export interface CleanControle {
@@ -153,6 +154,8 @@ export interface CleanControle {
   referentielCode: string | null
   exigenceRefs: string[]
   checklist: string[]
+  /** Contrôle du contrôle : identifiants des contrôles (N1) supervisés par ce contrôle (N2). */
+  superviseIds: string[]
 }
 
 /** Normalise une liste de refs d'exigences : chaînes non vides, dédupliquées. */
@@ -202,6 +205,7 @@ export function cleanControleInput(body: ControleInput): CleanControle {
     referentielCode: txt(body.referentielCode),
     exigenceRefs: cleanExigenceRefs(body.exigenceRefs),
     checklist: cleanChecklist(body.checklist),
+    superviseIds: cleanExigenceRefs(body.superviseIds),
   }
 }
 
@@ -211,6 +215,7 @@ export interface ExecutionInput {
   constat?: unknown
   tailleTestee?: unknown
   anomaliesTrouvees?: unknown
+  independant?: unknown
 }
 
 export interface CleanExecution {
@@ -219,6 +224,8 @@ export interface CleanExecution {
   constat: string | null
   tailleTestee: number | null
   anomaliesTrouvees: number | null
+  /** Exécutant indépendant de la 1ʳᵉ ligne (séparation des fonctions, contrôle N2). null = non renseigné. */
+  independant: boolean | null
 }
 
 function parseDate(v: unknown): Date | null {
@@ -252,6 +259,7 @@ export function cleanExecutionInput(body: ExecutionInput, now: Date = new Date()
     constat: txt(body.constat),
     tailleTestee: body.tailleTestee == null || body.tailleTestee === '' ? null : Math.max(0, Math.round(Number(body.tailleTestee))),
     anomaliesTrouvees: body.anomaliesTrouvees == null || body.anomaliesTrouvees === '' ? null : Math.max(0, Math.round(Number(body.anomaliesTrouvees))),
+    independant: typeof body.independant === 'boolean' ? body.independant : null,
   }
 }
 

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1277,6 +1277,13 @@ export const de: Translations = {
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Löschen',
     filtreAucun: 'Keine Kontrolle entspricht den Filtern.',
+    supervise: 'Überwachte Kontrollen (N1)',
+    superviseHint: 'eine N2-Kontrolle prüft diese First-Line-Kontrollen',
+    superviseVide: 'Keine N1-Kontrolle zu überwachen.',
+    superviseListe: 'Überwacht',
+    independantLabel: 'Ausführender unabhängig von der ersten Linie (Funktionstrennung)',
+    independantBadge: 'Unabhängig',
+    independantHint: 'Von einer von der ersten Linie unabhängigen Person durchgeführt',
     etats: {
       A_VENIR: 'Bevorstehend',
       DU: 'Fällig',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1277,6 +1277,13 @@ export const en: Translations = {
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Clear',
     filtreAucun: 'No control matches the filters.',
+    supervise: 'Supervised controls (N1)',
+    superviseHint: 'an N2 control verifies these first-line controls',
+    superviseVide: 'No N1 control to supervise.',
+    superviseListe: 'Supervises',
+    independantLabel: 'Performer independent from the first line (segregation of duties)',
+    independantBadge: 'Independent',
+    independantHint: 'Performed by someone independent from the first line',
     etats: {
       A_VENIR: 'Upcoming',
       DU: 'Due',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1277,6 +1277,13 @@ export const es: Translations = {
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Borrar',
     filtreAucun: 'Ningún control coincide con los filtros.',
+    supervise: 'Controles supervisados (N1)',
+    superviseHint: 'un control N2 verifica estos controles de primera línea',
+    superviseVide: 'Ningún control N1 que supervisar.',
+    superviseListe: 'Supervisa',
+    independantLabel: 'Ejecutante independiente de la primera línea (segregación de funciones)',
+    independantBadge: 'Independiente',
+    independantHint: 'Ejecutado por una persona independiente de la primera línea',
     etats: {
       A_VENIR: 'Próximo',
       DU: 'Vencido',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1300,6 +1300,13 @@ export const fr = {
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Effacer',
     filtreAucun: 'Aucun contrôle ne correspond aux filtres.',
+    supervise: 'Contrôles supervisés (N1)',
+    superviseHint: 'un contrôle N2 vérifie ces contrôles de 1ʳᵉ ligne',
+    superviseVide: 'Aucun contrôle N1 à superviser.',
+    superviseListe: 'Supervise',
+    independantLabel: 'Exécutant indépendant de la 1ʳᵉ ligne (séparation des fonctions)',
+    independantBadge: 'Indépendant',
+    independantHint: 'Exécuté par une personne indépendante de la 1ʳᵉ ligne',
     etats: {
       A_VENIR: 'À venir',
       DU: 'Dû',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1277,6 +1277,13 @@ export const it: Translations = {
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Cancella',
     filtreAucun: 'Nessun controllo corrisponde ai filtri.',
+    supervise: 'Controlli supervisionati (N1)',
+    superviseHint: 'un controllo N2 verifica questi controlli di prima linea',
+    superviseVide: 'Nessun controllo N1 da supervisionare.',
+    superviseListe: 'Supervisiona',
+    independantLabel: 'Esecutore indipendente dalla prima linea (separazione delle funzioni)',
+    independantBadge: 'Indipendente',
+    independantHint: 'Eseguito da una persona indipendente dalla prima linea',
     etats: {
       A_VENIR: 'In arrivo',
       DU: 'Dovuto',


### PR DESCRIPTION
## Chantier 2/5 — Renforcement du contrôle permanent N2 (bancaire)
Aligné sur l'arrêté ACPR du 3 nov. 2014 (contrôle permanent 2ᵉ niveau).

### Contrôle du contrôle (N2→N1)
Un contrôle **N2** supervise un ou plusieurs contrôles **N1** — il vérifie leur bonne exécution et leur efficacité.
- `Controle.superviseIds` (Json string[]) ; lien logique tolérant aux suppressions.
- Formulaire (N2) : liste à cocher des N1 avec **efficacité en aperçu**.
- Détail : rappel des N1 supervisés + leur taux de conformité.

### Indépendance de l'exécutant (séparation des fonctions)
- `ControleExecution.independant` (Boolean?) — case à cocher à l'exécution (N2), **badge « Indépendant »** à l'historique.

## Qualité
- `lib/controle.ts` (pur) : `superviseIds` dans `cleanControleInput`, `independant` dans `cleanExecutionInput`.
- Migration `20260823140000` rétrocompatible.
- TDD : +2 tests. `tsc` 0 erreur · **1218 tests verts**.
- Vérifié live (API + DB + UI) : N2 `superviseIds=[N1]` + exécution `independant=true` persistés ; formulaire N2 affiche la liste des N1.

Voir [`docs/specs/controle-n2-supervision.md`](docs/specs/controle-n2-supervision.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)