### PR TITLE
feat(controles): catalogues de contrôles par défaut ISO 27001 + DORA (import 1 clic)

### DIFF
--- a/src/__tests__/unit/lib/controles-catalogue.test.ts
+++ b/src/__tests__/unit/lib/controles-catalogue.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { CATALOGUES_CONTROLES, getCatalogueControle } from '@/lib/controles-catalogue'
+import { CONTROLE_NIVEAUX, PERIODICITES, cleanControleInput, validateControleInput } from '@/lib/controle'
+
+describe('controles-catalogue', () => {
+  it('expose les socles ISO27001 et DORA', () => {
+    expect(CATALOGUES_CONTROLES.map(c => c.id).sort()).toEqual(['DORA', 'ISO27001'])
+  })
+
+  it('getCatalogueControle retrouve un socle et renvoie undefined sinon', () => {
+    expect(getCatalogueControle('ISO27001')?.controles.length).toBeGreaterThan(5)
+    expect(getCatalogueControle('BOGUS')).toBeUndefined()
+  })
+
+  it('chaque modèle a un niveau, une périodicité et une checklist valides', () => {
+    for (const cat of CATALOGUES_CONTROLES) {
+      for (const t of cat.controles) {
+        expect(t.intitule.trim()).not.toBe('')
+        expect(CONTROLE_NIVEAUX).toContain(t.niveau)
+        expect(PERIODICITES).toContain(t.periodicite)
+        expect(t.referentielCode).toBe(cat.referentielCode)
+        expect(t.exigenceRefs.length).toBeGreaterThan(0)
+        expect(t.checklist.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('les modèles passent la validation/normalisation des contrôles', () => {
+    for (const cat of CATALOGUES_CONTROLES) {
+      for (const t of cat.controles) {
+        expect(validateControleInput(t)).toBeNull()
+        const c = cleanControleInput(t)
+        expect(c.niveau).toBe(t.niveau)
+        expect(c.checklist).toEqual(t.checklist)
+        expect(c.exigenceRefs).toEqual(t.exigenceRefs)
+      }
+    }
+  })
+
+  it('intitulés uniques au sein d\'un socle', () => {
+    for (const cat of CATALOGUES_CONTROLES) {
+      const noms = cat.controles.map(t => t.intitule)
+      expect(new Set(noms).size).toBe(noms.length)
+    }
+  })
+})

--- a/src/app/api/controles/import/route.ts
+++ b/src/app/api/controles/import/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { getAnalyseScope } from '@/lib/org-context.server'
+import { getOrgConfig } from '@/lib/org-config.server'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
+import { cleanControleInput } from '@/lib/controle'
+import { getCatalogueControle } from '@/lib/controles-catalogue'
+import { auditLog, getClientIp } from '@/lib/logger'
+
+export const dynamic = 'force-dynamic'
+
+async function ctx(session: { user: { id: string; role?: string } }) {
+  const userId = session.user.id
+  const instanceRole = (session.user.role ?? 'ANALYSTE') as UserRole
+  const scope = await getAnalyseScope(userId, instanceRole)
+  return { userId, userRole: scope.role, orgId: scope.activeOrgId }
+}
+
+const norm = (s: string) => s.normalize('NFD').replace(/[̀-ͯ]/g, '').trim().toLocaleLowerCase()
+
+// POST /api/controles/import — importe un socle de contrôles-types (2ᵉ ligne).
+// Body : { catalogue: 'ISO27001' | 'DORA' }. Idempotent : saute les contrôles dont
+// l'intitulé existe déjà dans l'organisation (comparaison insensible casse/accents).
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  const { userId, userRole, orgId } = await ctx(session as unknown as { user: { id: string; role?: string } })
+  if (!peutDefinir2eLigne(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!orgId) return NextResponse.json({ error: 'Aucune organisation active' }, { status: 400 })
+  const cfg = await getOrgConfig(orgId)
+  if (!cfg.controlePermanentActive) return NextResponse.json({ error: 'Module non activé' }, { status: 403 })
+
+  const body = await req.json().catch(() => ({}))
+  const cat = getCatalogueControle(typeof body.catalogue === 'string' ? body.catalogue : '')
+  if (!cat) return NextResponse.json({ error: 'catalogue_invalide' }, { status: 400 })
+
+  // Intitulés déjà présents → évite les doublons à l'import répété.
+  const existants = await prisma.controle.findMany({ where: { organizationId: orgId }, select: { intitule: true } })
+  const dejaLa = new Set(existants.map(c => norm(c.intitule)))
+
+  const aCreer = cat.controles.filter(t => !dejaLa.has(norm(t.intitule)))
+  if (aCreer.length > 0) {
+    await prisma.controle.createMany({
+      data: aCreer.map(t => ({ ...cleanControleInput(t), organizationId: orgId })),
+    })
+  }
+
+  await auditLog('ORGANIZATION_CONFIG_UPDATED', {
+    userId, userRole, organizationId: orgId, ip: getClientIp(req),
+    details: { scope: 'controle', action: 'import', catalogue: cat.id, created: aCreer.length, skipped: cat.controles.length - aCreer.length },
+  })
+  return NextResponse.json({ created: aCreer.length, skipped: cat.controles.length - aCreer.length }, { status: 201 })
+}

--- a/src/components/ControlesManager.tsx
+++ b/src/components/ControlesManager.tsx
@@ -198,6 +198,19 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
     await fetch(`/api/controles/${id}`, { method: 'DELETE' }); reload()
   }
 
+  // Import d'un socle de contrôles-types (ISO 27001 / DORA). Idempotent côté serveur.
+  async function importerSocle(catalogue: string) {
+    setBusy(true); setError(null); setFlash(null)
+    const res = await fetch('/api/controles/import', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ catalogue }),
+    })
+    const data = await res.json().catch(() => ({}))
+    setBusy(false)
+    if (!res.ok) { setError(err(data.error ?? 'erreur')); return }
+    setFlash(c.importResultat.replace('{n}', String(data.created ?? 0)).replace('{s}', String(data.skipped ?? 0)))
+    reload()
+  }
+
   const inp = 'px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm'
   // Suggestions d'autocomplétion à partir des contrôles déjà saisis (org courante).
   const intituleSug = suggestionsFromValues(controles.map(x => x.intitule))
@@ -213,7 +226,15 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
       <div className="flex items-center justify-between mb-1 flex-wrap gap-2">
         <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100"><FlaskConical size={22} className="inline align-[-0.15em] mr-2" aria-hidden="true" /> {c.title}</h1>
         {canDefine && !showForm && (
-          <button onClick={() => { setForm(emptyForm()); setEditId(null); setShowForm(true) }} className="btn-primary text-sm">{c.newBtn}</button>
+          <div className="flex items-center gap-1.5">
+            <select value="" disabled={busy} onChange={e => { if (e.target.value) importerSocle(e.target.value); e.target.value = '' }}
+              className={inp} aria-label={c.importLabel} title={c.importHint}>
+              <option value="">{c.importLabel}</option>
+              <option value="ISO27001">ISO/IEC 27001:2022</option>
+              <option value="DORA">DORA</option>
+            </select>
+            <button onClick={() => { setForm(emptyForm()); setEditId(null); setShowForm(true) }} className="btn-primary text-sm">{c.newBtn}</button>
+          </div>
         )}
       </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">{c.subtitle}</p>

--- a/src/lib/controles-catalogue.ts
+++ b/src/lib/controles-catalogue.ts
@@ -1,0 +1,68 @@
+// ─── Catalogues de contrôles par défaut ──────────────────────────────────────
+// Socles de contrôles-types prêts à l'emploi, importables en 1 clic dans la
+// bibliothèque de contrôle permanent. Chaque modèle est rattaché à un référentiel
+// et à ses exigences RÉELLES (refs builtin : ISO 27001:2022 « 5.x/8.x »,
+// DORA « DORA-XXX-n ») → la conformité dérivée se câble automatiquement.
+// Données PURES (aucune dépendance DB) → testables.
+
+import type { Periodicite, ControleNiveau } from './controle'
+
+export interface ControleTemplate {
+  intitule: string
+  description: string
+  niveau: ControleNiveau
+  periodicite: Periodicite
+  referentielCode: string
+  exigenceRefs: string[]
+  checklist: string[]
+}
+
+export interface CatalogueControle {
+  id: string          // identifiant stable du socle
+  nom: string         // libellé affiché
+  referentielCode: string
+  controles: ControleTemplate[]
+}
+
+// ── Socle ISO/IEC 27001:2022 (Annexe A) ──────────────────────────────────────
+const ISO27001: CatalogueControle = {
+  id: 'ISO27001', nom: 'ISO/IEC 27001:2022 — socle', referentielCode: 'ISO27001',
+  controles: [
+    { intitule: 'Revue annuelle des politiques de sécurité (PSSI)', description: 'Vérifier que la PSSI est approuvée par la direction, datée de moins de 12 mois et diffusée.', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'ISO27001', exigenceRefs: ['5.1'], checklist: ['PSSI approuvée par la direction', 'Version datée de moins de 12 mois', 'Diffusée et accessible aux personnels'] },
+    { intitule: 'Revue des droits d\'accès et comptes à privilèges', description: 'Contrôler la revue périodique des habilitations, la désactivation des comptes inactifs et le MFA sur les accès sensibles.', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'ISO27001', exigenceRefs: ['5.15', '5.18', '8.2'], checklist: ['Comptes des départs désactivés', 'Revue des droits formalisée', 'MFA actif sur les accès à privilèges', 'Aucun compte générique non justifié'] },
+    { intitule: 'Séparation des tâches sensibles', description: 'Vérifier l\'absence de cumul de fonctions incompatibles (demande/validation, dev/prod).', niveau: 'N2', periodicite: 'SEMESTRIEL', referentielCode: 'ISO27001', exigenceRefs: ['5.3'], checklist: ['Matrice de séparation des tâches à jour', 'Aucun cumul de fonctions incompatibles constaté'] },
+    { intitule: 'Inventaire des actifs à jour', description: 'Contrôler l\'exhaustivité et la fraîcheur de l\'inventaire des actifs et de leurs propriétaires.', niveau: 'N1', periodicite: 'SEMESTRIEL', referentielCode: 'ISO27001', exigenceRefs: ['5.9'], checklist: ['Inventaire exhaustif', 'Propriétaire défini par actif', 'Classification renseignée'] },
+    { intitule: 'Sensibilisation et formation à la sécurité', description: 'Vérifier la réalisation des actions de sensibilisation et leur taux de couverture.', niveau: 'N1', periodicite: 'ANNUEL', referentielCode: 'ISO27001', exigenceRefs: ['6.3'], checklist: ['Campagne réalisée sur la période', 'Taux de participation suivi', 'Nouveaux arrivants formés'] },
+    { intitule: 'Journalisation et surveillance des événements', description: 'Contrôler la collecte, la conservation et la revue des journaux de sécurité.', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'ISO27001', exigenceRefs: ['8.15', '8.16'], checklist: ['Journaux collectés sur les systèmes critiques', 'Durée de conservation respectée', 'Alertes revues et tracées'] },
+    { intitule: 'Sauvegardes et test de restauration', description: 'Vérifier la réalisation des sauvegardes et l\'efficacité d\'un test de restauration.', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'ISO27001', exigenceRefs: ['8.13'], checklist: ['Sauvegardes réalisées selon la politique', 'Test de restauration concluant', 'Copie isolée / hors-ligne disponible'] },
+    { intitule: 'Gestion des vulnérabilités et correctifs', description: 'Contrôler l\'application des correctifs et le traitement des vulnérabilités critiques dans les délais.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'ISO27001', exigenceRefs: ['8.8'], checklist: ['Scan de vulnérabilités réalisé', 'Correctifs critiques appliqués dans les délais', 'Vulnérabilités résiduelles suivies'] },
+    { intitule: 'Protection contre les codes malveillants', description: 'Vérifier la couverture et la mise à jour des protections anti-malware.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'ISO27001', exigenceRefs: ['8.7'], checklist: ['Protection déployée sur le parc', 'Signatures/moteur à jour', 'Détections traitées'] },
+    { intitule: 'Gestion des incidents de sécurité', description: 'Contrôler le traitement, la qualification et le retour d\'expérience des incidents.', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'ISO27001', exigenceRefs: ['5.24', '5.25', '5.26'], checklist: ['Incidents enregistrés et qualifiés', 'Délais de traitement respectés', 'Retour d\'expérience formalisé'] },
+    { intitule: 'Sécurité des relations fournisseurs', description: 'Vérifier l\'évaluation sécurité des fournisseurs et les clauses contractuelles.', niveau: 'N2', periodicite: 'SEMESTRIEL', referentielCode: 'ISO27001', exigenceRefs: ['5.19', '5.20', '5.21', '5.22'], checklist: ['Fournisseurs critiques évalués', 'Clauses de sécurité contractuelles présentes', 'Suivi des niveaux de service'] },
+    { intitule: 'Continuité d\'activité et tests', description: 'Contrôler l\'existence des plans de continuité et la réalisation d\'un test.', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'ISO27001', exigenceRefs: ['5.29', '5.30'], checklist: ['Plans de continuité à jour', 'Test de continuité réalisé', 'Écarts traités'] },
+  ],
+}
+
+// ── Socle DORA (UE 2022/2554) ────────────────────────────────────────────────
+const DORA: CatalogueControle = {
+  id: 'DORA', nom: 'DORA (UE 2022/2554) — socle', referentielCode: 'DORA',
+  controles: [
+    { intitule: 'Revue du cadre de gestion du risque ICT', description: 'Vérifier l\'approbation et la revue annuelle du cadre de gestion du risque ICT par l\'organe de direction (art. 5).', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'DORA', exigenceRefs: ['DORA-ICT-1'], checklist: ['Cadre documenté et approuvé', 'Revue par l\'organe de direction < 12 mois', 'Responsabilités définies'] },
+    { intitule: 'Cartographie des fonctions critiques et actifs ICT', description: 'Contrôler l\'identification et la mise à jour des fonctions critiques, actifs ICT et interdépendances (art. 8).', niveau: 'N1', periodicite: 'SEMESTRIEL', referentielCode: 'DORA', exigenceRefs: ['DORA-ICT-2'], checklist: ['Fonctions critiques identifiées', 'Actifs ICT rattachés', 'Interdépendances tenues à jour'] },
+    { intitule: 'Sécurité ICT : accès, chiffrement, segmentation', description: 'Vérifier les mesures de protection et de prévention des moyens ICT (art. 9).', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'DORA', exigenceRefs: ['DORA-ICT-3'], checklist: ['Gestion des accès appliquée', 'Chiffrement des données sensibles', 'Segmentation réseau en place'] },
+    { intitule: 'Détection des activités anormales', description: 'Contrôler les mécanismes de détection des anomalies et incidents ICT (art. 10).', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'DORA', exigenceRefs: ['DORA-ICT-4'], checklist: ['Détection déployée sur les systèmes critiques', 'Seuils et alertes définis', 'Alertes traitées'] },
+    { intitule: 'Continuité ICT et objectifs RTO/RPO', description: 'Vérifier la politique de continuité ICT et les plans de rétablissement (art. 11).', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'DORA', exigenceRefs: ['DORA-ICT-5'], checklist: ['Politique de continuité ICT établie', 'RTO/RPO définis', 'Plans de rétablissement testés'] },
+    { intitule: 'Sauvegardes et restauration éprouvées', description: 'Contrôler la réalisation et le test des sauvegardes sur environnement isolé (art. 12).', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'DORA', exigenceRefs: ['DORA-ICT-6'], checklist: ['Sauvegardes réalisées', 'Restauration testée', 'Environnement de test isolé'] },
+    { intitule: 'Processus de gestion des incidents ICT', description: 'Vérifier le processus de détection, gestion et journalisation des incidents ICT (art. 17).', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'DORA', exigenceRefs: ['DORA-INC-1'], checklist: ['Processus formalisé', 'Rôles et escalade définis', 'Journalisation des incidents'] },
+    { intitule: 'Classification et notification des incidents majeurs', description: 'Contrôler la classification DORA et la notification des incidents majeurs dans les délais (art. 18-19).', niveau: 'N2', periodicite: 'TRIMESTRIEL', referentielCode: 'DORA', exigenceRefs: ['DORA-INC-2', 'DORA-INC-3'], checklist: ['Critères de classification appliqués', 'Notifications initiale/intermédiaire/finale dans les délais', 'Autorité compétente informée'] },
+    { intitule: 'Programme de tests de résilience opérationnelle', description: 'Vérifier la réalisation du programme de tests (vulnérabilités, intrusion, continuité) (art. 24-25).', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'DORA', exigenceRefs: ['DORA-TEST-1'], checklist: ['Programme de tests défini', 'Tests réalisés sur les systèmes critiques', 'Remédiations suivies'] },
+    { intitule: 'Registre des prestataires tiers ICT', description: 'Contrôler la tenue à jour du registre d\'information des accords ICT (art. 28).', niveau: 'N2', periodicite: 'SEMESTRIEL', referentielCode: 'DORA', exigenceRefs: ['DORA-TPP-1', 'DORA-TPP-2'], checklist: ['Registre exhaustif des contrats ICT', 'Prestataires critiques identifiés', 'Évaluation de risque avant contractualisation'] },
+  ],
+}
+
+export const CATALOGUES_CONTROLES: CatalogueControle[] = [ISO27001, DORA]
+
+/** Retourne un socle par son identifiant, ou undefined. */
+export function getCatalogueControle(id: string): CatalogueControle | undefined {
+  return CATALOGUES_CONTROLES.find(c => c.id === id)
+}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1284,6 +1284,9 @@ export const de: Translations = {
     independantLabel: 'Ausführender unabhängig von der ersten Linie (Funktionstrennung)',
     independantBadge: 'Unabhängig',
     independantHint: 'Von einer von der ersten Linie unabhängigen Person durchgeführt',
+    importLabel: 'Vorlage importieren…',
+    importHint: 'Sofort einsatzbereite Kontroll-Vorlagen erstellen (Duplikate übersprungen)',
+    importResultat: '{n} Kontrolle(n) importiert, {s} bereits vorhanden.',
     etats: {
       A_VENIR: 'Bevorstehend',
       DU: 'Fällig',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1284,6 +1284,9 @@ export const en: Translations = {
     independantLabel: 'Performer independent from the first line (segregation of duties)',
     independantBadge: 'Independent',
     independantHint: 'Performed by someone independent from the first line',
+    importLabel: 'Import a baseline…',
+    importHint: 'Create ready-to-use control templates (duplicates skipped)',
+    importResultat: '{n} control(s) imported, {s} already present.',
     etats: {
       A_VENIR: 'Upcoming',
       DU: 'Due',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1284,6 +1284,9 @@ export const es: Translations = {
     independantLabel: 'Ejecutante independiente de la primera línea (segregación de funciones)',
     independantBadge: 'Independiente',
     independantHint: 'Ejecutado por una persona independiente de la primera línea',
+    importLabel: 'Importar un conjunto…',
+    importHint: 'Crear controles tipo listos para usar (duplicados omitidos)',
+    importResultat: '{n} control(es) importado(s), {s} ya presente(s).',
     etats: {
       A_VENIR: 'Próximo',
       DU: 'Vencido',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1307,6 +1307,9 @@ export const fr = {
     independantLabel: 'Exécutant indépendant de la 1ʳᵉ ligne (séparation des fonctions)',
     independantBadge: 'Indépendant',
     independantHint: 'Exécuté par une personne indépendante de la 1ʳᵉ ligne',
+    importLabel: 'Importer un socle…',
+    importHint: 'Créer des contrôles-types prêts à l\'emploi (doublons ignorés)',
+    importResultat: '{n} contrôle(s) importé(s), {s} déjà présent(s).',
     etats: {
       A_VENIR: 'À venir',
       DU: 'Dû',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1284,6 +1284,9 @@ export const it: Translations = {
     independantLabel: 'Esecutore indipendente dalla prima linea (separazione delle funzioni)',
     independantBadge: 'Indipendente',
     independantHint: 'Eseguito da una persona indipendente dalla prima linea',
+    importLabel: 'Importa un set…',
+    importHint: 'Crea controlli tipo pronti all\'uso (duplicati ignorati)',
+    importResultat: '{n} controllo/i importato/i, {s} già presente/i.',
     etats: {
       A_VENIR: 'In arrivo',
       DU: 'Dovuto',


### PR DESCRIPTION
## Chantier 4/5 — Contrôles par défaut (ISO 27001 / DORA)
La bibliothèque démarrait vide. Ajout de deux **socles de contrôles-types importables en un clic**.

- `lib/controles-catalogue.ts` (pur) : **ISO/IEC 27001:2022** (12 contrôles) et **DORA** (10 contrôles), chacun avec niveau (N1/N2), périodicité, checklist et `exigenceRefs` **réelles** (refs builtin « 5.x / 8.x », « DORA-XXX-n ») → la **conformité dérivée se câble automatiquement**.
- API `POST /api/controles/import { catalogue }` : 2ᵉ ligne (`peutDefinir2eLigne`), **idempotent** (saute les intitulés déjà présents, insensible casse/accents), renvoie `{created, skipped}`.
- `ControlesManager` : sélecteur **« Importer un socle… »** (ISO 27001 / DORA) + message de résultat.
- i18n 5 langues.

## Qualité
- TDD : +5 tests. `tsc` 0 erreur · **1226 tests verts**.
- Vérifié live : import ISO (**créé 12 / sauté 0**), ré-import **idempotent (0 / 12)**, modèle importé porte checklist + réf `8.13` + périodicité ; nettoyage OK.

Sans migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)