### PR TITLE
feat(config): 2e ligne de défense optionnelle — socle (Lot 0)

### DIFF
--- a/prisma/migrations/20260823170000_seconde_ligne_active/migration.sql
+++ b/prisma/migrations/20260823170000_seconde_ligne_active/migration.sql
@@ -1,0 +1,2 @@
+-- 2ᵉ ligne de défense optionnelle : toggle par organisation (défaut true = mode réglementé)
+ALTER TABLE "OrganizationConfig" ADD COLUMN "secondeLigneActive" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1358,6 +1358,9 @@ model OrganizationConfig {
   auditInterneActive         Boolean       @default(false)
   kriActive                  Boolean       @default(false)
   reglementaireActive        Boolean       @default(false)
+  // 2ᵉ ligne de défense (séparation des fonctions). true = mode réglementé (défaut) ;
+  // false = mode « ligne unique » (org non régulée) : quatre-yeux et rôles 2ᵉ ligne relâchés.
+  secondeLigneActive         Boolean       @default(true)
   // Appétit au risque : { seuilGlobal: number|null, parCategorie: { <codeTaxo>: number } }
   // — seuil de niveau résiduel (produit G×V, 1..25) accepté. Vide ⇒ hérité/aucun.
   appetitRisque              Json          @default("{}")

--- a/src/__tests__/unit/lib/module-policy.test.ts
+++ b/src/__tests__/unit/lib/module-policy.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import {
-  resolveModuleActivation, isModuleForced, sanitizeModulesPolicy,
+  resolveModuleActivation, isModuleForced, sanitizeModulesPolicy, GOVERNABLE_MODULES,
 } from '@/lib/module-policy'
+
+describe('GOVERNABLE_MODULES', () => {
+  it('inclut la 2ᵉ ligne de défense (gouvernable au niveau instance)', () => {
+    expect(GOVERNABLE_MODULES).toContain('secondeLigne')
+  })
+  it('sanitize accepte une politique sur secondeLigne', () => {
+    expect(sanitizeModulesPolicy({ secondeLigne: 'FORCE_ON' })).toEqual({ secondeLigne: 'FORCE_ON' })
+  })
+})
 
 describe('resolveModuleActivation', () => {
   it('PER_ORG / absent → la valeur de l\'organisation décide', () => {

--- a/src/__tests__/unit/lib/org-config.test.ts
+++ b/src/__tests__/unit/lib/org-config.test.ts
@@ -42,6 +42,12 @@ describe('resolveOrgConfig — héritage de configuration par organisation', () 
     expect(c.echellesEcosysteme).toEqual({})
   })
 
+  it('2ᵉ ligne de défense : active par défaut (rétrocompatible), désactivable par row', () => {
+    expect(resolveOrgConfig([]).secondeLigneActive).toBe(true)
+    expect(DEFAULT_ORG_CONFIG.secondeLigneActive).toBe(true)
+    expect(resolveOrgConfig([row({ secondeLigneActive: false })]).secondeLigneActive).toBe(false)
+  })
+
   it('un champ JSON vide hérite de l\'ancêtre (le plus proche non vide gagne)', () => {
     // chaîne SELF-first : [enfant, racine]
     const enfant = row({ entitesMesures: [] })                       // vide → hérite

--- a/src/app/api/admin/organization-config/route.ts
+++ b/src/app/api/admin/organization-config/route.ts
@@ -84,6 +84,7 @@ export async function GET(_req: NextRequest) {
     auditInterneActive: cfg.auditInterneActive,
     kriActive: cfg.kriActive,
     reglementaireActive: cfg.reglementaireActive,
+    secondeLigneActive: cfg.secondeLigneActive,
     echellesEcosysteme: echellesOut(cfg.echellesEcosysteme),
   })
 }
@@ -200,6 +201,7 @@ export async function PUT(req: NextRequest) {
   if (typeof body.auditInterneActive === 'boolean') data.auditInterneActive = body.auditInterneActive
   if (typeof body.kriActive === 'boolean') data.kriActive = body.kriActive
   if (typeof body.reglementaireActive === 'boolean') data.reglementaireActive = body.reglementaireActive
+  if (typeof body.secondeLigneActive === 'boolean') data.secondeLigneActive = body.secondeLigneActive
   // Taxonomie de risques : nettoyée avant stockage ([] ⇒ retour au défaut Bâle).
   if (Array.isArray(body.taxonomieRisques)) data.taxonomieRisques = sanitizeTaxonomie(body.taxonomieRisques)
 

--- a/src/app/configuration/page.tsx
+++ b/src/app/configuration/page.tsx
@@ -162,6 +162,7 @@ export default function ConfigurationPage() {
   const [auditInterneActive, setAuditInterneActive] = useState(false)
   const [kriActive, setKriActive] = useState(false)
   const [reglementaireActive, setReglementaireActive] = useState(false)
+  const [secondeLigneActive, setSecondeLigneActive] = useState(true) // défaut true = mode réglementé
   // Politique d'instance (SUPER_ADMIN) : { <module>: 'PER_ORG'|'FORCE_ON'|'FORCE_OFF' }.
   const [modulesPolicy, setModulesPolicy] = useState<Record<string, string>>({})
   const [taxonomieRisques, setTaxonomieRisques] = useState<TaxonomieNode[] | null>(null) // null = pas encore chargé
@@ -216,6 +217,7 @@ export default function ConfigurationPage() {
         setAuditInterneActive(Boolean(data.auditInterneActive))
         setKriActive(Boolean(data.kriActive))
         setReglementaireActive(Boolean(data.reglementaireActive))
+        setSecondeLigneActive(data.secondeLigneActive !== false) // défaut true
         if (data.modulesPolicy && typeof data.modulesPolicy === 'object') setModulesPolicy(data.modulesPolicy)
         setTaxonomieRisques(sanitizeTaxonomie(data.taxonomieRisques))
         setDerogationSortCatalogue(data.derogationSortCatalogue !== false)
@@ -262,8 +264,9 @@ export default function ConfigurationPage() {
     auditInterneActive: setAuditInterneActive,
     kriActive: setKriActive,
     reglementaireActive: setReglementaireActive,
+    secondeLigneActive: setSecondeLigneActive,
   }
-  async function saveFeature(field: 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive', value: boolean) {
+  async function saveFeature(field: 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive', value: boolean) {
     FEATURE_SETTERS[field]?.(value) // mise à jour optimiste
     setSavingFeatures(true)
     const res = await fetch('/api/admin/organization-config', {
@@ -720,7 +723,7 @@ export default function ConfigurationPage() {
             <h2 className="text-base font-semibold text-gray-800 mb-1">{t.modulesPolicy.sectionTitle}</h2>
             <p className="text-sm text-gray-500 mb-4">{t.modulesPolicy.sectionDesc}</p>
             <div className="space-y-3">
-              {([{ key: 'registreRisques', label: t.features.registreRisquesTitle }, { key: 'incidents', label: t.features.incidentsTitle }, { key: 'controlePermanent', label: t.features.controlePermanentTitle }, { key: 'auditInterne', label: t.features.auditInterneTitle }, { key: 'kri', label: t.features.kriTitle }, { key: 'reglementaire', label: t.features.reglementaireTitle }]).map(m => (
+              {([{ key: 'registreRisques', label: t.features.registreRisquesTitle }, { key: 'incidents', label: t.features.incidentsTitle }, { key: 'controlePermanent', label: t.features.controlePermanentTitle }, { key: 'auditInterne', label: t.features.auditInterneTitle }, { key: 'kri', label: t.features.kriTitle }, { key: 'reglementaire', label: t.features.reglementaireTitle }, { key: 'secondeLigne', label: t.features.secondeLigneTitle }]).map(m => (
                 <div key={m.key} className="flex flex-wrap items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 bg-gray-50">
                   <span className="text-sm font-medium text-gray-800">{m.label}</span>
                   <select
@@ -1259,6 +1262,7 @@ export default function ConfigurationPage() {
                 { field: 'auditInterneActive' as const, value: auditInterneActive, title: t.features.auditInterneTitle, desc: t.features.auditInterneDesc, href: 'https://www.acpr.banque-france.fr/', disabled: modulesPolicy.auditInterne === 'FORCE_ON' || modulesPolicy.auditInterne === 'FORCE_OFF', indent: false, forced: modulesPolicy.auditInterne },
                 { field: 'kriActive' as const, value: kriActive, title: t.features.kriTitle, desc: t.features.kriDesc, href: 'https://www.acpr.banque-france.fr/', disabled: modulesPolicy.kri === 'FORCE_ON' || modulesPolicy.kri === 'FORCE_OFF', indent: false, forced: modulesPolicy.kri },
                 { field: 'reglementaireActive' as const, value: reglementaireActive, title: t.features.reglementaireTitle, desc: t.features.reglementaireDesc, href: 'https://www.eiopa.europa.eu/digital-operational-resilience-act-dora_en', disabled: modulesPolicy.reglementaire === 'FORCE_ON' || modulesPolicy.reglementaire === 'FORCE_OFF', indent: false, forced: modulesPolicy.reglementaire },
+                { field: 'secondeLigneActive' as const, value: secondeLigneActive, title: t.features.secondeLigneTitle, desc: t.features.secondeLigneDesc, href: 'https://www.acpr.banque-france.fr/', disabled: modulesPolicy.secondeLigne === 'FORCE_ON' || modulesPolicy.secondeLigne === 'FORCE_OFF', indent: false, forced: modulesPolicy.secondeLigne },
               ]).map(f => {
                 const forced = (f as { forced?: string }).forced // 'FORCE_ON' | 'FORCE_OFF' | undefined
                 const isForced = forced === 'FORCE_ON' || forced === 'FORCE_OFF'

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -2943,6 +2943,8 @@ export const de: Translations = {
     kriDesc: 'Periodisch verfolgte Schlüsselrisikoindikatoren mit Warn-/Kritisch-Schwellen und Frühwarnung. Definition durch die 2., Messung durch die 1. Linie.',
     reglementaireTitle: 'Regulatorisches Reporting',
     reglementaireDesc: 'IKT-Vorfallregister (DORA-Klassifizierung schwer/erheblich/gering) und Verlustübersicht (ACPR LDC). Entscheidungshilfe, CSV-Export.',
+    secondeLigneTitle: '2. Verteidigungslinie (Funktionstrennung)',
+    secondeLigneDesc: 'Aktiviert (Standard): reguliertes Modell — Definition/Validierung durch die 2. Linie, Vier-Augen-Prinzip, Kontrolle der Kontrolle N2. Deaktiviert: „Einlinien"-Modus für nicht regulierte Organisationen (die 1. Linie führt die Aufgaben ohne Doppelvalidierung aus).',
     moduleForcedOn: 'Auf Instanzebene erzwungen',
     moduleForcedOff: 'Auf Instanzebene deaktiviert',
     learnMore:          'Mehr erfahren ↗',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2943,6 +2943,8 @@ export const en: Translations = {
     kriDesc: 'Key risk indicators tracked periodically, with alert/critical thresholds and early warning. Defined by the 2nd line, measured by the 1st.',
     reglementaireTitle: 'Regulatory reporting',
     reglementaireDesc: 'ICT incident register (DORA major/significant/minor classification) and loss summary (ACPR LDC). Decision support, CSV export.',
+    secondeLigneTitle: '2nd line of defence (segregation of duties)',
+    secondeLigneDesc: 'Enabled (default): regulated setup — definition/validation by the 2nd line, four-eyes, N2 control-of-control. Disabled: "single-line" mode for non-regulated organisations (the 1st line performs the tasks, without dual validation).',
     moduleForcedOn: 'Enforced at instance level',
     moduleForcedOff: 'Disabled at instance level',
     learnMore:          'Learn more ↗',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -2943,6 +2943,8 @@ export const es: Translations = {
     kriDesc: 'Indicadores clave de riesgo con seguimiento periódico, umbrales de alerta/crítico y señal temprana. Definidos por la 2ª línea, medidos por la 1ª.',
     reglementaireTitle: 'Reporte regulatorio',
     reglementaireDesc: 'Registro de incidentes TIC (clasificación DORA mayor/significativo/menor) y resumen de pérdidas (LDC ACPR). Apoyo a la decisión, exportación CSV.',
+    secondeLigneTitle: '2ª línea de defensa (segregación de funciones)',
+    secondeLigneDesc: 'Activada (predeterminado): dispositivo regulado — definición/validación por la 2ª línea, cuatro ojos, control del control N2. Desactivada: modo «línea única» para organizaciones no reguladas (la 1ª línea realiza las tareas, sin doble validación).',
     moduleForcedOn: 'Impuesto a nivel de instancia',
     moduleForcedOff: 'Desactivado a nivel de instancia',
     learnMore:          'Más información ↗',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -2991,6 +2991,8 @@ export const fr = {
     kriDesc: 'Indicateurs clés de risque suivis périodiquement, avec seuils d\'alerte/critique et signal avancé. Définition par la 2ᵉ ligne, saisie des mesures par la 1ʳᵉ.',
     reglementaireTitle: 'Reporting réglementaire',
     reglementaireDesc: 'Registre d\'incidents TIC (classification DORA majeur/significatif/mineur) et synthèse des pertes (LDC ACPR). Aide à la décision, export CSV.',
+    secondeLigneTitle: '2ᵉ ligne de défense (séparation des fonctions)',
+    secondeLigneDesc: 'Activée (défaut) : dispositif réglementé — définition/validation par la 2ᵉ ligne, quatre-yeux, contrôle du contrôle N2. Désactivée : mode « ligne unique » pour les organisations non régulées (la 1ʳᵉ ligne réalise les tâches, sans double validation).',
     moduleForcedOn: 'Imposé au niveau de l\'instance',
     moduleForcedOff: 'Désactivé au niveau de l\'instance',
     learnMore:          'En savoir plus ↗',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -2943,6 +2943,8 @@ export const it: Translations = {
     kriDesc: 'Indicatori chiave di rischio monitorati periodicamente, con soglie di allerta/critica e segnale anticipato. Definiti dalla 2ª linea, misurati dalla 1ª.',
     reglementaireTitle: 'Reporting normativo',
     reglementaireDesc: 'Registro incidenti ICT (classificazione DORA grave/significativo/minore) e sintesi perdite (LDC ACPR). Supporto alle decisioni, export CSV.',
+    secondeLigneTitle: '2ª linea di difesa (separazione delle funzioni)',
+    secondeLigneDesc: 'Attivata (predefinito): dispositivo regolamentato — definizione/validazione da parte della 2ª linea, quattro occhi, controllo del controllo N2. Disattivata: modalità «linea unica» per organizzazioni non regolamentate (la 1ª linea esegue i compiti, senza doppia validazione).',
     moduleForcedOn: 'Imposto a livello di istanza',
     moduleForcedOff: 'Disattivato a livello di istanza',
     learnMore:          'Scopri di più ↗',

--- a/src/lib/module-policy.ts
+++ b/src/lib/module-policy.ts
@@ -16,7 +16,7 @@ export type ModulePolicy = 'PER_ORG' | 'FORCE_ON' | 'FORCE_OFF'
 export const MODULE_POLICIES: ModulePolicy[] = ['PER_ORG', 'FORCE_ON', 'FORCE_OFF']
 
 /** Modules dont l'activation peut être gouvernée au niveau instance (extensible). */
-export const GOVERNABLE_MODULES = ['registreRisques', 'incidents', 'controlePermanent', 'auditInterne', 'kri', 'reglementaire'] as const
+export const GOVERNABLE_MODULES = ['registreRisques', 'incidents', 'controlePermanent', 'auditInterne', 'kri', 'reglementaire', 'secondeLigne'] as const
 export type GovernableModule = typeof GOVERNABLE_MODULES[number]
 
 /** Valeur effective d'activation d'un module : la politique d'instance prime. */

--- a/src/lib/org-config.server.ts
+++ b/src/lib/org-config.server.ts
@@ -38,6 +38,7 @@ const CONFIG_SELECT = {
   auditInterneActive: true,
   kriActive: true,
   reglementaireActive: true,
+  secondeLigneActive: true,
   appetitRisque: true,
 } as const
 
@@ -83,6 +84,7 @@ async function applyInstancePolicy(cfg: OrgConfigResolved): Promise<OrgConfigRes
       auditInterneActive: resolveModuleActivation(policy.auditInterne, cfg.auditInterneActive),
       kriActive: resolveModuleActivation(policy.kri, cfg.kriActive),
       reglementaireActive: resolveModuleActivation(policy.reglementaire, cfg.reglementaireActive),
+      secondeLigneActive: resolveModuleActivation(policy.secondeLigne, cfg.secondeLigneActive),
     }
   } catch {
     return cfg

--- a/src/lib/org-config.ts
+++ b/src/lib/org-config.ts
@@ -52,6 +52,7 @@ export interface RawOrgConfig {
   auditInterneActive?: boolean
   kriActive?: boolean
   reglementaireActive?: boolean
+  secondeLigneActive?: boolean
   appetitRisque?: unknown
 }
 
@@ -83,6 +84,8 @@ export interface OrgConfigResolved {
   auditInterneActive: boolean
   kriActive: boolean
   reglementaireActive: boolean
+  /** 2ᵉ ligne de défense (séparation des fonctions). true = mode réglementé (défaut). */
+  secondeLigneActive: boolean
   appetitRisque: AppetitConfig
 }
 
@@ -114,6 +117,7 @@ export const DEFAULT_ORG_CONFIG: OrgConfigResolved = {
   auditInterneActive: false,
   kriActive: false,
   reglementaireActive: false,
+  secondeLigneActive: true,
   appetitRisque: APPETIT_DEFAULT,
 }
 
@@ -126,7 +130,7 @@ function isEmptyJson(v: unknown): boolean {
 }
 
 type JsonKey = 'entitesMesures' | 'typesImpacts' | 'referentielsActifs' | 'strategiesTraitement' | 'exemplesAteliers' | 'echellesEcosysteme' | 'taxonomieRisques' | 'appetitRisque'
-type BoolKey = 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive'
+type BoolKey = 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive'
 type StrKey = 'conformiteNiveau' | 'conformiteSnapshotMode' | 'derogationWorkflow'
 type IntKey = 'derogationDureeDefautJours' | 'derogationAlerteJours'
 
@@ -188,6 +192,7 @@ export function resolveOrgConfig(chainSelfFirst: (RawOrgConfig | null)[], defaul
     auditInterneActive: pickBool('auditInterneActive', defaults.auditInterneActive),
     kriActive: pickBool('kriActive', defaults.kriActive),
     reglementaireActive: pickBool('reglementaireActive', defaults.reglementaireActive),
+    secondeLigneActive: pickBool('secondeLigneActive', defaults.secondeLigneActive),
     appetitRisque: pickJson('appetitRisque', defaults.appetitRisque),
   }
 }


### PR DESCRIPTION
## Épic « 2ᵉ ligne de défense optionnelle » — Lot 0 (socle)
Voir l'analyse : [`docs/specs/ligne-defense-2-optionnelle.md`](docs/specs/ligne-defense-2-optionnelle.md). **Purement additif — aucun effet fonctionnel encore** (les workflows sont câblés aux lots suivants).

- **`OrganizationConfig.secondeLigneActive`** (défaut **true** = mode réglementé, **rétrocompatible**) — migration `20260823170000`.
- **Résolution 3 niveaux** : héritage org (`resolveOrgConfig`/`pickBool`) + **politique d'instance** (`secondeLigne` ajouté à `GOVERNABLE_MODULES` → `FORCE_ON/OFF` possible), appliquée au **point unique** `getOrgConfig`.
- **/configuration** : toggle « 2ᵉ ligne de défense (séparation des fonctions) » (ADMIN, verrouillé si politique d'instance) + entrée dans la section politique d'instance (SUPER_ADMIN). API `GET`/`PUT` organization-config gèrent le champ.
- i18n 5 langues.

## Qualité
- TDD : +3 tests (défaut true + héritage ; `GOVERNABLE_MODULES` + `sanitizeModulesPolicy`). `tsc` 0 erreur · **1240 tests verts**.

Lots suivants : **1** permissions paramétrées → **2** workflows (RCSA/dérogations mono-acteur + masquage N2) → **3** reporting/vocabulaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)