### PR TITLE
feat(rbac): 2e ligne optionnelle — permissions paramétrées (Lot 1)

### DIFF
--- a/src/__tests__/unit/lib/derogation.test.ts
+++ b/src/__tests__/unit/lib/derogation.test.ts
@@ -173,6 +173,14 @@ describe('RBAC dérogations', () => {
     // Un AUTRE valideur métier reste autorisé.
     expect(canValiderDerogation(u('DIRECTION_METIER', 'autre'), { statut: 'VALIDATION_METIER', demandeurId: 'porteur' })).toBe(true)
   })
+  it('mode ligne unique (2ᵉ ligne off) : le demandeur peut valider (quatre-yeux relâché)', () => {
+    const self = { statut: 'VALIDATION_METIER' as const, demandeurId: 'porteur' }
+    // 2ᵉ ligne active (défaut) : refus ; off : autorisé pour le même acteur (DIRECTION_METIER/admin).
+    expect(canValiderDerogation(u('ADMIN', 'porteur'), self, { secondeLigneActive: false })).toBe(true)
+    expect(canValiderDerogation(u('ADMIN', 'porteur'), self, { secondeLigneActive: true })).toBe(false)
+    // Le rôle requis reste exigé même en mode ligne unique (LECTEUR ne valide pas).
+    expect(canValiderDerogation(u('LECTEUR', 'porteur'), self, { secondeLigneActive: false })).toBe(false)
+  })
   it('révocation : RSSI/métier/admin, depuis ACTIVE', () => {
     const d = { statut: 'ACTIVE' as const, demandeurId: 'p' }
     expect(canRevoquerDerogation(u('RSSI'), d)).toBe(true)

--- a/src/__tests__/unit/lib/permissions.test.ts
+++ b/src/__tests__/unit/lib/permissions.test.ts
@@ -361,6 +361,14 @@ describe('peutDefinir2eLigne (définition contrôles / KRI / campagnes — #125)
       expect(peutDefinir2eLigne(role)).toBe(false)
     }
   })
+  it('mode ligne unique (2ᵉ ligne off) : ouvert à tout rôle sauf LECTEUR', () => {
+    for (const role of ['ANALYSTE', 'METIER', 'DIRECTION_METIER', 'RISK_MANAGER', 'ADMIN'] as const) {
+      expect(peutDefinir2eLigne(role, { secondeLigneActive: false })).toBe(true)
+    }
+    expect(peutDefinir2eLigne('LECTEUR', { secondeLigneActive: false })).toBe(false)
+    // 2ᵉ ligne active (explicite) : comportement inchangé.
+    expect(peutDefinir2eLigne('ANALYSTE', { secondeLigneActive: true })).toBe(false)
+  })
 })
 
 describe('hasGlobalReadDispositif + analyseWhereClause (lecture globale — #126)', () => {

--- a/src/app/api/campagnes/[id]/route.ts
+++ b/src/app/api/campagnes/[id]/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import {
   validateCampagneInput, cleanCampagneInput, transitionCampagneAutorisee,
   avancementCampagne, type CampagneStatut,
@@ -15,8 +15,8 @@ export const dynamic = 'force-dynamic'
 
 type Params = { params: Promise<{ id: string }> }
 
-function peutPiloter(role: UserRole): boolean {
-  return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
+function peutPiloter(role: UserRole, secondeLigneActive: boolean): boolean {
+  return peutDefinir2eLigne(role, { secondeLigneActive })
 }
 
 async function loadInScope(session: { user: { id: string; role?: string } }, id: string) {
@@ -33,7 +33,7 @@ async function loadInScope(session: { user: { id: string; role?: string } }, id:
   if (!campagne) return { error: NextResponse.json({ error: 'Introuvable' }, { status: 404 }) }
   const cfg = await getOrgConfig(campagne.organizationId)
   if (!cfg.registreRisquesActive) return { error: NextResponse.json({ error: 'Module non activé' }, { status: 403 }) }
-  return { userId, userRole, campagne }
+  return { userId, userRole, campagne, secondeLigneActive: cfg.secondeLigneActive }
 }
 
 // GET /api/campagnes/[id] — détail + évaluations (avec le risque rattaché).
@@ -82,7 +82,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   const { id } = await params
   const c = await loadInScope(session as unknown as { user: { id: string; role?: string } }, id)
   if ('error' in c) return c.error
-  if (!peutPiloter(c.userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutPiloter(c.userRole, c.secondeLigneActive)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))
   const depuis = c.campagne.statut as CampagneStatut
@@ -182,7 +182,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   const { id } = await params
   const c = await loadInScope(session as unknown as { user: { id: string; role?: string } }, id)
   if ('error' in c) return c.error
-  if (!peutPiloter(c.userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutPiloter(c.userRole, c.secondeLigneActive)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   // Une campagne clôturée est une pièce d'archive : elle ne se supprime pas.
   if (c.campagne.statut === 'CLOTUREE') return NextResponse.json({ error: 'campagne_cloturee' }, { status: 400 })
 

--- a/src/app/api/campagnes/route.ts
+++ b/src/app/api/campagnes/route.ts
@@ -11,8 +11,8 @@ import { auditLog, getClientIp } from '@/lib/logger'
 export const dynamic = 'force-dynamic'
 
 /** Piloter une campagne relève de la 2ᵉ ligne (risk manager / RSSI / admin). */
-export function peutPiloter(role: UserRole): boolean {
-  return peutDefinir2eLigne(role)
+export function peutPiloter(role: UserRole, opts?: { secondeLigneActive?: boolean }): boolean {
+  return peutDefinir2eLigne(role, opts)
 }
 
 async function ctx(session: { user: { id: string; role?: string } }) {
@@ -51,9 +51,9 @@ export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions)
   if (!session?.user) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
   const { userId, userRole, orgId } = await ctx(session as unknown as { user: { id: string; role?: string } })
-  if (!peutPiloter(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!orgId) return NextResponse.json({ error: 'Aucune organisation active' }, { status: 400 })
   const cfg = await getOrgConfig(orgId)
+  if (!peutPiloter(userRole, { secondeLigneActive: cfg.secondeLigneActive })) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!cfg.registreRisquesActive) return NextResponse.json({ error: 'Module non activé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))

--- a/src/app/api/controles/[id]/route.ts
+++ b/src/app/api/controles/[id]/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
-import { isAdminRole, type UserRole } from '@/lib/permissions'
+import { peutDefinir2eLigne, type UserRole } from '@/lib/permissions'
 import { validateControleInput, cleanControleInput } from '@/lib/controle'
 import { auditLog, getClientIp } from '@/lib/logger'
 
@@ -12,8 +12,8 @@ export const dynamic = 'force-dynamic'
 
 type Params = { params: Promise<{ id: string }> }
 
-function peutDefinir(role: UserRole): boolean {
-  return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
+function peutDefinir(role: UserRole, secondeLigneActive: boolean): boolean {
+  return peutDefinir2eLigne(role, { secondeLigneActive })
 }
 
 async function loadInScope(session: { user: { id: string; role?: string } }, id: string) {
@@ -30,7 +30,7 @@ async function loadInScope(session: { user: { id: string; role?: string } }, id:
   if (!controle) return { error: NextResponse.json({ error: 'Introuvable' }, { status: 404 }) }
   const cfg = await getOrgConfig(controle.organizationId)
   if (!cfg.controlePermanentActive) return { error: NextResponse.json({ error: 'Module non activé' }, { status: 403 }) }
-  return { userId, userRole, orgId: controle.organizationId }
+  return { userId, userRole, orgId: controle.organizationId, secondeLigneActive: cfg.secondeLigneActive }
 }
 
 // PATCH /api/controles/[id] — modifier un contrôle (2ᵉ ligne). Mise à jour PARTIELLE.
@@ -40,7 +40,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   const { id } = await params
   const c = await loadInScope(session as unknown as { user: { id: string; role?: string } }, id)
   if ('error' in c) return c.error
-  if (!peutDefinir(c.userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutDefinir(c.userRole, c.secondeLigneActive)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))
   const erreur = validateControleInput(body)
@@ -76,7 +76,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   const { id } = await params
   const c = await loadInScope(session as unknown as { user: { id: string; role?: string } }, id)
   if ('error' in c) return c.error
-  if (!peutDefinir(c.userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutDefinir(c.userRole, c.secondeLigneActive)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
 
   await prisma.controle.delete({ where: { id } })
   await auditLog('ORGANIZATION_CONFIG_UPDATED', {

--- a/src/app/api/controles/campagnes/[id]/route.ts
+++ b/src/app/api/controles/campagnes/[id]/route.ts
@@ -20,7 +20,7 @@ async function guard(session: { user: { id: string; role?: string } }, id: strin
   if (!orgId) return { error: NextResponse.json({ error: 'org_absente' }, { status: 400 }) }
   const cfg = await getOrgConfig(orgId)
   if (!cfg.controlePermanentActive) return { error: NextResponse.json({ error: 'module_inactif' }, { status: 403 }) }
-  if (!peutDefinir(scope.role)) return { error: NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 }) }
+  if (!peutDefinir(scope.role, { secondeLigneActive: cfg.secondeLigneActive })) return { error: NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 }) }
   const row = await prisma.campagneControle.findFirst({ where: { id, organizationId: orgId }, select: { id: true } })
   if (!row) return { error: NextResponse.json({ error: 'introuvable' }, { status: 404 }) }
   return { userId, userRole: scope.role, orgId }

--- a/src/app/api/controles/campagnes/route.ts
+++ b/src/app/api/controles/campagnes/route.ts
@@ -42,7 +42,7 @@ export async function GET() {
     return { ...c, controleIds, avancement: av, enRetard: campagneEnRetard({ dateFin: c.dateFin }, av, now) }
   })
 
-  return NextResponse.json({ active: true, campagnes, controles, canDefine: peutDefinir(userRole) })
+  return NextResponse.json({ active: true, campagnes, controles, canDefine: peutDefinir(userRole, { secondeLigneActive: cfg.secondeLigneActive }) })
 }
 
 // POST /api/controles/campagnes — crée une campagne (2ᵉ ligne).
@@ -53,7 +53,7 @@ export async function POST(req: NextRequest) {
   if (!orgId) return NextResponse.json({ error: 'org_absente' }, { status: 400 })
   const cfg = await getOrgConfig(orgId)
   if (!cfg.controlePermanentActive) return NextResponse.json({ error: 'module_inactif' }, { status: 403 })
-  if (!peutDefinir(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutDefinir(userRole, { secondeLigneActive: cfg.secondeLigneActive })) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))
   const erreur = validateCampagneControleInput(body)

--- a/src/app/api/controles/import/route.ts
+++ b/src/app/api/controles/import/route.ts
@@ -27,9 +27,9 @@ export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions)
   if (!session?.user) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
   const { userId, userRole, orgId } = await ctx(session as unknown as { user: { id: string; role?: string } })
-  if (!peutDefinir2eLigne(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!orgId) return NextResponse.json({ error: 'Aucune organisation active' }, { status: 400 })
   const cfg = await getOrgConfig(orgId)
+  if (!peutDefinir2eLigne(userRole, { secondeLigneActive: cfg.secondeLigneActive })) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!cfg.controlePermanentActive) return NextResponse.json({ error: 'Module non activé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))

--- a/src/app/api/controles/route.ts
+++ b/src/app/api/controles/route.ts
@@ -13,9 +13,9 @@ import { auditLog, getClientIp } from '@/lib/logger'
 
 export const dynamic = 'force-dynamic'
 
-/** Définir le plan de contrôle relève de la 2ᵉ ligne. */
-export function peutDefinir(role: UserRole): boolean {
-  return peutDefinir2eLigne(role)
+/** Définir le plan de contrôle relève de la 2ᵉ ligne (ou de la 1ʳᵉ en mode ligne unique). */
+export function peutDefinir(role: UserRole, opts?: { secondeLigneActive?: boolean }): boolean {
+  return peutDefinir2eLigne(role, opts)
 }
 
 async function ctx(session: { user: { id: string; role?: string } }) {
@@ -71,9 +71,9 @@ export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions)
   if (!session?.user) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
   const { userId, userRole, orgId } = await ctx(session as unknown as { user: { id: string; role?: string } })
-  if (!peutDefinir(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!orgId) return NextResponse.json({ error: 'Aucune organisation active' }, { status: 400 })
   const cfg = await getOrgConfig(orgId)
+  if (!peutDefinir2eLigne(userRole, { secondeLigneActive: cfg.secondeLigneActive })) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!cfg.controlePermanentActive) return NextResponse.json({ error: 'Module non activé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))

--- a/src/app/api/derogations/[id]/route.ts
+++ b/src/app/api/derogations/[id]/route.ts
@@ -98,7 +98,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 
     // ── Validation métier → ACTIVE (ou application d'une prolongation) ──
     case 'VALIDER': {
-      if (!canValiderDerogation(sessionUser, rbac)) return NextResponse.json({ error: 'Action non autorisée' }, { status: 403 })
+      if (!canValiderDerogation(sessionUser, rbac, { secondeLigneActive: orgConfig.secondeLigneActive })) return NextResponse.json({ error: 'Action non autorisée' }, { status: 403 })
       const prolongation = derog.prolongationDemandee != null
       const dateFin = prolongation ? derog.prolongationDemandee! : calcDateFin(now, orgConfig.derogationDureeDefautJours)
       const historique = prolongation
@@ -119,7 +119,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 
     // ── Refus métier (au stade VALIDATION_METIER) ──
     case 'REJETER': {
-      if (!canValiderDerogation(sessionUser, rbac)) return NextResponse.json({ error: 'Action non autorisée' }, { status: 403 })
+      if (!canValiderDerogation(sessionUser, rbac, { secondeLigneActive: orgConfig.secondeLigneActive })) return NextResponse.json({ error: 'Action non autorisée' }, { status: 403 })
       if (!commentaire?.trim()) return NextResponse.json({ error: 'Un commentaire est requis pour le refus' }, { status: 400 })
       const updated = await save({ statut: 'REJETEE', rejeteePar: userId, rejeteeLe: now, rejetMotif: commentaire })
       await audit('DEROGATION_REJECTED', {})

--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -15,9 +15,11 @@ export const dynamic = 'force-dynamic'
 
 type Params = { params: Promise<{ id: string }> }
 
-// La QUALIFICATION relève de la 2ᵉ ligne (risk manager / RSSI / admin) :
-// taxonomie, coût réel, rattachement au registre.
-function peutQualifier(role: UserRole): boolean {
+// La QUALIFICATION relève de la 2ᵉ ligne (risk manager / RSSI / admin). En mode
+// « ligne unique » (2ᵉ ligne désactivée), elle est ouverte à la 1ʳᵉ ligne (tout
+// rôle sauf lecteur) : taxonomie, coût réel, rattachement au registre.
+function peutQualifier(role: UserRole, secondeLigneActive: boolean): boolean {
+  if (!secondeLigneActive) return role !== 'LECTEUR'
   return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
 }
 
@@ -35,7 +37,7 @@ async function loadInScope(session: { user: { id: string; role?: string } }, id:
   if (!incident) return { error: NextResponse.json({ error: 'Introuvable' }, { status: 404 }) }
   const orgConfig = await getOrgConfig(incident.organizationId)
   if (!orgConfig.incidentsActive) return { error: NextResponse.json({ error: 'Module non activé' }, { status: 403 }) }
-  return { userId, userRole, incident }
+  return { userId, userRole, incident, secondeLigneActive: orgConfig.secondeLigneActive }
 }
 
 // PATCH /api/incidents/[id] — qualifier, clôturer, rejeter ou corriger.
@@ -63,7 +65,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   const changeEtat = vers !== depuis
   const estDeclarant = incident.declarantId === userId
   if (changeEtat || !(estDeclarant && depuis === 'DECLARE')) {
-    if (!peutQualifier(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+    if (!peutQualifier(userRole, c.secondeLigneActive)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   }
 
   // Passer en QUALIFIE suppose la taxonomie renseignée (objet de la qualification).
@@ -117,7 +119,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   const c = await loadInScope(session as unknown as { user: { id: string; role?: string } }, id)
   if ('error' in c) return c.error
   const { userId, userRole, incident } = c
-  if (!peutQualifier(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutQualifier(userRole, c.secondeLigneActive)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
 
   await prisma.incident.delete({ where: { id } })
   await auditLog('ORGANIZATION_CONFIG_UPDATED', {

--- a/src/app/api/kri/[id]/route.ts
+++ b/src/app/api/kri/[id]/route.ts
@@ -28,7 +28,7 @@ async function loadInScope(session: { user: { id: string; role?: string } }, id:
   if (!kri) return { error: NextResponse.json({ error: 'Introuvable' }, { status: 404 }) }
   const cfg = await getOrgConfig(kri.organizationId)
   if (!cfg.kriActive) return { error: NextResponse.json({ error: 'Module non activé' }, { status: 403 }) }
-  return { userId, userRole, kri }
+  return { userId, userRole, kri, secondeLigneActive: cfg.secondeLigneActive }
 }
 
 // GET /api/kri/[id] — détail + historique des mesures + statut/tendance.
@@ -65,7 +65,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   const { id } = await params
   const c = await loadInScope(session as unknown as { user: { id: string; role?: string } }, id)
   if ('error' in c) return c.error
-  if (!peutDefinirKri(c.userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutDefinirKri(c.userRole, { secondeLigneActive: c.secondeLigneActive })) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))
   const erreur = validateKriInput(body, { partial: true })
@@ -97,7 +97,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   const { id } = await params
   const c = await loadInScope(session as unknown as { user: { id: string; role?: string } }, id)
   if ('error' in c) return c.error
-  if (!peutDefinirKri(c.userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+  if (!peutDefinirKri(c.userRole, { secondeLigneActive: c.secondeLigneActive })) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
 
   await prisma.kri.delete({ where: { id } })
   await auditLog('ORGANIZATION_CONFIG_UPDATED', {

--- a/src/app/api/kri/route.ts
+++ b/src/app/api/kri/route.ts
@@ -15,8 +15,8 @@ export const dynamic = 'force-dynamic'
 
 // La DÉFINITION d'un KRI relève de la 2ᵉ ligne (gouvernance) ; la SAISIE des
 // mesures est ouverte à la 1ʳᵉ ligne (cf. mesures/route.ts). L'admin gère aussi.
-export function peutDefinirKri(role: UserRole): boolean {
-  return peutDefinir2eLigne(role)
+export function peutDefinirKri(role: UserRole, opts?: { secondeLigneActive?: boolean }): boolean {
+  return peutDefinir2eLigne(role, opts)
 }
 
 async function ctx(session: { user: { id: string; role?: string } }) {
@@ -64,7 +64,7 @@ export async function GET() {
     kris,
     // La synthèse ne compte que les KRI actifs (les inactifs ne pilotent plus).
     synthese: synthetiserKri(kris.filter(k => k.actif).map(k => ({ statut: k.statut }))),
-    canDefine: peutDefinirKri(userRole),
+    canDefine: peutDefinirKri(userRole, { secondeLigneActive: cfg.secondeLigneActive }),
     active: true,
   })
 }
@@ -74,9 +74,9 @@ export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions)
   if (!session?.user) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
   const { userId, userRole, orgId } = await ctx(session as unknown as { user: { id: string; role?: string } })
-  if (!peutDefinirKri(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!orgId) return NextResponse.json({ error: 'Aucune organisation active' }, { status: 400 })
   const cfg = await getOrgConfig(orgId)
+  if (!peutDefinirKri(userRole, { secondeLigneActive: cfg.secondeLigneActive })) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
   if (!cfg.kriActive) return NextResponse.json({ error: 'Module non activé' }, { status: 403 })
 
   const body = await req.json().catch(() => ({}))

--- a/src/app/campagnes/page.tsx
+++ b/src/app/campagnes/page.tsx
@@ -23,7 +23,7 @@ export default async function CampagnesPage() {
 
   // Piloter (ouvrir/valider/clôturer) = 2ᵉ ligne ; coter = 1ʳᵉ ligne.
   // Aligné sur le garde de l'API /api/campagnes (peutDefinir2eLigne).
-  const canPilot = peutDefinir2eLigne(userRole)
+  const canPilot = peutDefinir2eLigne(userRole, { secondeLigneActive: orgConfig.secondeLigneActive })
   const canCote = userRole !== 'LECTEUR'
 
   return (

--- a/src/app/controles/campagnes/page.tsx
+++ b/src/app/controles/campagnes/page.tsx
@@ -24,7 +24,7 @@ export default async function CampagnesControlePage() {
   // Définition des campagnes = 2ᵉ ligne (pilotage du plan de contrôle).
   // Aligné sur le garde de l'API /api/controles/campagnes (peutDefinir2eLigne).
   const role = scope.role
-  const canDefine = peutDefinir2eLigne(role)
+  const canDefine = peutDefinir2eLigne(role, { secondeLigneActive: orgConfig.secondeLigneActive })
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">

--- a/src/app/controles/page.tsx
+++ b/src/app/controles/page.tsx
@@ -22,7 +22,7 @@ export default async function ControlesPage() {
 
   // Définir le plan de contrôle = 2ᵉ ligne ; l'exécuter = 1ʳᵉ ligne (tous sauf LECTEUR).
   // Aligné sur le garde de l'API POST /api/controles (peutDefinir2eLigne).
-  const canDefine = peutDefinir2eLigne(userRole)
+  const canDefine = peutDefinir2eLigne(userRole, { secondeLigneActive: orgConfig.secondeLigneActive })
   const canExecute = userRole !== 'LECTEUR'
 
   return (

--- a/src/app/incidents/page.tsx
+++ b/src/app/incidents/page.tsx
@@ -21,7 +21,10 @@ export default async function IncidentsPage() {
   if (!orgConfig.incidentsActive) redirect('/dashboard')
 
   // La déclaration est ouverte à tous (1ʳᵉ ligne) ; la qualification à la 2ᵉ ligne.
-  const canQualify = isAdminRole(userRole) || userRole === 'RISK_MANAGER' || userRole === 'RSSI'
+  // Qualification = 2ᵉ ligne ; en mode ligne unique, ouverte à la 1ʳᵉ ligne (sauf lecteur).
+  const canQualify = orgConfig.secondeLigneActive === false
+    ? userRole !== 'LECTEUR'
+    : (isAdminRole(userRole) || userRole === 'RISK_MANAGER' || userRole === 'RSSI')
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">

--- a/src/app/kri/page.tsx
+++ b/src/app/kri/page.tsx
@@ -22,7 +22,7 @@ export default async function KriPage() {
 
   // Définition = 2ᵉ ligne (gouvernance) ; saisie de mesure = 1ʳᵉ ligne (tout sauf lecteur).
   // Aligné sur le garde de l'API POST /api/kri (peutDefinir2eLigne).
-  const canDefine = peutDefinir2eLigne(userRole)
+  const canDefine = peutDefinir2eLigne(userRole, { secondeLigneActive: orgConfig.secondeLigneActive })
   const canMeasure = userRole !== 'LECTEUR'
 
   return (

--- a/src/lib/derogation.ts
+++ b/src/lib/derogation.ts
@@ -219,10 +219,14 @@ export function canDoubleRegardDerogation(user: SessionUser, d: DerogationRbacSo
  * Le DEMANDEUR ne peut jamais valider sa propre dérogation (séparation des tâches /
  * quatre-yeux, cohérent avec les gardes avis RSSI et double regard — cf. #122).
  */
-export function canValiderDerogation(user: SessionUser, d: DerogationRbacSource): boolean {
-  return d.statut === 'VALIDATION_METIER'
+export function canValiderDerogation(user: SessionUser, d: DerogationRbacSource, opts?: { secondeLigneActive?: boolean }): boolean {
+  const base = d.statut === 'VALIDATION_METIER'
     && (user.role === 'DIRECTION_METIER' || isAdminRole(user.role))
-    && user.id !== d.demandeurId
+  if (!base) return false
+  // Mode « ligne unique » (2ᵉ ligne off) : le quatre-yeux (demandeur ≠ valideur)
+  // est relâché ; sinon il reste imposé (CWE-863, #122).
+  if (opts?.secondeLigneActive === false) return true
+  return user.id !== d.demandeurId
 }
 
 /** Révocation d'une dérogation ACTIVE : RSSI, métier ou admin. */

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -52,7 +52,10 @@ export function isAdminRole(role: UserRole): boolean {
  * Helper CENTRAL : les 3 modules (controles, kri, campagnes) délèguent ici pour
  * rester cohérents (cf. correctif #125).
  */
-export function peutDefinir2eLigne(role: UserRole): boolean {
+export function peutDefinir2eLigne(role: UserRole, opts?: { secondeLigneActive?: boolean }): boolean {
+  // Mode « ligne unique » (org non régulée, 2ᵉ ligne désactivée) : la 1ʳᵉ ligne
+  // réalise elle-même la définition ; ouvert à tout rôle sauf le lecteur.
+  if (opts?.secondeLigneActive === false) return role !== 'LECTEUR'
   return isAdminRole(role) || role === 'RISK_MANAGER' || role === 'RSSI'
     || role === 'CONTROLEUR' || role === 'CONFORMITE'
 }


### PR DESCRIPTION
## Épic « 2ᵉ ligne optionnelle » — Lot 1 (permissions)
Premier effet fonctionnel : en mode **« ligne unique »** (`secondeLigneActive=false`), la 1ʳᵉ ligne réalise les tâches de 2ᵉ ligne et le **quatre-yeux se relâche**. **Défaut inchangé** (mode réglementé).

- `peutDefinir2eLigne(role, { secondeLigneActive })` : off → tout rôle sauf `LECTEUR` (définition contrôles/KRI/campagnes).
- `canValiderDerogation(user, d, { secondeLigneActive })` : off → quatre-yeux (demandeur ≠ valideur, CWE-863) **relâché** ; sinon **imposé** (#122).
- Incidents `peutQualifier(role, secondeLigneActive)` : off → ouvert à la 1ʳᵉ ligne.
- Câblage `getOrgConfig.secondeLigneActive` dans les routes (controles + `[id]` + import + campagnes-contrôle ; kri + `[id]` ; campagnes RCSA + `[id]` ; derogations `[id]` ; incidents `[id]`) et les pages. Alignement au passage de gardes `[id]` hétérogènes sur `peutDefinir2eLigne`.

**Hors périmètre (Lot 2)** : workflow RCSA mono-étape (validation par évaluation) + masquage N2 ; badge « pending » dérogations multi-org laissé standard.

## Qualité
- TDD : +2 tests. `tsc` 0 erreur · **1242 tests verts**.
- ⚠️ Vérif live non réalisée ce jour (démon **Docker de l'hôte non réactif**) → validé par la suite unitaire + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)