### PR TITLE
feat(rbac): 2e ligne optionnelle — workflows RCSA mono-étape + masquage N2 (Lot 2)

### DIFF
--- a/src/__tests__/unit/lib/campagne.test.ts
+++ b/src/__tests__/unit/lib/campagne.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   validateCampagneInput, cleanCampagneInput, transitionCampagneAutorisee,
   validateEvaluationInput, cleanEvaluationInput, evaluationComplete, suggestResiduel,
-  transitionEvaluationAutorisee, peutValider, avancementCampagne,
+  transitionEvaluationAutorisee, peutValider, avancementCampagne, statutApresCotation,
   CAMPAGNE_STATUTS, EVALUATION_STATUTS, EFFICACITES,
 } from '@/lib/campagne'
 
@@ -87,6 +87,16 @@ describe('suggestResiduel', () => {
   it('null si une donnée manque', () => {
     expect(suggestResiduel(null, 'FORTE')).toBeNull()
     expect(suggestResiduel(4, null)).toBeNull()
+  })
+})
+
+describe('statutApresCotation (mode 2ᵉ ligne optionnelle)', () => {
+  it('2ᵉ ligne active (défaut) → COTEE (validation distincte requise)', () => {
+    expect(statutApresCotation(true)).toBe('COTEE')
+    expect(statutApresCotation(undefined)).toBe('COTEE')
+  })
+  it('2ᵉ ligne désactivée (mode ligne unique) → VALIDEE (cotation vaut clôture)', () => {
+    expect(statutApresCotation(false)).toBe('VALIDEE')
   })
 })
 

--- a/src/app/api/campagnes/[id]/evaluations/[evalId]/route.ts
+++ b/src/app/api/campagnes/[id]/evaluations/[evalId]/route.ts
@@ -7,7 +7,7 @@ import { getOrgConfig } from '@/lib/org-config.server'
 import { isAdminRole, type UserRole } from '@/lib/permissions'
 import {
   validateEvaluationInput, cleanEvaluationInput, evaluationComplete,
-  transitionEvaluationAutorisee, peutValider, type EvaluationStatut,
+  transitionEvaluationAutorisee, peutValider, statutApresCotation, type EvaluationStatut,
 } from '@/lib/campagne'
 import { auditLog, getClientIp } from '@/lib/logger'
 
@@ -62,11 +62,15 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   }
 
   const now = new Date()
+  // Mode « ligne unique » (org non régulée, 2ᵉ ligne désactivée) : la cotation vaut
+  // clôture — pas d'étape de validation distincte ni de quatre-yeux.
+  const mono = cfg.secondeLigneActive === false
 
   // ── Validation / rejet (2ᵉ ligne, quatre-yeux) ─────────────────────────────
   if (vers === 'VALIDEE' || vers === 'REJETEE') {
-    if (!peutPiloter(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
-    if (!peutValider(evaluation.evaluateurId, userId)) {
+    // En mode ligne unique, la 1ʳᵉ ligne peut valider elle-même (hors quatre-yeux).
+    if (!mono && !peutPiloter(userRole)) return NextResponse.json({ error: 'Rôle non autorisé' }, { status: 403 })
+    if (!mono && !peutValider(evaluation.evaluateurId, userId)) {
       return NextResponse.json({ error: 'quatre_yeux' }, { status: 403 })
     }
     const motif = typeof body.motifRejet === 'string' ? body.motifRejet.trim() : ''
@@ -96,17 +100,20 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: 'cotation_incomplete' }, { status: 400 })
   }
 
+  // En mode ligne unique, la cotation atteint directement VALIDEE (validation implicite).
+  const statutFinal = vers === 'COTEE' ? statutApresCotation(cfg.secondeLigneActive) : vers
   const updated = await prisma.campagneEvaluation.update({
     where: { id: evalId },
     data: {
       ...data,
-      statut: vers,
+      statut: statutFinal,
       ...(vers === 'COTEE' ? { evaluateurId: userId, coteeLe: now, motifRejet: null } : {}),
+      ...(statutFinal === 'VALIDEE' ? { valideurId: userId, valideeLe: now } : {}),
     },
   })
   await auditLog('ORGANIZATION_CONFIG_UPDATED', {
     userId, userRole, organizationId: evaluation.organizationId, ip: getClientIp(req),
-    details: { scope: 'campagne-evaluation', action: 'coter', campagneId: id, id: evalId },
+    details: { scope: 'campagne-evaluation', action: mono ? 'coter+valider' : 'coter', campagneId: id, id: evalId },
   })
   return NextResponse.json(updated)
 }

--- a/src/app/controles/page.tsx
+++ b/src/app/controles/page.tsx
@@ -29,7 +29,7 @@ export default async function ControlesPage() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <Navbar />
       <main className="max-w-6xl mx-auto px-4 py-8">
-        <ControlesManager canDefine={canDefine} canExecute={canExecute} currentUserName={session.user.name ?? null} />
+        <ControlesManager canDefine={canDefine} canExecute={canExecute} currentUserName={session.user.name ?? null} secondeLigneActive={orgConfig.secondeLigneActive} />
       </main>
     </div>
   )

--- a/src/components/ControlesManager.tsx
+++ b/src/components/ControlesManager.tsx
@@ -64,7 +64,7 @@ const CHECK_BADGE: Record<string, string> = {
   NA: 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-200',
 }
 
-export default function ControlesManager({ canDefine, canExecute, currentUserName }: { canDefine: boolean; canExecute: boolean; currentUserName?: string | null }) {
+export default function ControlesManager({ canDefine, canExecute, currentUserName, secondeLigneActive = true }: { canDefine: boolean; canExecute: boolean; currentUserName?: string | null; secondeLigneActive?: boolean }) {
   const { t, locale } = useTranslation()
   const c = t.controles
   // Formulaire vierge : responsable pré-rempli avec l'utilisateur courant (modifiable).
@@ -310,8 +310,9 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
             )}
           </div>
           {/* Contrôle du contrôle : un contrôle N2 supervise des contrôles N1 (2ᵉ ligne
-              qui vérifie la bonne exécution et l'efficacité de la 1ʳᵉ ligne). */}
-          {form.niveau === 'N2' && (
+              qui vérifie la bonne exécution et l'efficacité de la 1ʳᵉ ligne).
+              Masqué en mode « ligne unique » (2ᵉ ligne désactivée). */}
+          {secondeLigneActive && form.niveau === 'N2' && (
             <div>
               <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">{c.supervise} <span className="text-gray-400">— {c.superviseHint}</span> ({form.superviseIds.length})</div>
               {controles.filter(x => x.niveau === 'N1' && x.id !== editId).length === 0
@@ -563,8 +564,9 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
                             </ul>
                           )}
                         </div>
-                        {/* Indépendance de l'exécutant (séparation des fonctions) — contrôle N2 */}
-                        {x.niveau === 'N2' && (
+                        {/* Indépendance de l'exécutant (séparation des fonctions) — contrôle N2.
+                            Masqué en mode « ligne unique » (2ᵉ ligne désactivée). */}
+                        {secondeLigneActive && x.niveau === 'N2' && (
                           <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
                             <input type="checkbox" checked={exec.independant} onChange={e => setExec(f => ({ ...f, independant: e.target.checked }))} />
                             {c.independantLabel}

--- a/src/lib/campagne.ts
+++ b/src/lib/campagne.ts
@@ -155,6 +155,16 @@ export function peutValider(evaluateurId: string | null, valideurId: string): bo
   return evaluateurId !== valideurId
 }
 
+/**
+ * Statut atteint par une évaluation dès la cotation, selon la présence d'une 2ᵉ ligne.
+ * 2ᵉ ligne active (défaut) : COTEE (une validation distincte, en quatre-yeux, suit).
+ * 2ᵉ ligne désactivée (mode ligne unique, org non régulée) : VALIDEE — la cotation
+ * de la 1ʳᵉ ligne vaut clôture, sans étape de validation séparée.
+ */
+export function statutApresCotation(secondeLigneActive?: boolean): EvaluationStatut {
+  return secondeLigneActive === false ? 'VALIDEE' : 'COTEE'
+}
+
 // ─── Avancement ──────────────────────────────────────────────────────────────
 
 export interface EvaluationLite { statut: string }


### PR DESCRIPTION
## Lot 2/3 — 2ᵉ ligne optionnelle : workflows
Mode **« ligne unique »** (`secondeLigneActive=false`, organisation non régulée) :

- **RCSA** : la cotation de la 1ʳᵉ ligne **vaut clôture** — l'évaluation atteint directement `VALIDEE` (`statutApresCotation`, pur+testé), sans étape de validation distincte ni quatre-yeux. En mode réglementé (défaut) : **inchangé** (`COTEE` puis `VALIDEE` en quatre-yeux).
- **ControlesManager** : masque le **contrôle du contrôle N2→N1** et l'**attestation d'indépendance** quand la 2ᵉ ligne est désactivée.

## Sécurité
Le relâchement du quatre-yeux RCSA est **strictement conditionné** à `secondeLigneActive=false` (choix org explicite, verrouillable par l'instance).

## Vérifié LIVE (Docker relancé)
- **mono** : cotation ⇒ `VALIDEE`, valideur = évaluateur (même user), 200 ;
- **réglementé** : cotation reste `COTEE`, auto-validation empêchée, self-validate ⇒ **403 `quatre_yeux`** (contrôle de sécurité intact).
- TDD : +2 tests. `tsc` 0 erreur · **1244 tests verts**.

Reste : Lot 3 (reporting fusion 1ʳᵉ/2ᵉ ligne + vocabulaire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)