### PR TITLE
feat(audit): 4e niveau — source auditeur externe + suivi de contrôle externe

### DIFF
--- a/docs/specs/quatre-niveaux-controle.md
+++ b/docs/specs/quatre-niveaux-controle.md
@@ -1,0 +1,39 @@
+# Spec — Suivis des 4 niveaux de contrôle + 4ᵉ niveau externe
+
+Demande : suivi spécifique des **constats régulateur / plan d'action autorité de
+contrôle**, en distinguant le **4ᵉ niveau** qui peut être une **autorité de contrôle
+(régulateur)** OU un **auditeur externe** (commissaire aux comptes / audit tiers) ;
+et **mettre en place des suivis pour les 4 niveaux de contrôle**.
+
+## Modèle des 4 niveaux
+| Niveau | Nature | Source dans ACRA |
+|-------|--------|------------------|
+| **N1** | Contrôle permanent — 1ʳᵉ ligne (opérationnel) | `Controle.niveau = N1` + ses exécutions |
+| **N2** | Contrôle permanent — 2ᵉ ligne (fonction de contrôle) | `Controle.niveau = N2` |
+| **N3** | Contrôle périodique — audit interne (3ᵉ ligne) | `AuditConstat.source = AUDIT_INTERNE` |
+| **N4** | Contrôle externe | `AuditConstat.source = REGULATEUR` (autorité) **ou** `AUDITEUR_EXTERNE` (audit tiers) |
+
+## Chantier A — 4ᵉ niveau : source « auditeur externe » + suivi externe
+- `CONSTAT_SOURCES` étendu : `AUDIT_INTERNE | REGULATEUR | AUDITEUR_EXTERNE`.
+- `SOURCE_NIVEAU` / `niveauControle(source)` (pur) : mappe la source au niveau
+  (AUDIT_INTERNE→N3 ; REGULATEUR, AUDITEUR_EXTERNE→N4).
+- Suivi externe : `filtrerControleExterne` (REGULATEUR ∪ AUDITEUR_EXTERNE) ; la vue
+  « suivi régulateur » devient « suivi autorité de contrôle & audit externe »,
+  couvrant les deux sources, avec plan d'action (responsable, échéance, statut,
+  retard) et export.
+- UI : le formulaire de constat propose la source « auditeur externe » ; filtre par
+  source. i18n 5 langues.
+- Sans migration (`source` est une colonne texte ; nouvelle valeur d'énumération).
+
+## Chantier B — Suivi consolidé des 4 niveaux
+- Fonction pure `synthetiserQuatreNiveaux({ n1, n2, n3, n4 })` → 4 lignes, chacune
+  avec : activité (contrôles/missions), anomalies/constats **ouverts**, **en retard**.
+- Section « Suivi des 4 niveaux de contrôle » dans `/pilotage` (cockpit GRC) :
+  agrège N1/N2 (contrôle permanent par niveau), N3 (constats audit interne), N4
+  (constats externes), par sous-arbre d'organisation.
+
+## Tests
+- Unitaires : `niveauControle`, `filtrerControleExterne`, synthèse externe,
+  `synthetiserQuatreNiveaux` (nominal + limites).
+- Runtime : création d'un constat AUDITEUR_EXTERNE, présence dans le suivi externe,
+  section 4 niveaux du cockpit.

--- a/src/__tests__/unit/lib/audit.test.ts
+++ b/src/__tests__/unit/lib/audit.test.ts
@@ -3,8 +3,25 @@ import {
   validateMissionInput, cleanMissionInput, transitionMissionAutorisee, prochaineFenetreMission,
   filtrerMissions, filtrerConstats,
   validateConstatInput, cleanConstatInput, constatTermine, constatEnRetard, synthetiserConstats,
-  MISSION_STATUTS, CONSTAT_STATUTS, CONSTAT_SOURCES,
+  MISSION_STATUTS, CONSTAT_STATUTS, CONSTAT_SOURCES, niveauControle, SOURCE_NIVEAU,
 } from '@/lib/audit'
+
+describe('4ᵉ niveau — source de constat & niveau de contrôle', () => {
+  it('CONSTAT_SOURCES inclut l\'auditeur externe (4ᵉ niveau)', () => {
+    expect([...CONSTAT_SOURCES]).toEqual(['AUDIT_INTERNE', 'REGULATEUR', 'AUDITEUR_EXTERNE'])
+  })
+  it('niveauControle : audit interne = N3 ; régulateur & auditeur externe = N4', () => {
+    expect(niveauControle('AUDIT_INTERNE')).toBe('N3')
+    expect(niveauControle('REGULATEUR')).toBe('N4')
+    expect(niveauControle('AUDITEUR_EXTERNE')).toBe('N4')
+    expect(SOURCE_NIVEAU.AUDITEUR_EXTERNE).toBe('N4')
+  })
+  it('cleanConstatInput accepte la nouvelle source', () => {
+    expect(cleanConstatInput({ intitule: 'X', source: 'AUDITEUR_EXTERNE' }).source).toBe('AUDITEUR_EXTERNE')
+    expect(validateConstatInput({ intitule: 'X', source: 'AUDITEUR_EXTERNE' })).toBeNull()
+    expect(validateConstatInput({ intitule: 'X', source: 'BOGUS' })).toBe('source_invalide')
+  })
+})
 
 describe('validateMissionInput', () => {
   it('intitulé requis', () => {
@@ -165,7 +182,7 @@ describe('énumérations', () => {
   it('statuts et sources', () => {
     expect([...MISSION_STATUTS]).toEqual(['PLANIFIEE', 'EN_COURS', 'CLOTUREE'])
     expect([...CONSTAT_STATUTS]).toEqual(['OUVERT', 'EN_COURS', 'RESOLU', 'ACCEPTE'])
-    expect([...CONSTAT_SOURCES]).toEqual(['AUDIT_INTERNE', 'REGULATEUR'])
+    expect([...CONSTAT_SOURCES]).toEqual(['AUDIT_INTERNE', 'REGULATEUR', 'AUDITEUR_EXTERNE'])
   })
 
   it('validateMissionInput partial: intitulé non requis si absent', () => {

--- a/src/__tests__/unit/lib/suivi-regulateur.test.ts
+++ b/src/__tests__/unit/lib/suivi-regulateur.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   filtrerRegulateur,
+  filtrerControleExterne,
   synthetiserSuiviRegulateur,
   prochaineEcheanceRegulateur,
   suiviRegulateurToCsvRow,
@@ -24,6 +25,13 @@ describe('filtrerRegulateur', () => {
   it('ne garde que les constats de source REGULATEUR', () => {
     const list = [c({ id: '1', source: 'REGULATEUR' }), c({ id: '2', source: 'AUDIT_INTERNE' })]
     expect(filtrerRegulateur(list).map(x => x.id)).toEqual(['1'])
+  })
+})
+
+describe('filtrerControleExterne (4ᵉ niveau)', () => {
+  it('garde régulateur ET auditeur externe, exclut l\'audit interne', () => {
+    const list = [c({ id: '1', source: 'REGULATEUR' }), c({ id: '2', source: 'AUDIT_INTERNE' }), c({ id: '3', source: 'AUDITEUR_EXTERNE' })]
+    expect(filtrerControleExterne(list).map(x => x.id)).toEqual(['1', '3'])
   })
 })
 

--- a/src/app/api/reglementaire/suivi-regulateur/route.ts
+++ b/src/app/api/reglementaire/suivi-regulateur/route.ts
@@ -31,7 +31,8 @@ export async function GET(req: NextRequest) {
   if (!cfg.reglementaireActive) return NextResponse.json({ active: false, constats: [] })
 
   const rows = await prisma.auditConstat.findMany({
-    where: { organizationId: orgId, source: 'REGULATEUR' },
+    // Contrôle EXTERNE (4ᵉ niveau) : autorité de contrôle + auditeur externe.
+    where: { organizationId: orgId, source: { in: ['REGULATEUR', 'AUDITEUR_EXTERNE'] } },
     include: { mission: { select: { intitule: true } } },
     orderBy: [{ echeance: 'asc' }, { criticite: 'desc' }],
   })

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -9,8 +9,24 @@ import { cleanChecklist, cleanChecklistResultats, cleanExigenceRefs, type Checkl
 export const MISSION_STATUTS = ['PLANIFIEE', 'EN_COURS', 'CLOTUREE'] as const
 export type MissionStatut = (typeof MISSION_STATUTS)[number]
 
-export const CONSTAT_SOURCES = ['AUDIT_INTERNE', 'REGULATEUR'] as const
+// Source d'un constat : audit interne (3ᵉ ligne / N3), ou contrôle EXTERNE (4ᵉ
+// niveau) qui peut être une autorité de contrôle (REGULATEUR) ou un auditeur
+// externe / commissaire aux comptes (AUDITEUR_EXTERNE).
+export const CONSTAT_SOURCES = ['AUDIT_INTERNE', 'REGULATEUR', 'AUDITEUR_EXTERNE'] as const
 export type ConstatSource = (typeof CONSTAT_SOURCES)[number]
+
+/** Niveau du dispositif de contrôle porté par la source du constat. */
+export type NiveauControle = 'N3' | 'N4'
+export const SOURCE_NIVEAU: Record<ConstatSource, NiveauControle> = {
+  AUDIT_INTERNE: 'N3',       // contrôle périodique / audit interne (3ᵉ ligne)
+  REGULATEUR: 'N4',          // contrôle externe — autorité de contrôle
+  AUDITEUR_EXTERNE: 'N4',    // contrôle externe — audit tiers / commissaire aux comptes
+}
+export function niveauControle(source: string): NiveauControle {
+  return SOURCE_NIVEAU[source as ConstatSource] ?? 'N3'
+}
+/** Sources de contrôle EXTERNE (4ᵉ niveau) : régulateur + auditeur externe. */
+export const SOURCES_EXTERNES: ConstatSource[] = ['REGULATEUR', 'AUDITEUR_EXTERNE']
 
 // Suivi d'un constat/recommandation : ouvert → en cours → résolu (ou accepté
 // par la direction si le risque est assumé sans remédiation).

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1463,7 +1463,8 @@ export const de: Translations = {
     },
     sources: {
       AUDIT_INTERNE: 'Interne Revision',
-      REGULATEUR: 'Aufsicht',
+      REGULATEUR: 'Aufsicht / Aufsichtsbehörde',
+      AUDITEUR_EXTERNE: 'Externer Prüfer (Abschlussprüfer / Dritter)',
     },
     errors: {
       intitule_requis: 'Titel ist erforderlich.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1463,7 +1463,8 @@ export const en: Translations = {
     },
     sources: {
       AUDIT_INTERNE: 'Internal audit',
-      REGULATEUR: 'Regulator',
+      REGULATEUR: 'Regulator / supervisory authority',
+      AUDITEUR_EXTERNE: 'External auditor (statutory / third-party)',
     },
     errors: {
       intitule_requis: 'Title is required.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1463,7 +1463,8 @@ export const es: Translations = {
     },
     sources: {
       AUDIT_INTERNE: 'Auditoría interna',
-      REGULATEUR: 'Regulador',
+      REGULATEUR: 'Regulador / autoridad de control',
+      AUDITEUR_EXTERNE: 'Auditor externo (cuentas / terceros)',
     },
     errors: {
       intitule_requis: 'El título es obligatorio.',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1486,7 +1486,8 @@ export const fr = {
     },
     sources: {
       AUDIT_INTERNE: 'Audit interne',
-      REGULATEUR: 'Régulateur',
+      REGULATEUR: 'Régulateur / autorité de contrôle',
+      AUDITEUR_EXTERNE: 'Auditeur externe (CAC / tiers)',
     },
     errors: {
       intitule_requis: 'L\'intitulé est requis.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1463,7 +1463,8 @@ export const it: Translations = {
     },
     sources: {
       AUDIT_INTERNE: 'Audit interno',
-      REGULATEUR: 'Regolatore',
+      REGULATEUR: 'Regolatore / autorità di controllo',
+      AUDITEUR_EXTERNE: 'Revisore esterno (conti / terzi)',
     },
     errors: {
       intitule_requis: 'Il titolo è obbligatorio.',

--- a/src/lib/suivi-regulateur.ts
+++ b/src/lib/suivi-regulateur.ts
@@ -35,6 +35,15 @@ export function filtrerRegulateur<T extends { source: string }>(constats: T[]): 
   return constats.filter(c => c.source === 'REGULATEUR')
 }
 
+/**
+ * Ne conserve que les constats de CONTRÔLE EXTERNE (4ᵉ niveau) : autorité de
+ * contrôle (REGULATEUR) OU auditeur externe / commissaire aux comptes
+ * (AUDITEUR_EXTERNE).
+ */
+export function filtrerControleExterne<T extends { source: string }>(constats: T[]): T[] {
+  return constats.filter(c => c.source === 'REGULATEUR' || c.source === 'AUDITEUR_EXTERNE')
+}
+
 export interface SuiviRegulateurSynthese {
   total: number
   ouverts: number // non terminés


### PR DESCRIPTION
## Épic « 4 niveaux » — PR A : 4ᵉ niveau externe
Le **4ᵉ niveau de contrôle (externe)** peut être une **autorité de contrôle** (régulateur) **ou** un **auditeur externe** (commissaire aux comptes / tiers).

- `CONSTAT_SOURCES` += `AUDITEUR_EXTERNE` ; `SOURCE_NIVEAU` / `niveauControle` (purs) mappent la source au niveau (`AUDIT_INTERNE→N3` ; `REGULATEUR`, `AUDITEUR_EXTERNE→N4`).
- **Suivi externe** : `filtrerControleExterne` (REGULATEUR ∪ AUDITEUR_EXTERNE) ; la vue de suivi couvre les **deux sources externes** (plan d'action : responsable, échéance, statut, retard, export).
- API `/reglementaire/suivi-regulateur` : requête élargie aux deux sources.
- UI constat : source « auditeur externe » au formulaire ; i18n 5 langues.
- **Sans migration** (source = colonne texte).

## Qualité
- TDD : +4 tests. `tsc` 0 erreur · **1250 tests verts**.
- Vérifié live : constat `AUDITEUR_EXTERNE` (201) présent dans le suivi externe.

Voir [`docs/specs/quatre-niveaux-controle.md`](docs/specs/quatre-niveaux-controle.md). Suite (PR B) : suivi consolidé des 4 niveaux dans le cockpit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)