### PR TITLE
fix(cron): auth par en-tête uniquement + constant-time (#127, CWE-598)

### DIFF
--- a/src/__tests__/unit/lib/cron-auth.test.ts
+++ b/src/__tests__/unit/lib/cron-auth.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { assertCronAuth, cronSecretMatches } from '@/lib/cron-auth'
+
+function reqWith(headers: Record<string, string> = {}, url = 'https://acra.example/api/cron/x') {
+  const h = new Headers(headers)
+  // Objet minimal compatible avec assertCronAuth (headers.get + nextUrl).
+  return { headers: h, nextUrl: new URL(url), url } as unknown as Parameters<typeof assertCronAuth>[0]
+}
+
+describe('cronSecretMatches (temps constant)', () => {
+  it('vrai uniquement pour une correspondance exacte', () => {
+    expect(cronSecretMatches('s3cret', 's3cret')).toBe(true)
+    expect(cronSecretMatches('s3cret', 'other!')).toBe(false)
+    expect(cronSecretMatches('', 's3cret')).toBe(false)
+    expect(cronSecretMatches('court', 's3cret-plus-long')).toBe(false) // longueurs différentes
+  })
+})
+
+describe('assertCronAuth', () => {
+  const OLD = process.env.CRON_SECRET
+  beforeEach(() => { process.env.CRON_SECRET = 'top-secret-value' })
+  afterEach(() => { if (OLD === undefined) delete process.env.CRON_SECRET; else process.env.CRON_SECRET = OLD })
+
+  it('autorise via l\'en-tête Authorization: Bearer (retourne null)', () => {
+    expect(assertCronAuth(reqWith({ authorization: 'Bearer top-secret-value' }))).toBeNull()
+  })
+
+  it('REJETTE le secret passé en query-string ?token= (CWE-598)', async () => {
+    const res = assertCronAuth(reqWith({}, 'https://acra.example/api/cron/x?token=top-secret-value'))
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(401)
+  })
+
+  it('401 si l\'en-tête ne correspond pas ou est absent', () => {
+    expect(assertCronAuth(reqWith({ authorization: 'Bearer wrong' }))!.status).toBe(401)
+    expect(assertCronAuth(reqWith({}))!.status).toBe(401)
+  })
+
+  it('fail-closed : 503 si CRON_SECRET absent', () => {
+    delete process.env.CRON_SECRET
+    expect(assertCronAuth(reqWith({ authorization: 'Bearer anything' }))!.status).toBe(503)
+  })
+})

--- a/src/app/api/cron/conformite-snapshots/route.ts
+++ b/src/app/api/cron/conformite-snapshots/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { assertCronAuth } from '@/lib/cron-auth'
 import { prisma } from '@/lib/prisma'
 import { getOrgConfig } from '@/lib/org-config.server'
 import { sanitizeConformite } from '@/lib/conformite'
@@ -16,11 +17,8 @@ import { sanitizeSnapshotMode, dueForAutoSnapshot } from '@/lib/conformite-confi
  * ne correspond pas. Aucune donnée métier retournée.
  */
 export async function POST(req: NextRequest) {
-  const secret = process.env.CRON_SECRET
-  if (!secret) return NextResponse.json({ error: 'Cron désactivé (CRON_SECRET absent)' }, { status: 503 })
-  const auth = req.headers.get('authorization') ?? ''
-  const token = auth.startsWith('Bearer ') ? auth.slice(7) : req.nextUrl.searchParams.get('token') ?? ''
-  if (token !== secret) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  const denied = assertCronAuth(req)
+  if (denied) return denied
 
   const now = new Date()
   const confs = await prisma.conformite.findMany({

--- a/src/app/api/cron/controles-echeances/route.ts
+++ b/src/app/api/cron/controles-echeances/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { assertCronAuth } from '@/lib/cron-auth'
 import { prisma } from '@/lib/prisma'
 import { getOrgConfig } from '@/lib/org-config.server'
 import { prochaineEcheance, etatEcheance, type Periodicite } from '@/lib/controle'
@@ -21,11 +22,8 @@ const RECIPIENT_ROLES = ['RSSI', 'ADMIN', 'RISK_MANAGER'] as const
  * 503 si CRON_SECRET absent ; 401 si le secret ne correspond pas.
  */
 export async function POST(req: NextRequest) {
-  const secret = process.env.CRON_SECRET
-  if (!secret) return NextResponse.json({ error: 'Cron désactivé (CRON_SECRET absent)' }, { status: 503 })
-  const auth = req.headers.get('authorization') ?? ''
-  const token = auth.startsWith('Bearer ') ? auth.slice(7) : req.nextUrl.searchParams.get('token') ?? ''
-  if (token !== secret) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  const denied = assertCronAuth(req)
+  if (denied) return denied
 
   const now = new Date()
   const candidats = await prisma.controle.findMany({

--- a/src/app/api/cron/demo-purge/route.ts
+++ b/src/app/api/cron/demo-purge/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { assertCronAuth } from '@/lib/cron-auth'
 import { purgeExpiredDemoOrgs, warnExpiringDemoOrgs, isDemoInstance } from '@/lib/demo-server'
 import { auditLog } from '@/lib/logger'
 
@@ -18,11 +19,8 @@ import { auditLog } from '@/lib/logger'
  * erreur en démo reste stampée PROD → purge refusée (garde-fou anti-destruction).
  */
 export async function POST(req: NextRequest) {
-  const secret = process.env.CRON_SECRET
-  if (!secret) return NextResponse.json({ error: 'Cron désactivé (CRON_SECRET absent)' }, { status: 503 })
-  const auth = req.headers.get('authorization') ?? ''
-  const token = auth.startsWith('Bearer ') ? auth.slice(7) : req.nextUrl.searchParams.get('token') ?? ''
-  if (token !== secret) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  const denied = assertCronAuth(req)
+  if (denied) return denied
 
   // Garde-fou : ne JAMAIS purger hors d'une instance de démo prouvée (env + marqueur figé).
   if (!(await isDemoInstance())) {

--- a/src/app/api/cron/derogations-digest/route.ts
+++ b/src/app/api/cron/derogations-digest/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { assertCronAuth } from '@/lib/cron-auth'
 import { prisma } from '@/lib/prisma'
 import { getOrgConfig } from '@/lib/org-config.server'
 import { buildDerogationDigest, type DigestSource } from '@/lib/derogation'
@@ -21,11 +22,8 @@ const RECIPIENT_ROLES = ['RSSI', 'ADMIN', 'RISK_MANAGER'] as const
  * 503 si CRON_SECRET absent ; 401 si le secret ne correspond pas.
  */
 export async function POST(req: NextRequest) {
-  const secret = process.env.CRON_SECRET
-  if (!secret) return NextResponse.json({ error: 'Cron désactivé (CRON_SECRET absent)' }, { status: 503 })
-  const auth = req.headers.get('authorization') ?? ''
-  const token = auth.startsWith('Bearer ') ? auth.slice(7) : req.nextUrl.searchParams.get('token') ?? ''
-  if (token !== secret) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  const denied = assertCronAuth(req)
+  if (denied) return denied
 
   const now = new Date()
   const actives = await prisma.derogation.findMany({

--- a/src/app/api/cron/derogations-expiry/route.ts
+++ b/src/app/api/cron/derogations-expiry/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { assertCronAuth } from '@/lib/cron-auth'
 import { prisma } from '@/lib/prisma'
 import { getOrgConfig } from '@/lib/org-config.server'
 import { needsExpiryAlert, joursAvantExpiration, type DerogationStatut } from '@/lib/derogation'
@@ -23,11 +24,8 @@ const RECIPIENT_ROLES = ['RSSI', 'ADMIN', 'RISK_MANAGER'] as const
  * 503 si CRON_SECRET absent ; 401 si le secret ne correspond pas.
  */
 export async function POST(req: NextRequest) {
-  const secret = process.env.CRON_SECRET
-  if (!secret) return NextResponse.json({ error: 'Cron désactivé (CRON_SECRET absent)' }, { status: 503 })
-  const auth = req.headers.get('authorization') ?? ''
-  const token = auth.startsWith('Bearer ') ? auth.slice(7) : req.nextUrl.searchParams.get('token') ?? ''
-  if (token !== secret) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  const denied = assertCronAuth(req)
+  if (denied) return denied
 
   const now = new Date()
   const candidates = await prisma.derogation.findMany({

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,0 +1,31 @@
+// ─── Authentification des endpoints cron (planificateur externe) ─────────────
+// Convention UNIQUE partagée par toutes les routes /api/cron/* : le secret
+// d'infrastructure (CRON_SECRET) est présenté par l'en-tête
+// `Authorization: Bearer <CRON_SECRET>` — JAMAIS en query-string (le secret ne
+// doit pas transiter dans l'URL : journalisé par le proxy/les logs/Referer,
+// CWE-598). Comparaison à temps constant (CWE-208). Fail-closed.
+
+import { NextResponse } from 'next/server'
+import { timingSafeEqual } from 'crypto'
+
+/** Comparaison à temps constant du jeton présenté et du secret (longueurs égales requises). */
+export function cronSecretMatches(token: string, secret: string): boolean {
+  const a = Buffer.from(token, 'utf8')
+  const b = Buffer.from(secret, 'utf8')
+  if (a.length === 0 || a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+/**
+ * Garde d'authentification d'un appel cron. Retourne une NextResponse d'erreur
+ * (503 si CRON_SECRET absent, 401 sinon), ou `null` si l'appel est autorisé.
+ * N'accepte que l'en-tête Authorization (pas de fallback query-string).
+ */
+export function assertCronAuth(req: { headers: { get(name: string): string | null } }): NextResponse | null {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return NextResponse.json({ error: 'Cron désactivé (CRON_SECRET absent)' }, { status: 503 })
+  const auth = req.headers.get('authorization') ?? ''
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : ''
+  if (!cronSecretMatches(token, secret)) return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
+  return null
+}


### PR DESCRIPTION
## #127 — CRON_SECRET exposé en query-string (CWE-598)
Les 5 routes `/api/cron/*` acceptaient le `CRON_SECRET` via un **fallback query-string** (`?token=…`) → le secret d'infrastructure **transitait dans l'URL** (journalisé par le reverse-proxy, les logs applicatifs, l'en-tête `Referer`). CWE-598 / OWASP A09.

- **Helper pur** `lib/cron-auth.ts` : `assertCronAuth(req)` n'accepte **que** l'en-tête `Authorization: Bearer <CRON_SECRET>` (plus de query-string), avec **comparaison à temps constant** (`crypto.timingSafeEqual`, CWE-208) et **fail-closed** (503 si `CRON_SECRET` absent).
- Les **5 routes** (`derogations-digest`, `controles-echeances`, `demo-purge`, `derogations-expiry`, `conformite-snapshots`) consomment le helper → **une seule convention**, plus de dérive par-route.

Aucun appelant légitime n'utilisait le fallback (le scheduler n'envoie que l'en-tête Bearer) → **pas de régression**.

## Qualité
- TDD : **+5 tests** (`cron-auth.test.ts`). `tsc` 0 erreur · **1268 tests verts**.
- **Vérifié live** : `?token=<secret>` → **401** (fallback supprimé), en-tête correct → auth OK (`demo-purge` → 400 par sa garde démo), fail-closed 503 préservé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)