### PR TITLE
feat(api-v1): import en masse de risques et contrôles (scope write)

### DIFF
--- a/src/__tests__/unit/lib/api-import.test.ts
+++ b/src/__tests__/unit/lib/api-import.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { prepareImport, API_IMPORT_MAX } from '@/lib/api-import'
+
+// Validateur/nettoyeur factices (le vrai import réutilise les libs métier testées).
+const validate = (i: { nom?: string }) => (i && typeof i.nom === 'string' && i.nom.trim() ? null : 'nom_requis')
+const clean = (i: { nom: string }) => ({ nom: i.nom.trim().toUpperCase() })
+
+describe('prepareImport', () => {
+  it('sépare valides (nettoyés) et erreurs (par index)', () => {
+    const r = prepareImport([{ nom: ' a ' }, { nom: '' }, { nom: 'b' }], validate, clean)
+    expect(r.valid).toEqual([{ nom: 'A' }, { nom: 'B' }])
+    expect(r.errors).toEqual([{ index: 1, error: 'nom_requis' }])
+    expect(r.skipped).toBe(0)
+  })
+  it('cape la cardinalité et compte les ignorés', () => {
+    const items = Array.from({ length: 12 }, (_, i) => ({ nom: `n${i}` }))
+    const r = prepareImport(items, validate, clean, 10)
+    expect(r.valid).toHaveLength(10)
+    expect(r.skipped).toBe(2)
+  })
+  it('item malformé (validateur qui lève) → erreur, pas de crash', () => {
+    const throwing = (i: { nom: string }) => (i.nom ? null : 'x') // lève sur null
+    const r = prepareImport([null, { nom: 'ok' }], throwing, clean)
+    expect(r.errors).toEqual([{ index: 0, error: 'item_invalide' }])
+    expect(r.valid).toEqual([{ nom: 'OK' }])
+  })
+  it('entrée non-tableau → vide', () => {
+    expect(prepareImport('x', validate, clean)).toEqual({ valid: [], errors: [], skipped: 0 })
+  })
+  it('cap par défaut = 500', () => {
+    expect(API_IMPORT_MAX).toBe(500)
+  })
+})

--- a/src/app/api/v1/import/route.ts
+++ b/src/app/api/v1/import/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { authenticateApiRequest } from '@/lib/api-auth.server'
+import { getOrgConfig } from '@/lib/org-config.server'
+import { prepareImport, type ImportItemError } from '@/lib/api-import'
+import { validateRiskItemInput, cleanRiskItem } from '@/lib/risk-item'
+import { validateControleInput, cleanControleInput } from '@/lib/controle'
+import { auditLog, getClientIp } from '@/lib/logger'
+
+export const dynamic = 'force-dynamic'
+
+// POST /api/v1/import — import EN MASSE de risques et/ou contrôles (scope write).
+// Body : { risks?: [...], controls?: [...] }. Chaque item est validé par la lib
+// métier ; les invalides sont remontés par index (l'import continue). Porté à
+// l'organisation de la clé.
+export async function POST(req: NextRequest) {
+  const auth = await authenticateApiRequest(req, 'write')
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const cfg = await getOrgConfig(auth.organizationId)
+  const body = await req.json().catch(() => ({}))
+
+  const created: Record<string, number> = {}
+  const skipped: Record<string, number> = {}
+  const errors: (ImportItemError & { resource: string })[] = []
+
+  // ── Risques ────────────────────────────────────────────────────────────────
+  if (Array.isArray(body.risks)) {
+    if (!cfg.registreRisquesActive) {
+      errors.push({ resource: 'risks', index: -1, error: 'module_inactif' })
+    } else {
+      const p = prepareImport(body.risks, validateRiskItemInput, cleanRiskItem)
+      if (p.valid.length) {
+        await prisma.riskItem.createMany({ data: p.valid.map(v => ({ ...v, organizationId: auth.organizationId, provenance: 'API' })) })
+      }
+      created.risks = p.valid.length
+      skipped.risks = p.skipped
+      p.errors.forEach(e => errors.push({ resource: 'risks', ...e }))
+    }
+  }
+
+  // ── Contrôles ────────────────────────────────────────────────────────────────
+  if (Array.isArray(body.controls)) {
+    if (!cfg.controlePermanentActive) {
+      errors.push({ resource: 'controls', index: -1, error: 'module_inactif' })
+    } else {
+      const p = prepareImport(body.controls, validateControleInput, cleanControleInput)
+      if (p.valid.length) {
+        await prisma.controle.createMany({ data: p.valid.map(v => ({ ...v, organizationId: auth.organizationId })) as never })
+      }
+      created.controls = p.valid.length
+      skipped.controls = p.skipped
+      p.errors.forEach(e => errors.push({ resource: 'controls', ...e }))
+    }
+  }
+
+  const totalCreated = Object.values(created).reduce((s, n) => s + n, 0)
+  await auditLog('ORGANIZATION_CONFIG_UPDATED', {
+    userId: `apikey:${auth.keyId}`, userRole: 'API', organizationId: auth.organizationId, ip: getClientIp(req),
+    details: { scope: 'api-import', created, skipped, errors: errors.length },
+  })
+  return NextResponse.json({ created, skipped, errors }, { status: totalCreated > 0 || errors.length === 0 ? 201 : 400 })
+}

--- a/src/app/api/v1/openapi.json/route.ts
+++ b/src/app/api/v1/openapi.json/route.ts
@@ -52,6 +52,32 @@ export async function GET() {
       '/risks': { get: { summary: 'Registre de risques', operationId: 'listRisks', responses: listResponse('#/components/schemas/Risk') } },
       '/controls': { get: { summary: 'Bibliothèque de contrôles', operationId: 'listControls', responses: listResponse('#/components/schemas/Control') } },
       '/incidents': { get: { summary: 'Incidents & pertes (LDC)', operationId: 'listIncidents', responses: listResponse('#/components/schemas/Incident') } },
+      '/import': {
+        post: {
+          summary: 'Import en masse (risques, contrôles)',
+          operationId: 'bulkImport',
+          description: 'Nécessite le scope write. Corps { risks?: [...], controls?: [...] }. Chaque item est validé ; les invalides sont remontés par index (l\'import continue). Plafond de 500 items par ressource.',
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    risks: { type: 'array', items: { type: 'object' } },
+                    controls: { type: 'array', items: { type: 'object' } },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '201': { description: 'Import traité', content: { 'application/json': { schema: { type: 'object', properties: { created: { type: 'object' }, skipped: { type: 'object' }, errors: { type: 'array', items: { type: 'object', properties: { resource: { type: 'string' }, index: { type: 'integer' }, error: { type: 'string' } } } } } } } } },
+            '400': { description: 'Aucun item créé (erreurs de validation ou module inactif)' },
+            '401': { description: 'Authentification requise' },
+            '403': { description: 'Scope write requis' },
+          },
+        },
+      },
     },
   }
   return NextResponse.json(spec)

--- a/src/lib/api-import.ts
+++ b/src/lib/api-import.ts
@@ -1,0 +1,38 @@
+// ─── Import en masse via l'API publique v1 ───────────────────────────────────
+// Prépare un lot d'items (risques, contrôles) : valide chacun avec le validateur
+// métier existant, nettoie les valides, cape la cardinalité et remonte les erreurs
+// par index. Logique PURE (réutilise les libs testées) → testable sans DB.
+
+export const API_IMPORT_MAX = 500
+
+export interface ImportItemError { index: number; error: string }
+export interface PreparedImport<C> { valid: C[]; errors: ImportItemError[]; skipped: number }
+
+/**
+ * Valide + nettoie une liste d'items d'import. `validate` renvoie un code d'erreur
+ * i18n ou null ; les valides sont nettoyés par `clean`. Au-delà de `cap`, les items
+ * excédentaires sont ignorés (comptés dans `skipped`).
+ */
+export function prepareImport<I, C>(
+  items: unknown,
+  validate: (i: I) => string | null,
+  clean: (i: I) => C,
+  cap: number = API_IMPORT_MAX,
+): PreparedImport<C> {
+  if (!Array.isArray(items)) return { valid: [], errors: [], skipped: 0 }
+  const capped = items.slice(0, cap)
+  const skipped = items.length - capped.length
+  const valid: C[] = []
+  const errors: ImportItemError[] = []
+  capped.forEach((it, index) => {
+    try {
+      const err = validate(it as I)
+      if (err) errors.push({ index, error: err })
+      else valid.push(clean(it as I))
+    } catch {
+      // Item non-objet ou malformé (ex. null, primitive) : erreur, pas de crash.
+      errors.push({ index, error: 'item_invalide' })
+    }
+  })
+  return { valid, errors, skipped }
+}


### PR DESCRIPTION
## Contexte
P1 stratégique (interopérabilité / export-import) : compléter l'API publique v1 avec l'**écriture en masse**, pour alimenter le registre de risques et la bibliothèque de contrôles depuis un SI tiers (GRC, ETL, tableur exporté).

## Ce que fait la PR
`POST /api/v1/import` (scope **write**) — corps `{ risks?: [...], controls?: [...] }` :
- Chaque item validé par les **libs métier déjà testées** (`validateRiskItemInput`/`cleanRiskItem`, `validateControleInput`/`cleanControleInput`) — pas de duplication de règles.
- Items invalides **remontés par index** (`{ resource, index, error }`) sans interrompre l'import (import partiel).
- Plafond **500 items / ressource** (`API_IMPORT_MAX`), excédent compté dans `skipped`.
- **Gating module** par ressource : `registreRisquesActive` / `controlePermanentActive` (résolus via `getOrgConfig`, politique d'instance incluse).
- Risques créés avec `provenance: 'API'` ; **audit log** de l'opération.
- Helper pur **`prepareImport()`** (TDD, `src/lib/api-import.ts`) : robuste aux items malformés (`null`/primitives → `item_invalide`, pas de 500).
- OpenAPI (`/api/v1/openapi.json`) mis à jour.

## Tests
- Unitaires : `src/__tests__/unit/lib/api-import.test.ts` (valides/erreurs/cap/malformé). Suite complète : **1279 tests OK**, `tsc` clean.
- Vérif live (dev :3010, org StarBank, clé scope write) : risque valide créé (`provenance=API`), items invalides remontés par index (`cotation_invalide`, `intitule_requis`, `item_invalide`), contrôle créé ; `401` sans/mauvaise clé. Données de test nettoyées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)