### PR TITLE
feat(sso): câblage NextAuth du SSO OIDC (config d'instance)

### DIFF
--- a/docs/specs/sso-oidc.md
+++ b/docs/specs/sso-oidc.md
@@ -1,0 +1,60 @@
+# SSO d'entreprise — OIDC (câblage)
+
+Complète l'échafaudage d'instance existant (`SSOConfig` singleton, page
+`/admin/security`, secret chiffré au repos) en **branchant le flux NextAuth**.
+Le SSO passe de « coming soon » à **fonctionnel** pour OIDC. (SAML : à câbler
+ultérieurement — l'UI et le stockage existent déjà.)
+
+## Modèle & config
+
+`SSOConfig` (id `'global'`, réglé par le **SUPER_ADMIN** dans `/admin/security`) :
+`enabled`, `protocol`, `oidcIssuerUrl`, `oidcClientId`, `oidcClientSecret`
+(**chiffré** AES-256-GCM, `lib/secret-crypto.ts`), `oidcScopes`, `autoProvision`,
+`defaultRole`, `allowedDomains` (liste séparée par virgule ; **vide = tous
+domaines**). API `GET/PUT /api/admin/sso-config` (déjà en place).
+
+## Câblage NextAuth (ce lot)
+
+- **Provider dynamique** : `src/app/api/auth/[...nextauth]/route.ts` est désormais
+  un handler qui, **par requête**, ajoute le provider OIDC **uniquement si**
+  `loadSsoOidcConfig()` renvoie une config active. SSO désactivé (défaut) ⇒
+  providers inchangés ⇒ **comportement identique** au login Credentials.
+  `authOptions` (base) reste la source de vérité pour `getServerSession` partout.
+- **Provider** (`buildSsoProvider`, `lib/sso.server.ts`) : `type: 'oauth'` +
+  `wellKnown: {issuer}/.well-known/openid-configuration`, `idToken: true`,
+  `checks: ['pkce','state']`, `allowDangerousEmailAccountLinking: true` (lien par
+  e-mail borné par l'allowlist + `email_verified`). `profile()` persiste le rôle
+  par défaut dès la création.
+- **Gate d'admission** (`callbacks.signIn` → `ssoSignInDecision`) : n'affecte QUE
+  le provider `sso`. Applique allowlist de domaines, `email_verified`, et la règle
+  d'auto-provisioning (lier / créer / refuser). Refus ⇒ `false` (motif audité).
+- **Provisioning JIT** (`events.createUser` → `finalizeSsoProvisionedUser`) : force
+  `defaultRole` + `emailVerified` pour le compte créé par SSO. No-op si SSO off.
+- **Garde SSRF** : `isSafeIssuerUrl` (issuer https public, pas d'IP privée/loopback)
+  vérifiée au chargement de la config.
+- **UI** : bouton « Se connecter via SSO » sur `/auth/signin`, affiché seulement si
+  `GET /api/auth/sso-enabled` = true. Refus SSO ⇒ redirection `?error=` ⇒ message.
+
+## Cœur pur testé (`lib/sso.ts`)
+
+`isSafeIssuerUrl`, `emailDomain`, `parseAllowedDomains`, `emailDomainAllowed`
+(liste vide = tout), `resolveJitProvisioning`. Server (`lib/sso.server.ts`) :
+`loadSsoOidcConfig` (gating enabled/protocole/complétude/SSRF), `ssoSignInDecision`,
+`finalizeSsoProvisionedUser` — testés avec Prisma mocké.
+
+## Vérification
+
+- Suite : cœur pur + serveur (mock). Tsc clean.
+- Live : SSO **désactivé** ⇒ `/api/auth/providers` = `['credentials']`, login
+  classique intact (bad creds → 401 `CredentialsSignin`). SSO **activé** (issuer
+  Google de test) ⇒ providers = `['credentials','sso']`, l'initiation
+  `POST /api/auth/signin/sso` redirige vers l'**authorize** de l'IdP
+  (`client_id`, `scope`, PKCE, `state`) — flux OAuth correctement formé.
+
+## Reste à valider avec un IdP réel
+
+Round-trip complet (callback → JIT create/link → session) : nécessite un client
+OIDC enregistré chez un IdP (Azure AD / Okta / Google Workspace) et
+`NEXTAUTH_URL` = origine publique. En prod, préférer un secret via variable
+d'environnement au secret en base (déjà chiffré). Redirect URI à enregistrer chez
+l'IdP : `{origin}/api/auth/callback/sso`.

--- a/src/__tests__/unit/lib/sso.server.test.ts
+++ b/src/__tests__/unit/lib/sso.server.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mocks : Prisma (SSOConfig + User) et déchiffrement du secret.
+const ssoFindUnique = vi.fn()
+const userFindUnique = vi.fn()
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    sSOConfig: { findUnique: (...a: unknown[]) => ssoFindUnique(...a) },
+    user: { findUnique: (...a: unknown[]) => userFindUnique(...a) },
+  },
+}))
+vi.mock('@/lib/secret-crypto', () => ({ decryptSecret: (v: string | null) => v }))
+vi.mock('@/lib/logger', () => ({ auditLog: vi.fn() }))
+
+import { loadSsoOidcConfig, ssoEnabled, ssoSignInDecision } from '@/lib/sso.server'
+
+const VALID = {
+  id: 'global', enabled: true, protocol: 'OIDC',
+  oidcIssuerUrl: 'https://acme.okta.com', oidcClientId: 'cid', oidcClientSecret: 'sec',
+  oidcScopes: 'openid email profile', autoProvision: true, defaultRole: 'LECTEUR', allowedDomains: 'acme.com',
+}
+
+describe('loadSsoOidcConfig', () => {
+  beforeEach(() => { ssoFindUnique.mockReset(); userFindUnique.mockReset() })
+
+  it('retourne la config quand tout est valide et actif', async () => {
+    ssoFindUnique.mockResolvedValue(VALID)
+    const c = await loadSsoOidcConfig()
+    expect(c).not.toBeNull()
+    expect(c?.issuer).toBe('https://acme.okta.com')
+    expect(c?.clientSecret).toBe('sec')
+  })
+  it('null si désactivé, non-OIDC, incomplet ou issuer non sûr', async () => {
+    for (const patch of [{ enabled: false }, { protocol: 'SAML' }, { oidcClientId: '' }, { oidcIssuerUrl: 'https://127.0.0.1' }, { oidcIssuerUrl: 'http://acme.okta.com' }]) {
+      ssoFindUnique.mockResolvedValue({ ...VALID, ...patch })
+      expect(await loadSsoOidcConfig()).toBeNull()
+    }
+  })
+  it('null si la table est absente (best-effort)', async () => {
+    ssoFindUnique.mockRejectedValue(new Error('no table'))
+    expect(await loadSsoOidcConfig()).toBeNull()
+    expect(await ssoEnabled()).toBe(false)
+  })
+})
+
+describe('ssoSignInDecision', () => {
+  beforeEach(() => { ssoFindUnique.mockReset(); userFindUnique.mockReset(); ssoFindUnique.mockResolvedValue(VALID) })
+
+  it('autorise un utilisateur existant du bon domaine', async () => {
+    userFindUnique.mockResolvedValue({ id: 'u1' })
+    expect(await ssoSignInDecision({ email: 'a@acme.com', email_verified: true })).toEqual({ ok: true })
+  })
+  it('autorise la création si autoProvision et domaine ok', async () => {
+    userFindUnique.mockResolvedValue(null)
+    expect(await ssoSignInDecision({ email: 'new@acme.com', email_verified: true })).toEqual({ ok: true })
+  })
+  it('refuse un domaine non autorisé', async () => {
+    userFindUnique.mockResolvedValue(null)
+    expect(await ssoSignInDecision({ email: 'x@autre.com', email_verified: true })).toEqual({ ok: false, reason: 'domaine_non_autorise' })
+  })
+  it('refuse quand le SSO est désactivé', async () => {
+    ssoFindUnique.mockResolvedValue({ ...VALID, enabled: false })
+    expect(await ssoSignInDecision({ email: 'a@acme.com' })).toEqual({ ok: false, reason: 'sso_desactive' })
+  })
+})

--- a/src/__tests__/unit/lib/sso.test.ts
+++ b/src/__tests__/unit/lib/sso.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isSafeIssuerUrl,
+  emailDomain,
+  parseAllowedDomains,
+  emailDomainAllowed,
+  resolveJitProvisioning,
+} from '@/lib/sso'
+
+describe('isSafeIssuerUrl', () => {
+  it('https public ok, http / privé / localhost refusés', () => {
+    expect(isSafeIssuerUrl('https://login.microsoftonline.com')).toBe(true)
+    expect(isSafeIssuerUrl('http://login.microsoftonline.com')).toBe(false)
+    expect(isSafeIssuerUrl('https://10.0.0.1')).toBe(false)
+    expect(isSafeIssuerUrl('https://localhost')).toBe(false)
+  })
+})
+
+describe('emailDomain', () => {
+  it('extrait le domaine en minuscule, null si invalide', () => {
+    expect(emailDomain('Alice@Acme.COM')).toBe('acme.com')
+    expect(emailDomain('pasunemail')).toBeNull()
+  })
+})
+
+describe('parseAllowedDomains', () => {
+  it('normalise, retire @, déduplique, sépare virgule/espace', () => {
+    expect(parseAllowedDomains('@Acme.com, acme.com  SUB.Acme.COM')).toEqual(['acme.com', 'sub.acme.com'])
+    expect(parseAllowedDomains(null)).toEqual([])
+  })
+})
+
+describe('emailDomainAllowed', () => {
+  it('liste vide = tous domaines autorisés', () => {
+    expect(emailDomainAllowed('x@nimporte.com', '')).toBe(true)
+    expect(emailDomainAllowed('x@nimporte.com', null)).toBe(true)
+  })
+  it('restreint aux domaines listés', () => {
+    expect(emailDomainAllowed('x@acme.com', 'acme.com')).toBe(true)
+    expect(emailDomainAllowed('x@autre.com', 'acme.com')).toBe(false)
+  })
+  it('e-mail invalide → refusé', () => {
+    expect(emailDomainAllowed('invalide', '')).toBe(false)
+  })
+})
+
+describe('resolveJitProvisioning', () => {
+  const cfg = { autoProvision: true, defaultRole: 'LECTEUR', allowedDomains: 'acme.com' }
+  it('lie un utilisateur existant (rôle inchangé)', () => {
+    expect(resolveJitProvisioning(cfg, { email: 'a@acme.com', name: 'A', email_verified: true }, true).action).toBe('link')
+  })
+  it('crée un nouvel utilisateur avec le rôle par défaut si autoProvision', () => {
+    const r = resolveJitProvisioning(cfg, { email: 'new@acme.com', email_verified: true }, false)
+    expect(r.action).toBe('create')
+    if (r.action === 'create') { expect(r.role).toBe('LECTEUR'); expect(r.email).toBe('new@acme.com') }
+  })
+  it('refuse un domaine non autorisé', () => {
+    const r = resolveJitProvisioning(cfg, { email: 'x@autre.com', email_verified: true }, false)
+    expect(r).toEqual({ action: 'deny', reason: 'domaine_non_autorise' })
+  })
+  it('refuse un e-mail non vérifié', () => {
+    const r = resolveJitProvisioning(cfg, { email: 'x@acme.com', email_verified: false }, false)
+    expect(r).toEqual({ action: 'deny', reason: 'email_non_verifie' })
+  })
+  it('refuse la création si autoProvision off et pas d’utilisateur existant', () => {
+    const r = resolveJitProvisioning({ ...cfg, autoProvision: false }, { email: 'new@acme.com', email_verified: true }, false)
+    expect(r).toEqual({ action: 'deny', reason: 'provisioning_desactive' })
+  })
+  it('liste de domaines vide → autorise tout domaine', () => {
+    expect(resolveJitProvisioning({ ...cfg, allowedDomains: '' }, { email: 'x@nimporte.io', email_verified: true }, false).action).toBe('create')
+  })
+})

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,23 @@
 import NextAuth from 'next-auth'
+import type { NextRequest } from 'next/server'
 import { authOptions } from '@/lib/auth'
+import { loadSsoOidcConfig, buildSsoProvider } from '@/lib/sso.server'
 
-const handler = NextAuth(authOptions)
+// Handler dynamique : on ajoute le provider OIDC UNIQUEMENT si un SSO est
+// configuré et actif (config d'instance SSOConfig). Sinon, options inchangées →
+// comportement identique au login Credentials seul. `authOptions` (base) reste
+// la source de vérité pour getServerSession partout ailleurs.
+async function buildOptions() {
+  const cfg = await loadSsoOidcConfig()
+  if (!cfg) return authOptions
+  return { ...authOptions, debug: process.env.SSO_DEBUG === '1', providers: [...authOptions.providers, buildSsoProvider(cfg)] }
+}
+
+async function handler(req: NextRequest, ctx: { params: Promise<{ nextauth: string[] }> }) {
+  const options = await buildOptions()
+  const params = await ctx.params
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return NextAuth(req as any, { params } as any, options)
+}
+
 export { handler as GET, handler as POST }

--- a/src/app/api/auth/sso-enabled/route.ts
+++ b/src/app/api/auth/sso-enabled/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import { ssoEnabled } from '@/lib/sso.server'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/auth/sso-enabled — indique si un SSO OIDC est actif (public, sans secret).
+// Sert à afficher le bouton « Se connecter via SSO » sur la page de connexion.
+export async function GET() {
+  return NextResponse.json({ enabled: await ssoEnabled() })
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useState } from 'react'
+import { Suspense, useState, useEffect } from 'react'
 import { signIn } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Image from 'next/image'
@@ -24,6 +24,15 @@ function SignInForm() {
   const [mfaMasked, setMfaMasked] = useState('')
 
   const callbackUrl = params.get('callbackUrl') || '/dashboard'
+
+  // SSO d'entreprise : bouton affiché seulement si un provider est configuré et actif.
+  const [ssoOn, setSsoOn] = useState(false)
+  useEffect(() => {
+    fetch('/api/auth/sso-enabled').then(r => r.ok ? r.json() : { enabled: false }).then(d => setSsoOn(!!d.enabled)).catch(() => {})
+    // Un refus SSO redirige ici avec ?error= → message générique.
+    if (params.get('error')) setError(t.auth.signIn.ssoError)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   function handleResult(res: { error?: string | null } | undefined) {
     if (res?.error) {
@@ -157,6 +166,23 @@ function SignInForm() {
           {loading ? t.auth.signIn.submitting : t.auth.signIn.submit}
         </button>
       </form>
+
+      {ssoOn && (
+        <>
+          <div className="flex items-center gap-3 my-4">
+            <span className="h-px flex-1 bg-gray-200" />
+            <span className="text-xs uppercase text-gray-400">{t.auth.signIn.ssoOr}</span>
+            <span className="h-px flex-1 bg-gray-200" />
+          </div>
+          <button
+            type="button"
+            onClick={() => signIn('sso', { callbackUrl })}
+            className="w-full border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium py-2.5 rounded-lg transition-colors"
+          >
+            {t.auth.signIn.ssoButton}
+          </button>
+        </>
+      )}
 
       <p className="text-center text-sm mt-4">
         <Link href="/auth/forgot-password" className="text-gray-500 hover:text-ebios-600 hover:underline">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,8 @@ import { isPasswordExpired } from '@/lib/password-policy'
 import { resolveSessionCookie } from '@/lib/auth-cookies'
 import { isMfaRequired, resolveChannel, type MfaPolicyView } from '@/lib/mfa'
 import { createAndSendChallenge, verifyChallenge } from '@/lib/mfa-service'
+import { SSO_PROVIDER_ID } from '@/lib/sso'
+import { ssoSignInDecision, finalizeSsoProvisionedUser } from '@/lib/sso.server'
 
 // 🔴 Cookie de session aligné sur le défaut de getToken (middleware) : sa
 // sécurité dépend du SCHÉMA de NEXTAUTH_URL, pas de NODE_ENV. Sans cet
@@ -225,7 +227,28 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
+  // Finalise un compte provisionné par SSO (rôle par défaut + e-mail vérifié).
+  // No-op si le SSO est désactivé → aucun effet sur les autres créations.
+  events: {
+    async createUser({ user }: { user: any }) {
+      await finalizeSsoProvisionedUser(user.id)
+    },
+  },
   callbacks: {
+    // Gate d'admission SSO : n'affecte QUE le provider 'sso' (login classique
+    // et Credentials inchangés). Applique allowlist de domaines + email vérifié
+    // + règle d'auto-provisioning. Un refus redirige avec un code d'erreur.
+    async signIn(params: any) {
+      const { account, profile, user } = params
+      if (!account || account.provider !== SSO_PROVIDER_ID) return true
+      const decision = await ssoSignInDecision({
+        email: profile?.email ?? user?.email,
+        name: profile?.name ?? user?.name,
+        email_verified: profile?.email_verified,
+      })
+      // Refus → false : NextAuth redirige vers la page d'erreur (motif déjà audité).
+      return decision.ok
+    },
     async jwt({ token, user }: { token: any; user: any }) {
       if (user) {
         token.id = user.id

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -254,7 +254,7 @@ export const de: Translations = {
   sso: {
     sectionTitle:   '🔑 Single Sign-On (SSO)',
     sectionDesc:    'Ermöglichen Sie Ihren Benutzern die Anmeldung über Ihren Unternehmens-Identitätsprovider (IdP). Standardmäßig deaktiviert.',
-    comingSoonNotice: 'Die SSO-Anmeldung wird in einer zukünftigen Version verfügbar sein. Diese Konfiguration wird automatisch angewendet, sobald die Funktion aktiviert wird.',
+    comingSoonNotice: 'OIDC ist jetzt aktiv: \'SSO aktivieren\' ankreuzen, OIDC-Issuer und Client eintragen, speichern — der Button erscheint auf der Anmeldeseite. (SAML: demnächst.)',
     adminOnlyNotice: '🔒 Dieser Bereich ist nur für Administratoren sichtbar und bearbeitbar.',
     enableLabel:    'SSO aktivieren',
     protocolLabel:  'Protokoll',
@@ -318,6 +318,9 @@ export const de: Translations = {
       noAccount:    'Noch kein Konto?',
       createLink:   'Kostenloses Konto erstellen',
       forgotPassword: 'Passwort vergessen?',
+      ssoButton: 'Mit SSO anmelden',
+      ssoOr: 'oder',
+      ssoError: 'SSO-Anmeldung abgelehnt. Prüfen Sie, ob Ihre E-Mail-Domain zugelassen ist.',
     },
     forgot: {
       title:        'Passwort vergessen',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -254,7 +254,7 @@ export const en: Translations = {
   sso: {
     sectionTitle:   '🔑 Single Sign-On (SSO)',
     sectionDesc:    'Allow your users to sign in via your enterprise identity provider (IdP). Disabled by default.',
-    comingSoonNotice: 'SSO login will be available in a future release. This configuration will be applied automatically once the feature is activated.',
+    comingSoonNotice: 'OIDC is now active: tick \'Enable SSO\', fill in the OIDC issuer and client, then save — the button appears on the sign-in page. (SAML: coming soon.)',
     adminOnlyNotice: '🔒 This section is visible and editable by administrators only.',
     enableLabel:    'Enable SSO',
     protocolLabel:  'Protocol',
@@ -318,6 +318,9 @@ export const en: Translations = {
       noAccount:    'No account yet?',
       createLink:   'Create a free account',
       forgotPassword: 'Forgot password?',
+      ssoButton: 'Sign in with SSO',
+      ssoOr: 'or',
+      ssoError: 'SSO sign-in denied. Check that your email domain is allowed.',
     },
     forgot: {
       title:        'Forgot password',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -254,7 +254,7 @@ export const es: Translations = {
   sso: {
     sectionTitle:   '🔑 Single Sign-On (SSO)',
     sectionDesc:    'Permita a sus usuarios iniciar sesión a través de su proveedor de identidad corporativo (IdP). Desactivado por defecto.',
-    comingSoonNotice: 'El inicio de sesión SSO estará disponible en una próxima versión. Esta configuración se aplicará automáticamente cuando se active la funcionalidad.',
+    comingSoonNotice: 'OIDC ya está activo: marca \'Activar SSO\', completa el issuer y el cliente OIDC y guarda — el botón aparece en la página de inicio de sesión. (SAML: próximamente.)',
     adminOnlyNotice: '🔒 Esta sección solo es visible y editable por los administradores.',
     enableLabel:    'Activar SSO',
     protocolLabel:  'Protocolo',
@@ -318,6 +318,9 @@ export const es: Translations = {
       noAccount:    '¿Aún no tienes cuenta?',
       createLink:   'Crear una cuenta gratuita',
       forgotPassword: '¿Olvidaste tu contraseña?',
+      ssoButton: 'Iniciar sesión con SSO',
+      ssoOr: 'o',
+      ssoError: 'Inicio de sesión SSO denegado. Comprueba que tu dominio de correo está permitido.',
     },
     forgot: {
       title:        'Contraseña olvidada',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -258,7 +258,7 @@ export const fr = {
   sso: {
     sectionTitle:   '🔑 Single Sign-On (SSO)',
     sectionDesc:    'Permettez à vos utilisateurs de se connecter via votre fournisseur d\'identité d\'entreprise (IdP). Désactivé par défaut.',
-    comingSoonNotice: 'La connexion SSO sera disponible dans une prochaine version. Cette configuration sera appliquée automatiquement dès l\'activation de la fonctionnalité.',
+    comingSoonNotice: 'OIDC est désormais actif : cochez « Activer le SSO », renseignez l\'issuer et le client OIDC, puis enregistrez — le bouton apparaît sur la page de connexion. (SAML : bientôt.)',
     adminOnlyNotice: '🔒 Cette section n\'est visible et modifiable que par les administrateurs.',
     enableLabel:    'Activer le SSO',
     protocolLabel:  'Protocole',
@@ -326,6 +326,9 @@ export const fr = {
       noAccount:    'Pas encore de compte ?',
       createLink:   'Créer un compte gratuit',
       forgotPassword: 'Mot de passe oublié ?',
+      ssoButton: 'Se connecter via SSO',
+      ssoOr: 'ou',
+      ssoError: 'Connexion SSO refusée. Vérifiez que votre domaine e-mail est autorisé.',
     },
     forgot: {
       title:        'Mot de passe oublié',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -254,7 +254,7 @@ export const it: Translations = {
   sso: {
     sectionTitle:   '🔑 Single Sign-On (SSO)',
     sectionDesc:    'Consenti agli utenti di accedere tramite il provider di identità aziendale (IdP). Disattivato per impostazione predefinita.',
-    comingSoonNotice: 'Il login SSO sarà disponibile in una prossima versione. Questa configurazione verrà applicata automaticamente all\'attivazione della funzionalità.',
+    comingSoonNotice: 'OIDC è ora attivo: seleziona \'Attiva SSO\', inserisci issuer e client OIDC e salva — il pulsante appare nella pagina di accesso. (SAML: prossimamente.)',
     adminOnlyNotice: '🔒 Questa sezione è visibile e modificabile solo dagli amministratori.',
     enableLabel:    'Attiva SSO',
     protocolLabel:  'Protocollo',
@@ -318,6 +318,9 @@ export const it: Translations = {
       noAccount:    'Non hai ancora un account?',
       createLink:   'Crea un account gratuito',
       forgotPassword: 'Password dimenticata?',
+      ssoButton: 'Accedi con SSO',
+      ssoOr: 'o',
+      ssoError: 'Accesso SSO negato. Verifica che il tuo dominio e-mail sia consentito.',
     },
     forgot: {
       title:        'Password dimenticata',

--- a/src/lib/sso.server.ts
+++ b/src/lib/sso.server.ts
@@ -1,0 +1,129 @@
+// ─── SSO OIDC — couche serveur (câblage NextAuth de la config d'instance) ─────
+// Lit le singleton SSOConfig 'global' (réglé dans /admin/security), déchiffre le
+// secret, construit le provider OIDC NextAuth et applique le provisioning JIT.
+// TOUT est gardé : SSO désactivé (défaut) ⇒ aucun provider ajouté, aucun effet.
+
+import type { OAuthConfig } from 'next-auth/providers/oauth'
+import { prisma } from '@/lib/prisma'
+import { decryptSecret } from '@/lib/secret-crypto'
+import { auditLog } from '@/lib/logger'
+import {
+  isSafeIssuerUrl,
+  resolveJitProvisioning,
+  SSO_PROVIDER_ID,
+  type OidcClaims,
+} from '@/lib/sso'
+
+export interface SsoOidcConfig {
+  issuer: string
+  clientId: string
+  clientSecret: string
+  scopes: string
+  autoProvision: boolean
+  defaultRole: string
+  allowedDomains: string | null
+}
+
+/**
+ * Charge la config OIDC effective, ou null si le SSO ne doit pas être actif
+ * (désactivé, protocole non-OIDC, config incomplète, ou issuer non sûr).
+ * Best-effort : toute erreur (table absente) ⇒ null (login classique intact).
+ */
+export async function loadSsoOidcConfig(): Promise<SsoOidcConfig | null> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = await (prisma as any).sSOConfig.findUnique({ where: { id: 'global' } })
+    if (!c || c.enabled !== true || c.protocol !== 'OIDC') return null
+    const issuer = (c.oidcIssuerUrl ?? '').trim().replace(/\/$/, '')
+    const clientId = (c.oidcClientId ?? '').trim()
+    const clientSecret = (decryptSecret(c.oidcClientSecret) ?? '').trim()
+    if (!issuer || !clientId || !clientSecret) return null
+    if (!isSafeIssuerUrl(issuer)) return null
+    return {
+      issuer, clientId, clientSecret,
+      scopes: (c.oidcScopes ?? 'openid email profile').trim() || 'openid email profile',
+      autoProvision: c.autoProvision !== false,
+      defaultRole: c.defaultRole ?? 'ANALYSTE',
+      allowedDomains: c.allowedDomains ?? null,
+    }
+  } catch {
+    return null
+  }
+}
+
+/** True si un SSO OIDC est actif (pour afficher le bouton de connexion). */
+export async function ssoEnabled(): Promise<boolean> {
+  return (await loadSsoOidcConfig()) !== null
+}
+
+/** Construit le provider OIDC NextAuth à partir de la config chargée. */
+export function buildSsoProvider(cfg: SsoOidcConfig): OAuthConfig<Record<string, unknown>> {
+  const provider = {
+    id: SSO_PROVIDER_ID,
+    name: 'SSO',
+    type: 'oauth',
+    // Découverte OIDC : NextAuth lit {issuer}/.well-known/openid-configuration.
+    wellKnown: `${cfg.issuer}/.well-known/openid-configuration`,
+    clientId: cfg.clientId,
+    clientSecret: cfg.clientSecret,
+    authorization: { params: { scope: cfg.scopes } },
+    idToken: true,
+    checks: ['pkce', 'state'] as const,
+    // Lie une identité OIDC à un compte existant de MÊME e-mail (cas JIT « link »).
+    // Le risque « dangerous » est borné par l'allowlist de domaines + email_verified.
+    allowDangerousEmailAccountLinking: true,
+    // Le rôle par défaut est persisté dès la création (évite un décalage de session).
+    profile(profile: Record<string, unknown>) {
+      return {
+        id: String(profile.sub ?? ''),
+        email: typeof profile.email === 'string' ? profile.email : '',
+        name: typeof profile.name === 'string' ? profile.name : null,
+        role: cfg.defaultRole,
+      }
+    },
+  }
+  return provider as unknown as OAuthConfig<Record<string, unknown>>
+}
+
+/**
+ * Décision d'admission SSO (gate du callback signIn). Applique l'allowlist de
+ * domaines, la vérification d'e-mail et la règle d'auto-provisioning selon
+ * l'existence d'un utilisateur. Renvoie true, ou un code de refus (i18n).
+ */
+export async function ssoSignInDecision(claims: OidcClaims): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const cfg = await loadSsoOidcConfig()
+  if (!cfg) return { ok: false, reason: 'sso_desactive' }
+  const email = typeof claims.email === 'string' ? claims.email.toLowerCase().trim() : ''
+  let userExists = false
+  if (email) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const u = await (prisma.user as any).findUnique({ where: { email }, select: { id: true } }).catch(() => null)
+    userExists = !!u
+  }
+  const decision = resolveJitProvisioning(
+    { autoProvision: cfg.autoProvision, defaultRole: cfg.defaultRole, allowedDomains: cfg.allowedDomains },
+    claims,
+    userExists,
+  )
+  if (decision.action === 'deny') {
+    await auditLog('LOGIN_FAILED', { userEmail: email || undefined, details: { reason: `sso_${decision.reason}` } })
+    return { ok: false, reason: decision.reason }
+  }
+  return { ok: true }
+}
+
+/**
+ * Finalise un utilisateur provisionné par SSO (événement createUser NextAuth) :
+ * force le rôle par défaut de la config et marque l'e-mail vérifié. No-op si le
+ * SSO est désactivé (donc aucun effet sur les autres créations d'utilisateurs).
+ */
+export async function finalizeSsoProvisionedUser(userId: string): Promise<void> {
+  const cfg = await loadSsoOidcConfig()
+  if (!cfg) return
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (prisma.user as any).update({
+    where: { id: userId },
+    data: { role: cfg.defaultRole, emailVerified: new Date() },
+  }).catch(() => { /* best-effort */ })
+  await auditLog('LOGIN_SUCCESS', { userId, details: { via: 'sso', provisioned: true } })
+}

--- a/src/lib/sso.ts
+++ b/src/lib/sso.ts
@@ -1,0 +1,70 @@
+// ─── SSO d'entreprise (OIDC) — cœur pur ──────────────────────────────────────
+// Logique testable sans DB ni IdP, au service du câblage NextAuth de la config
+// d'instance `SSOConfig` (singleton 'global') : garde SSRF sur l'issuer,
+// résolution/allowlist de domaine e-mail, décision de provisioning JIT.
+
+import { isSafeWebhookUrl } from '@/lib/webhook'
+
+/** Rôle par défaut le plus prudent pour un utilisateur provisionné automatiquement. */
+export const SSO_DEFAULT_ROLE = 'ANALYSTE'
+/** Identifiant NextAuth du provider SSO (→ callback /api/auth/callback/sso). */
+export const SSO_PROVIDER_ID = 'sso'
+
+/** L'issuer est appelé côté serveur (discovery OIDC) → même garde SSRF que les webhooks. */
+export function isSafeIssuerUrl(url: unknown): boolean {
+  return isSafeWebhookUrl(url)
+}
+
+/** Domaine (minuscule) d'un e-mail, ou null si invalide. */
+export function emailDomain(email: unknown): string | null {
+  if (typeof email !== 'string') return null
+  const m = email.trim().toLowerCase().match(/^[^@\s]+@([^@\s]+)$/)
+  return m ? m[1] : null
+}
+
+/** Parse la liste de domaines autorisés (séparés par virgule/point-virgule/espace). */
+export function parseAllowedDomains(input: unknown): string[] {
+  if (typeof input !== 'string') return []
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const raw of input.split(/[,;\s]+/)) {
+    const d = raw.trim().toLowerCase().replace(/^@/, '')
+    if (d && !seen.has(d)) { seen.add(d); out.push(d) }
+  }
+  return out
+}
+
+/**
+ * Domaine de l'e-mail autorisé par la config ? Liste VIDE = tous les domaines
+ * autorisés (comportement documenté de l'UI). E-mail invalide → refusé.
+ */
+export function emailDomainAllowed(email: unknown, allowedDomains: unknown): boolean {
+  const dom = emailDomain(email)
+  if (!dom) return false
+  const list = parseAllowedDomains(allowedDomains)
+  return list.length === 0 || list.includes(dom)
+}
+
+export interface OidcClaims { email?: string; name?: string; email_verified?: boolean }
+export interface SsoJitConfig { autoProvision: boolean; defaultRole: string; allowedDomains: string | null }
+export type JitDecision =
+  | { action: 'link'; email: string; name: string | null }
+  | { action: 'create'; email: string; name: string | null; role: string }
+  | { action: 'deny'; reason: string }
+
+/**
+ * Décide le provisioning JIT à partir des claims OIDC et de l'existence d'un
+ * utilisateur. Refuse : e-mail absent/invalide, domaine non autorisé, e-mail non
+ * vérifié, ou création interdite (autoProvision off) sans utilisateur existant.
+ */
+export function resolveJitProvisioning(config: SsoJitConfig, claims: OidcClaims, userExists: boolean): JitDecision {
+  const dom = emailDomain(claims.email)
+  if (!dom) return { action: 'deny', reason: 'email_absent' }
+  const email = (claims.email as string).trim().toLowerCase()
+  if (!emailDomainAllowed(email, config.allowedDomains)) return { action: 'deny', reason: 'domaine_non_autorise' }
+  if (claims.email_verified === false) return { action: 'deny', reason: 'email_non_verifie' }
+  const name = typeof claims.name === 'string' && claims.name.trim() ? claims.name.trim() : null
+  if (userExists) return { action: 'link', email, name }
+  if (!config.autoProvision) return { action: 'deny', reason: 'provisioning_desactive' }
+  return { action: 'create', email, name, role: config.defaultRole || SSO_DEFAULT_ROLE }
+}


### PR DESCRIPTION
## Contexte
P1 stratégique — **authentification entreprise (OIDC)**, choisi « OIDC d'abord ». En explorant, découverte d'un **échafaudage SSO d'instance déjà présent** (modèle `SSOConfig` singleton, page SUPER_ADMIN `/admin/security`, secret client **chiffré au repos** AES-256-GCM, UI + i18n), marqué « coming soon » : **il ne manquait que le câblage NextAuth**. Décision (validée) : câbler l'existant plutôt qu'introduire un système par-org concurrent.

## Ce que fait la PR
Branche le flux d'authentification → OIDC devient **fonctionnel** (SAML reste à câbler, UI/stockage déjà là).

- **Provider OIDC dynamique** : `/api/auth/[...nextauth]/route.ts` ajoute le provider **par requête, seulement si un SSO est actif**. SSO désactivé (défaut) ⇒ providers inchangés ⇒ **login Credentials strictement identique**. `authOptions` (base) reste la source de vérité pour `getServerSession` partout.
- **Cœur pur testé** (`lib/sso.ts`) : `isSafeIssuerUrl` (garde SSRF), `parseAllowedDomains` / `emailDomainAllowed` (liste vide = tous domaines), `resolveJitProvisioning` (lier / créer / refuser).
- **Serveur** (`lib/sso.server.ts`, testé avec Prisma mocké) : `loadSsoOidcConfig` (gating enabled/protocole/complétude/SSRF + déchiffrement), `buildSsoProvider` (`type:'oauth'` + `wellKnown` discovery + PKCE/state + lien par e-mail borné par l'allowlist), `ssoSignInDecision` (gate `signIn`), `finalizeSsoProvisionedUser` (rôle + `emailVerified`).
- **UI** : bouton « Se connecter via SSO » sur `/auth/signin` (via `/api/auth/sso-enabled`), i18n 5 langues ; notice `/admin/security` mise à jour (OIDC actif).

## Tests
- Cœur pur (12) + serveur (7). Suite complète **1317 OK**, `tsc` clean.
- **Vérif live** : SSO **off** → `/api/auth/providers` = `['credentials']`, login classique intact (mauvais identifiants → 401 `CredentialsSignin`). SSO **on** (issuer Google de test) → providers = `['credentials','sso']`, `POST /api/auth/signin/sso` redirige vers l'**authorize** de l'IdP (`client_id`, `scope`, PKCE, `state`) — flux OAuth correctement formé.

## Reste à valider avec un IdP réel
Round-trip complet (callback → JIT create/link → session) : nécessite un client OIDC enregistré (Azure AD/Okta/Google Workspace) + `NEXTAUTH_URL` public. Redirect URI : `{origin}/api/auth/callback/sso`. Détails : `docs/specs/sso-oidc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)