### PR TITLE
feat(sso): SAML 2.0 en mode maintenance (dormant, testé, inerte)

### DIFF
--- a/docs/specs/sso-oidc.md
+++ b/docs/specs/sso-oidc.md
@@ -71,6 +71,30 @@ connexion**.
   `POST /api/auth/signin/sso` redirige vers l'**authorize** de l'IdP
   (`client_id`, `scope`, PKCE, `state`) — flux OAuth correctement formé.
 
+## SAML 2.0 — en développement (mode maintenance)
+
+SAML est développé mais **inerte** : jamais actif tant que
+`SSO_SAML_ENABLED='true'` n'est pas posé **et** que la vérification d'assertion
+(dépendance `@node-saml`) n'est pas câblée + validée avec un IdP réel. Aucun
+impact sur OIDC ni sur le login Credentials.
+
+- **Flag** : `isSamlMaintenanceMode()` (`lib/saml.server.ts`) — maintenance ON par
+  défaut. `samlActive()` reste faux tant que flag + config valide ne sont pas réunis.
+- **Cœur pur testé** (`lib/saml.ts`) : `validateSamlConfig` (entityId requis,
+  URL SSO https/SSRF, certificat PEM), `isPemCertificate`, `extractSamlClaims`
+  (attributs d'assertion → `{ email, name, groups }`, noms usuels Azure AD/ADFS/
+  Okta/Shibboleth, insensible à la casse) → rebranche le **même** JIT + mapping de
+  rôles que OIDC.
+- **Routes inertes** : `POST /api/auth/saml/acs` (ACS) et `GET /api/auth/saml/login`
+  renvoient **503 « saml_en_maintenance »**. UI `/admin/security` : bandeau
+  « maintenance » sur la section SAML (config enregistrée mais inactive).
+
+**À faire pour l'activer (IdP dispo)** : `npm i @node-saml/node-saml`, câbler
+l'`AuthnRequest` signée (login) et la **vérification de signature** de l'assertion
+dans l'ACS, extraire via `extractSamlClaims`, appliquer JIT + rôles, émettre la
+session ; puis poser `SSO_SAML_ENABLED='true'`. Redirect/ACS URL à enregistrer
+chez l'IdP : `{origin}/api/auth/saml/acs`.
+
 ## Reste à valider avec un IdP réel
 
 Round-trip complet (callback → JIT create/link → session) : nécessite un client

--- a/src/__tests__/unit/lib/saml.server.test.ts
+++ b/src/__tests__/unit/lib/saml.server.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const ssoFindUnique = vi.fn()
+vi.mock('@/lib/prisma', () => ({ prisma: { sSOConfig: { findUnique: (...a: unknown[]) => ssoFindUnique(...a) } } }))
+
+import { isSamlMaintenanceMode, samlActive } from '@/lib/saml.server'
+
+const VALID_SAML = {
+  id: 'global', enabled: true, protocol: 'SAML',
+  samlEntityId: 'https://acra.example.com', samlSsoUrl: 'https://idp.example.com/sso',
+  samlCertificate: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----',
+}
+
+describe('SAML — mode maintenance', () => {
+  const prev = process.env.SSO_SAML_ENABLED
+  beforeEach(() => { ssoFindUnique.mockReset() })
+  afterEach(() => { if (prev === undefined) delete process.env.SSO_SAML_ENABLED; else process.env.SSO_SAML_ENABLED = prev })
+
+  it('maintenance activée par défaut (flag absent)', () => {
+    delete process.env.SSO_SAML_ENABLED
+    expect(isSamlMaintenanceMode()).toBe(true)
+  })
+  it('SAML inactif en maintenance même avec une config valide', async () => {
+    delete process.env.SSO_SAML_ENABLED
+    ssoFindUnique.mockResolvedValue(VALID_SAML)
+    expect(await samlActive()).toBe(false)
+  })
+  it('flag levé + config valide → actif', async () => {
+    process.env.SSO_SAML_ENABLED = 'true'
+    ssoFindUnique.mockResolvedValue(VALID_SAML)
+    expect(isSamlMaintenanceMode()).toBe(false)
+    expect(await samlActive()).toBe(true)
+  })
+  it('flag levé mais config incomplète/non-SAML → inactif', async () => {
+    process.env.SSO_SAML_ENABLED = 'true'
+    ssoFindUnique.mockResolvedValue({ ...VALID_SAML, samlCertificate: 'invalide' })
+    expect(await samlActive()).toBe(false)
+    ssoFindUnique.mockResolvedValue({ ...VALID_SAML, protocol: 'OIDC' })
+    expect(await samlActive()).toBe(false)
+  })
+})

--- a/src/__tests__/unit/lib/saml.test.ts
+++ b/src/__tests__/unit/lib/saml.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SAML_PROVIDER_ID,
+  validateSamlConfig,
+  isPemCertificate,
+  extractSamlClaims,
+} from '@/lib/saml'
+
+describe('SAML_PROVIDER_ID', () => {
+  it('vaut « saml »', () => expect(SAML_PROVIDER_ID).toBe('saml'))
+})
+
+describe('validateSamlConfig', () => {
+  const ok = {
+    samlEntityId: 'https://acra.example.com',
+    samlSsoUrl: 'https://idp.example.com/sso',
+    samlCertificate: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----',
+  }
+  it('accepte une config SAML valide', () => {
+    expect(validateSamlConfig(ok)).toBeNull()
+  })
+  it('exige un entity ID', () => {
+    expect(validateSamlConfig({ ...ok, samlEntityId: '' })).toBe('entity_id_requis')
+  })
+  it('exige une URL SSO https publique', () => {
+    expect(validateSamlConfig({ ...ok, samlSsoUrl: 'http://idp.example.com/sso' })).toBe('sso_url_invalide')
+    expect(validateSamlConfig({ ...ok, samlSsoUrl: 'https://127.0.0.1/sso' })).toBe('sso_url_invalide')
+  })
+  it('exige un certificat PEM', () => {
+    expect(validateSamlConfig({ ...ok, samlCertificate: 'pas un pem' })).toBe('certificat_invalide')
+  })
+})
+
+describe('isPemCertificate', () => {
+  it('reconnaît un bloc PEM', () => {
+    expect(isPemCertificate('-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----')).toBe(true)
+    expect(isPemCertificate('abc')).toBe(false)
+    expect(isPemCertificate(null)).toBe(false)
+  })
+})
+
+describe('extractSamlClaims', () => {
+  it('extrait e-mail, nom et groupes via des noms d’attributs usuels', () => {
+    const c = extractSamlClaims({
+      'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'alice@acme.com',
+      displayName: 'Alice',
+      memberOf: ['grp-rssi', 'grp-lecture'],
+    })
+    expect(c.email).toBe('alice@acme.com')
+    expect(c.name).toBe('Alice')
+    expect(c.groups).toEqual(['grp-rssi', 'grp-lecture'])
+  })
+  it('gère les valeurs en tableau et la casse des clés', () => {
+    const c = extractSamlClaims({ Email: ['bob@acme.com'], Groups: 'g1' })
+    expect(c.email).toBe('bob@acme.com')
+    expect(c.groups).toEqual(['g1'])
+  })
+  it('champs absents → undefined / vide', () => {
+    const c = extractSamlClaims({})
+    expect(c.email).toBeUndefined()
+    expect(c.groups).toEqual([])
+  })
+})

--- a/src/app/admin/security/page.tsx
+++ b/src/app/admin/security/page.tsx
@@ -762,6 +762,9 @@ export default function AdminSecurityPage() {
                   {sso.protocol === 'SAML' && (
                     <div className="bg-gray-50 rounded-xl p-4 space-y-4 border border-gray-200">
                       <p className="text-xs font-semibold text-gray-800"><Lock size={15} className="inline align-[-0.15em] mr-1.5" aria-hidden="true" /> {t.sso.samlSection}</p>
+                      <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-800">
+                        {t.sso.samlMaintenanceNotice}
+                      </div>
 
                       {/* SP Entity ID */}
                       <div>

--- a/src/app/api/auth/saml/acs/route.ts
+++ b/src/app/api/auth/saml/acs/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { samlActive, isSamlMaintenanceMode } from '@/lib/saml.server'
+
+export const dynamic = 'force-dynamic'
+
+// POST /api/auth/saml/acs — Assertion Consumer Service (SAML).
+// MODE MAINTENANCE : inerte tant que le SSO SAML n'est pas activé ET câblé.
+// TODO (quand IdP disponible) : ajouter @node-saml, vérifier la signature de
+// l'assertion, extraire les attributs (extractSamlClaims), appliquer le même
+// provisioning JIT + mapping de rôles que OIDC, puis émettre la session NextAuth.
+export async function POST() {
+  if (isSamlMaintenanceMode() || !(await samlActive())) {
+    return NextResponse.json({ error: 'saml_en_maintenance' }, { status: 503 })
+  }
+  // Non atteint tant que le câblage @node-saml n'est pas en place.
+  return NextResponse.json({ error: 'saml_non_implemente' }, { status: 501 })
+}

--- a/src/app/api/auth/saml/login/route.ts
+++ b/src/app/api/auth/saml/login/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+import { samlActive, isSamlMaintenanceMode } from '@/lib/saml.server'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/auth/saml/login — initiation de la connexion SAML (AuthnRequest).
+// MODE MAINTENANCE : inerte. TODO (IdP dispo) : construire l'AuthnRequest signée
+// et rediriger vers samlSsoUrl de l'IdP.
+export async function GET() {
+  if (isSamlMaintenanceMode() || !(await samlActive())) {
+    return NextResponse.json({ error: 'saml_en_maintenance' }, { status: 503 })
+  }
+  return NextResponse.json({ error: 'saml_non_implemente' }, { status: 501 })
+}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -259,6 +259,7 @@ export const de: Translations = {
     enableLabel:    'SSO aktivieren',
     protocolLabel:  'Protokoll',
     samlSection:    'SAML 2.0 Konfiguration',
+    samlMaintenanceNotice: 'SAML befindet sich in Entwicklung (Wartungsmodus): Die Konfiguration wird gespeichert, aber die SAML-Anmeldung ist noch nicht aktiv. Sie wird nach der Validierung mit einem echten Identitätsanbieter aktiviert.',
     samlEntityId:   'SP Entity ID',
     samlEntityIdPh: 'https://acra.ihre-domain.com',
     samlEntityIdHint: 'Ihr Anwendungsbezeichner (Service Provider) beim IdP. Normalerweise die Basis-URL der Anwendung.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -259,6 +259,7 @@ export const en: Translations = {
     enableLabel:    'Enable SSO',
     protocolLabel:  'Protocol',
     samlSection:    'SAML 2.0 Configuration',
+    samlMaintenanceNotice: 'SAML is under development (maintenance mode): the configuration is saved but SAML sign-in is not active yet. It will be enabled after validation with a real identity provider.',
     samlEntityId:   'SP Entity ID',
     samlEntityIdPh: 'https://acra.your-domain.com',
     samlEntityIdHint: 'Your application identifier (Service Provider) with the IdP. Usually the base URL of the application.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -259,6 +259,7 @@ export const es: Translations = {
     enableLabel:    'Activar SSO',
     protocolLabel:  'Protocolo',
     samlSection:    'Configuración SAML 2.0',
+    samlMaintenanceNotice: 'SAML está en desarrollo (modo mantenimiento): la configuración se guarda pero el inicio de sesión SAML aún no está activo. Se habilitará tras la validación con un proveedor de identidad real.',
     samlEntityId:   'SP Entity ID',
     samlEntityIdPh: 'https://acra.su-dominio.com',
     samlEntityIdHint: 'Identificador de su aplicación (Service Provider) ante el IdP. Generalmente la URL base de la aplicación.',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -264,6 +264,7 @@ export const fr = {
     protocolLabel:  'Protocole',
     // SAML
     samlSection:    'Configuration SAML 2.0',
+    samlMaintenanceNotice: 'SAML est en cours de développement (mode maintenance) : la configuration est enregistrée mais la connexion SAML n\'est pas encore active. Elle le sera après validation avec un fournisseur d\'identité réel.',
     samlEntityId:   'SP Entity ID',
     samlEntityIdPh: 'https://acra.votre-domaine.com',
     samlEntityIdHint: 'Identifiant de votre application (Service Provider) auprès de l\'IdP. Souvent l\'URL de base de l\'application.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -259,6 +259,7 @@ export const it: Translations = {
     enableLabel:    'Attiva SSO',
     protocolLabel:  'Protocollo',
     samlSection:    'Configurazione SAML 2.0',
+    samlMaintenanceNotice: 'SAML è in sviluppo (modalità manutenzione): la configurazione viene salvata ma l\'accesso SAML non è ancora attivo. Sarà abilitato dopo la convalida con un provider di identità reale.',
     samlEntityId:   'SP Entity ID',
     samlEntityIdPh: 'https://acra.vostro-dominio.com',
     samlEntityIdHint: 'Identificatore dell\'applicazione (Service Provider) presso l\'IdP. Di solito l\'URL base dell\'applicazione.',

--- a/src/lib/saml.server.ts
+++ b/src/lib/saml.server.ts
@@ -1,0 +1,35 @@
+// ─── SSO SAML — couche serveur (MODE MAINTENANCE) ────────────────────────────
+// Le SSO SAML est développé mais **inerte** : il n'est jamais actif tant que
+//   (1) le flag d'instance SSO_SAML_ENABLED n'est pas mis à 'true', ET
+//   (2) la vérification cryptographique de l'assertion (dépendance @node-saml)
+//       n'est pas câblée et validée avec un IdP réel.
+// Tant que l'une manque, l'ACS renvoie 503 « en maintenance » et aucun bouton
+// SAML n'est proposé. Aucun impact sur OIDC ni sur le login Credentials.
+
+import { prisma } from '@/lib/prisma'
+import { validateSamlConfig } from '@/lib/saml'
+
+/**
+ * Mode maintenance SAML. INERTE par défaut : n'est levé que si l'exploitant met
+ * explicitement SSO_SAML_ENABLED='true' (et que le câblage @node-saml existe).
+ */
+export function isSamlMaintenanceMode(): boolean {
+  return process.env.SSO_SAML_ENABLED !== 'true'
+}
+
+/**
+ * SAML réellement actif ? Faux tant qu'on est en maintenance, ou que la config
+ * SSOConfig n'est pas activée / de protocole SAML / complète et valide.
+ * Best-effort : toute erreur ⇒ inactif.
+ */
+export async function samlActive(): Promise<boolean> {
+  if (isSamlMaintenanceMode()) return false
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = await (prisma as any).sSOConfig.findUnique({ where: { id: 'global' } })
+    if (!c || c.enabled !== true || c.protocol !== 'SAML') return false
+    return validateSamlConfig(c) === null
+  } catch {
+    return false
+  }
+}

--- a/src/lib/saml.ts
+++ b/src/lib/saml.ts
@@ -1,0 +1,72 @@
+// ─── SSO SAML 2.0 — cœur pur (MODE MAINTENANCE) ──────────────────────────────
+// Fondations testables du SSO SAML : validation de config, reconnaissance de
+// certificat PEM, extraction des claims depuis les attributs d'assertion. Le
+// flux SAML reste INERTE tant que le mode maintenance n'est pas levé (flag) et
+// que la vérification cryptographique de l'assertion (dépendance @node-saml)
+// n'est pas câblée + testée avec un IdP réel. Cf. lib/saml.server.ts + doc.
+
+import { isSafeIssuerUrl, type OidcClaims } from '@/lib/sso'
+
+/** Identifiant NextAuth du provider SAML (→ ACS /api/auth/saml/acs). */
+export const SAML_PROVIDER_ID = 'saml'
+
+export interface SamlConfigInput {
+  samlEntityId?: unknown
+  samlSsoUrl?: unknown
+  samlCertificate?: unknown
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '')
+
+/** Vrai si la valeur ressemble à un certificat X.509 au format PEM. */
+export function isPemCertificate(cert: unknown): boolean {
+  if (typeof cert !== 'string') return false
+  return /-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----/.test(cert)
+}
+
+/**
+ * Valide une config SAML. Renvoie un code d'erreur i18n ou null.
+ * L'URL SSO de l'IdP est appelée côté serveur (redirection) → garde https/SSRF.
+ */
+export function validateSamlConfig(cfg: SamlConfigInput): string | null {
+  if (!str(cfg.samlEntityId)) return 'entity_id_requis'
+  if (!isSafeIssuerUrl(str(cfg.samlSsoUrl))) return 'sso_url_invalide'
+  if (!isPemCertificate(cfg.samlCertificate)) return 'certificat_invalide'
+  return null
+}
+
+// Noms d'attributs SAML usuels (Azure AD, ADFS, Okta, Shibboleth…), insensibles
+// à la casse. On tente chaque candidat dans l'ordre.
+const EMAIL_ATTRS = ['email', 'emailaddress', 'mail', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', 'urn:oid:0.9.2342.19200300.100.1.3']
+const NAME_ATTRS = ['name', 'displayname', 'cn', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', 'urn:oid:2.16.840.1.113730.3.1.241']
+const GROUP_ATTRS = ['groups', 'memberof', 'http://schemas.xmlsoap.org/claims/group', 'http://schemas.microsoft.com/ws/2008/06/identity/claims/groups']
+
+function firstAttr(lower: Map<string, string[]>, candidates: string[]): string | undefined {
+  for (const c of candidates) {
+    const v = lower.get(c)
+    if (v && v.length && v[0]) return v[0]
+  }
+  return undefined
+}
+
+/**
+ * Extrait { email, name, groups } depuis les attributs d'une assertion SAML.
+ * Les attributs peuvent être des chaînes ou des tableaux ; les clés sont
+ * comparées en minuscules. Réutilise le type de claims OIDC pour brancher le
+ * même provisioning JIT + mapping de rôles que OIDC.
+ */
+export function extractSamlClaims(attributes: Record<string, unknown>): OidcClaims & { groups: string[] } {
+  const lower = new Map<string, string[]>()
+  for (const [k, v] of Object.entries(attributes ?? {})) {
+    const arr = Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : typeof v === 'string' ? [v] : []
+    lower.set(k.toLowerCase(), arr)
+  }
+  const email = firstAttr(lower, EMAIL_ATTRS)
+  const name = firstAttr(lower, NAME_ATTRS)
+  let groups: string[] = []
+  for (const g of GROUP_ATTRS) {
+    const v = lower.get(g)
+    if (v && v.length) { groups = v; break }
+  }
+  return { email, name, groups }
+}


### PR DESCRIPTION
## Contexte
Réponse à « peut-on commencer à développer SAML mais le garder en mode maintenance en attendant de tester ? » — **oui**. Cette PR pose les fondations SAML **inertes** : rien n'est actif tant que (1) le flag `SSO_SAML_ENABLED` n'est pas à `true` et (2) la vérification cryptographique de l'assertion (dépendance `@node-saml`) n'est pas câblée + validée avec un IdP réel. **Zéro impact** sur OIDC et sur le login Credentials.

## Ce que fait la PR
- **Cœur pur testé** (`lib/saml.ts`) : `validateSamlConfig` (entityId requis, URL SSO **https + garde SSRF**, certificat **PEM**), `isPemCertificate`, `extractSamlClaims` (attributs d'assertion → `{ email, name, groups }`, noms usuels Azure AD / ADFS / Okta / Shibboleth, insensible à la casse) — rebranche le **même** provisioning JIT + mapping de rôles que OIDC.
- **Garde** (`lib/saml.server.ts`) : `isSamlMaintenanceMode()` (maintenance **ON par défaut**), `samlActive()` (faux tant que flag + config valide non réunis).
- **Routes inertes** : `POST /api/auth/saml/acs` et `GET /api/auth/saml/login` → **503 `saml_en_maintenance`**.
- **UI** `/admin/security` : bandeau « maintenance » sur la section SAML (config enregistrée mais inactive) ; i18n 5 langues.

## Tests
- +13 tests (cœur pur + serveur). Suite complète **1340 OK**, `tsc` clean.
- **Vérif live** : ACS/login → 503 ; `sso-enabled` et `providers=['credentials']` intacts (OIDC/login non affectés).

## Pour l'activer plus tard (IdP dispo)
`npm i @node-saml/node-saml`, câbler l'`AuthnRequest` signée (login) + la **vérification de signature** de l'assertion (ACS) → `extractSamlClaims` → JIT + rôles → session, puis `SSO_SAML_ENABLED='true'`. ACS URL à enregistrer chez l'IdP : `{origin}/api/auth/saml/acs`. Détails : `docs/specs/sso-oidc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)