### PR TITLE
fix(conformité): note ORSA (Solvabilité II) via le sous-secteur assurance (#128)

### DIFF
--- a/src/__tests__/unit/lib/regulatory-guidance.test.ts
+++ b/src/__tests__/unit/lib/regulatory-guidance.test.ts
@@ -79,9 +79,16 @@ describe('reportUsageNotes (issues #70/#74)', () => {
     expect(reportUsageNotes(['ANSSI_HYG'], 'Administration publique')).toContain('homologationSSI')
     expect(reportUsageNotes([], 'Collectivité territoriale')).toContain('homologationSSI')
   })
-  it('assurance → note d’articulation ORSA (Solvabilité II) (issue #96)', () => {
+  it('assurance → note d’articulation ORSA (Solvabilité II) (issue #96/#128)', () => {
+    // En prod, un assureur a secteur = 'Banque / Finance' (libellé TOP-LEVEL de
+    // SECTEURS_ACTIVITE) + sousSecteur = 'banque-assurance' (id). La note ORSA doit
+    // se déclencher via le sous-secteur, pas seulement via le secteur top-level (#128).
+    expect(reportUsageNotes([], 'Banque / Finance', false, 'banque-assurance')).toContain('orsaSolva2')
+    // Le libellé de sous-secteur (« Assurance / mutuelle ») fonctionne aussi.
     expect(reportUsageNotes([], 'Assurance / mutuelle')).toContain('orsaSolva2')
+    // Banque hors assurance (sans sous-secteur, ou sous-secteur ≠ assurance) → pas d'ORSA.
     expect(reportUsageNotes(['DORA'], 'Banque / Finance')).not.toContain('orsaSolva2')
+    expect(reportUsageNotes(['DORA'], 'Banque / Finance', false, 'banque-detail')).not.toContain('orsaSolva2')
   })
   it('défense privée (BITD) avec VM classifiée → note homologation II 901 (issue #103)', () => {
     // Seulement si une valeur métier est classifiée (DR/SD)

--- a/src/components/workshops/Atelier5.tsx
+++ b/src/components/workshops/Atelier5.tsx
@@ -200,7 +200,7 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
   const regObligations = regulatoryObligations(analyse?.qualification?.statutReglementaire, analyse?.secteur)
   // Opportunités d'usage du rapport (DORA art. 8 / homologation SSI) — issues #70/#74
   const hasClassifiedVm = (analyse?.cadrage?.valeursMetier || []).some((vm: any) => isClassified(vm?.classification))
-  const usageNotes = reportUsageNotes(recommendedFw, analyse?.secteur, hasClassifiedVm)
+  const usageNotes = reportUsageNotes(recommendedFw, analyse?.secteur, hasClassifiedVm, analyse?.sousSecteur)
   // Ressource sectorielle : rapport ANSSI « cabinets d'avocats » (issue #57)
   const isJuridique = /juridique|avocat|barreau|legal/i.test(analyse?.secteur || '')
 

--- a/src/lib/pdf-template.tsx
+++ b/src/lib/pdf-template.tsx
@@ -452,6 +452,7 @@ function SummaryPage({ analyse, date, config, tp }: { analyse: any; date: string
     recommendedFrameworksForSector(analyse.secteur, analyse.cadrage?.tailleAnalyse, analyse.sousSecteur, analyse.qualification?.statutReglementaire, analyse.qualification?.entiteFinanciereAgreee),
     analyse.secteur,
     hasClassifiedVm,
+    analyse.sousSecteur,
   )
 
   const statutsMesures = [

--- a/src/lib/regulatory-guidance.ts
+++ b/src/lib/regulatory-guidance.ts
@@ -44,14 +44,17 @@ export function suggestsComplianceModule(secteur?: string | null, statut?: strin
  * constituer la pièce d'analyse de risques du dossier d'homologation II 901
  * (déclenché seulement si une valeur métier est classifiée IGI-1300 ≠ NP). Pur, testé.
  */
-export function reportUsageNotes(frameworks?: string[] | null, secteur?: string | null, hasClassifiedVm?: boolean): string[] {
+export function reportUsageNotes(frameworks?: string[] | null, secteur?: string | null, hasClassifiedVm?: boolean, sousSecteur?: string | null): string[] {
   const notes: string[] = []
   if ((frameworks ?? []).includes('DORA')) notes.push('doraArt8')
   if (/administration|public|collectivit|état|etat|government|établissement public/i.test(secteur ?? '')) notes.push('homologationSSI')
   // Défense privée (BITD) opérant un SI DR → homologation II 901 (issue #103)
   if (hasClassifiedVm && /défense|defense|militaire|defence|armement|bitd|dga/i.test(secteur ?? '')) notes.push('homologationII901')
-  // Assurance : le rapport alimente l'évaluation ORSA (Solvabilité II art. 45) (issue #96)
-  if (/assur|mutuelle|insurance|réassur|reassur/i.test(secteur ?? '')) notes.push('orsaSolva2')
+  // Assurance : le rapport alimente l'évaluation ORSA (Solvabilité II art. 45) (issue #96).
+  // « Assurance » est un SOUS-secteur (id `banque-assurance`) sous le secteur top-level
+  // « Banque / Finance » → tester secteur ET sousSecteur, sinon la note n'atteint jamais
+  // l'assureur en prod (`analyse.secteur` = 'Banque / Finance') (issue #128).
+  if (/assur|mutuelle|insurance|réassur|reassur/i.test(`${secteur ?? ''} ${sousSecteur ?? ''}`)) notes.push('orsaSolva2')
   return notes
 }
 


### PR DESCRIPTION
## Problème (issue #128)
En production, un assureur a `analyse.secteur = 'Banque / Finance'` (libellé **top-level** de `SECTEURS_ACTIVITE`) et `analyse.sousSecteur = 'banque-assurance'` (id). La note d'articulation **ORSA (Solvabilité II art. 45)** dans le rapport ne se déclenchait que sur le **secteur** → elle **n'atteignait jamais** l'assureur en prod.

## Correctif
`reportUsageNotes(...)` accepte désormais `sousSecteur` et teste `secteur` **+** `sousSecteur` pour la détection assurance. Les deux points d'appel (`Atelier5.tsx`, `pdf-template.tsx`) passent `analyse.sousSecteur`.

## Tests
- `regulatory-guidance.test.ts` étendu : ORSA via `sousSecteur='banque-assurance'`, via le libellé « Assurance / mutuelle », et **non**-déclenchement pour « Banque / Finance » sans sous-secteur ou avec `banque-detail`. **22 tests OK**, `tsc` clean.

> Note : ce correctif était présent dans l'arbre de travail (produit par la tâche de test continu) ; je le livre séparément pour ne pas le perdre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)