### PR TITLE
feat(scim): provisioning SCIM 2.0 per-org (SailPoint / Azure AD / Okta)

### DIFF
--- a/docs/specs/scim-provisioning.md
+++ b/docs/specs/scim-provisioning.md
@@ -1,0 +1,60 @@
+# SCIM 2.0 — Provisioning / déprovisioning
+
+Permet à un IdP / IGA (SailPoint, Azure AD, Okta) de **créer, mettre à jour et
+désactiver** les comptes ACRA automatiquement (cycle de vie complet, hors login).
+Complète le SSO OIDC + le mapping de rôles : le SSO authentifie et synchronise le
+rôle à la connexion ; SCIM gère l'existence des comptes (arrivées/départs).
+
+## Portée & auth
+
+**Per-organisation** (comme les clés d'API et webhooks). L'IdP s'authentifie avec
+une **clé d'API à scope `provision`** (`Authorization: Bearer acra_<prefix>_<secret>`,
+créée dans `/configuration` → Clés d'API, case « provisioning SCIM »). Les comptes
+sont provisionnés **dans l'organisation de la clé**, via `OrgMembership`. Le compte
+`User` (e-mail unique) est partagé entre organisations.
+
+`/api/scim/` est exempté de l'auth par session (middleware) ; chaque route
+authentifie la clé et exige le scope `provision`.
+
+## Endpoints (`/api/scim/v2`)
+
+| Méthode | Chemin | Effet |
+|---|---|---|
+| GET | `/ServiceProviderConfig` | Capacités annoncées (patch, filter, bearer). |
+| GET | `/Users?filter=userName eq "x"` | Recherche par e-mail dans l'org (0/1). |
+| POST | `/Users` | **Provisionne** : crée le compte si besoin + appartenance (rôle `LECTEUR`), réactive. `409` si déjà membre. |
+| GET | `/Users/{id}` | Lit le compte (s'il est membre de l'org). |
+| PUT | `/Users/{id}` | Remplacement (nom, `active`). |
+| PATCH | `/Users/{id}` | Ops SCIM — surtout `replace active=false` (**déprovisioning** Azure AD). |
+| DELETE | `/Users/{id}` | **Déprovisionne** (retire l'appartenance à l'org). |
+
+Réponses au format `application/scim+json` (enveloppes ListResponse / Error).
+
+## Sémantique du déprovisioning
+
+`active=false` (PATCH/PUT) ou `DELETE` → **retire l'appartenance à CETTE org**
+(révoque l'accès). Si c'était la **dernière** appartenance du compte, `User.isActive`
+passe à `false` (blocage global du login). Un `GET /Users/{id}` renvoie alors `404`
+(l'IdP voit le compte retiré de l'org).
+
+## Cœur pur testé (`lib/scim.ts`)
+
+`scimUserToAcra` (userName/emails → e-mail, name, active), `acraUserToScim`,
+`parseScimUserNameFilter` (`userName eq`), `applyScimPatch` (replace active/nom,
+value objet), enveloppes `scimListResponse` / `scimError`. La couche serveur
+(`lib/scim.server.ts`) porte la persistance per-org (create User + OrgMembership,
+retrait d'appartenance, désactivation si dernière).
+
+## Vérification
+
+- Suite : 12 tests purs. `tsc` clean.
+- **Live** (org StarBank, clé scope provision) : no-auth → 401 ; ServiceProviderConfig
+  → 200 ; POST provision → 201 (User + membership) ; filtre `userName eq` → 1 ;
+  POST en double → 409 ; PATCH `active=false` → `active:false`, appartenance retirée,
+  `User.isActive=false` (dernière appartenance) ; GET après déprovisioning → 404.
+
+## Limites / évolutions
+
+v1 : ressource **Users** uniquement, rôle provisionné = `LECTEUR` (le rôle fin est
+géré à la connexion via le mapping de groupes OIDC). Évolutions possibles : ressource
+**Groups**, mapping SCIM `roles`/groupes → rôle ACRA, pagination des listes.

--- a/src/__tests__/unit/lib/scim.test.ts
+++ b/src/__tests__/unit/lib/scim.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  scimUserToAcra,
+  acraUserToScim,
+  parseScimUserNameFilter,
+  applyScimPatch,
+  scimListResponse,
+  scimError,
+  SCIM_USER_SCHEMA,
+} from '@/lib/scim'
+
+describe('scimUserToAcra', () => {
+  it('extrait e-mail (userName), nom et active', () => {
+    const r = scimUserToAcra({
+      userName: 'Alice@Acme.com', displayName: 'Alice Doe', active: true,
+      name: { givenName: 'Alice', familyName: 'Doe' },
+    })
+    expect(r).toEqual({ email: 'alice@acme.com', name: 'Alice Doe', active: true })
+  })
+  it('replie sur emails[primary] et name.formatted, active défaut true', () => {
+    const r = scimUserToAcra({ emails: [{ value: 'bob@acme.com', primary: true }], name: { formatted: 'Bob' } })
+    expect(r).toEqual({ email: 'bob@acme.com', name: 'Bob', active: true })
+  })
+  it('sans e-mail → null', () => {
+    expect(scimUserToAcra({ displayName: 'x' })).toBeNull()
+  })
+})
+
+describe('acraUserToScim', () => {
+  it('mappe un utilisateur ACRA vers une ressource SCIM', () => {
+    const s = acraUserToScim({ id: 'u1', email: 'a@acme.com', name: 'Alice', isActive: true })
+    expect(s.schemas).toEqual([SCIM_USER_SCHEMA])
+    expect(s.id).toBe('u1')
+    expect(s.userName).toBe('a@acme.com')
+    expect(s.active).toBe(true)
+    expect(s.emails?.[0]).toEqual({ value: 'a@acme.com', primary: true })
+  })
+})
+
+describe('parseScimUserNameFilter', () => {
+  it('parse userName eq "x"', () => {
+    expect(parseScimUserNameFilter('userName eq "alice@acme.com"')).toBe('alice@acme.com')
+    expect(parseScimUserNameFilter('userName Eq "BOB@acme.com"')).toBe('bob@acme.com')
+  })
+  it('filtre non supporté → null', () => {
+    expect(parseScimUserNameFilter('displayName eq "x"')).toBeNull()
+    expect(parseScimUserNameFilter('')).toBeNull()
+    expect(parseScimUserNameFilter(undefined)).toBeNull()
+  })
+})
+
+describe('applyScimPatch', () => {
+  const base = { active: true, name: 'Alice' }
+  it('désactive via op replace path=active (déprovisioning Azure AD)', () => {
+    expect(applyScimPatch(base, [{ op: 'Replace', path: 'active', value: false }])).toEqual({ active: false, name: 'Alice' })
+  })
+  it('accepte value booléen sous forme de chaîne', () => {
+    expect(applyScimPatch(base, [{ op: 'replace', path: 'active', value: 'False' }]).active).toBe(false)
+  })
+  it('op replace sans path avec objet value', () => {
+    expect(applyScimPatch(base, [{ op: 'replace', value: { active: false, displayName: 'Alice D' } }])).toEqual({ active: false, name: 'Alice D' })
+  })
+  it('ignore les ops inconnues sans casser', () => {
+    expect(applyScimPatch(base, [{ op: 'add', path: 'foo', value: 1 }])).toEqual(base)
+  })
+})
+
+describe('enveloppes SCIM', () => {
+  it('scimListResponse', () => {
+    const l = scimListResponse([{ id: 'u1' }], 1)
+    expect(l.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:ListResponse')
+    expect(l.totalResults).toBe(1)
+    expect(l.Resources).toHaveLength(1)
+  })
+  it('scimError porte le statut et le détail', () => {
+    const e = scimError(404, 'introuvable')
+    expect(e.status).toBe('404')
+    expect(e.detail).toBe('introuvable')
+    expect(e.schemas).toContain('urn:ietf:params:scim:api:messages:2.0:Error')
+  })
+})

--- a/src/app/api/scim/v2/ServiceProviderConfig/route.ts
+++ b/src/app/api/scim/v2/ServiceProviderConfig/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/scim/v2/ServiceProviderConfig — capacités SCIM annoncées à l'IdP.
+export async function GET() {
+  const body = {
+    schemas: ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
+    documentationUri: '/api/scim/v2/ServiceProviderConfig',
+    patch: { supported: true },
+    bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
+    filter: { supported: true, maxResults: 200 },
+    changePassword: { supported: false },
+    sort: { supported: false },
+    etag: { supported: false },
+    authenticationSchemes: [
+      { type: 'oauthbearertoken', name: 'Bearer', description: "Clé d'API ACRA à scope provision" },
+    ],
+  }
+  return NextResponse.json(body, { headers: { 'Content-Type': 'application/scim+json' } })
+}

--- a/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/src/app/api/scim/v2/Users/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { authenticateApiRequest } from '@/lib/api-auth.server'
+import { auditLog, getClientIp } from '@/lib/logger'
+import { scimUserToAcra, applyScimPatch, scimError, type ScimPatchOp } from '@/lib/scim'
+import { scimGetById, scimUpdate, scimDeprovision } from '@/lib/scim.server'
+
+export const dynamic = 'force-dynamic'
+
+type Params = { params: Promise<{ id: string }> }
+const SCIM_CT = { 'Content-Type': 'application/scim+json' }
+const scimJson = (body: unknown, status = 200) => NextResponse.json(body, { status, headers: SCIM_CT })
+
+// GET /api/scim/v2/Users/[id]
+export async function GET(req: NextRequest, { params }: Params) {
+  const auth = await authenticateApiRequest(req, 'provision')
+  if (!auth.ok) return scimJson(scimError(auth.status, auth.error), auth.status)
+  const { id } = await params
+  const resource = await scimGetById(auth.organizationId, id)
+  return resource ? scimJson(resource) : scimJson(scimError(404, 'introuvable'), 404)
+}
+
+// PUT /api/scim/v2/Users/[id] — remplacement complet (nom, active).
+export async function PUT(req: NextRequest, { params }: Params) {
+  const auth = await authenticateApiRequest(req, 'provision')
+  if (!auth.ok) return scimJson(scimError(auth.status, auth.error), auth.status)
+  const { id } = await params
+  const body = await req.json().catch(() => ({}))
+  const fields = scimUserToAcra(body)
+  if (!fields) return scimJson(scimError(400, 'ressource invalide'), 400)
+  const resource = await scimUpdate(auth.organizationId, id, { active: fields.active, name: fields.name })
+  if (!resource) return scimJson(scimError(404, 'introuvable'), 404)
+  await auditLog('ORGANIZATION_CONFIG_UPDATED', { userId: `apikey:${auth.keyId}`, userRole: 'API', organizationId: auth.organizationId, ip: getClientIp(req), details: { scope: 'scim', action: 'replace', id, active: fields.active } })
+  return scimJson(resource)
+}
+
+// PATCH /api/scim/v2/Users/[id] — surtout active=false (déprovisioning Azure AD).
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const auth = await authenticateApiRequest(req, 'provision')
+  if (!auth.ok) return scimJson(scimError(auth.status, auth.error), auth.status)
+  const { id } = await params
+  const current = await scimGetById(auth.organizationId, id)
+  if (!current) return scimJson(scimError(404, 'introuvable'), 404)
+  const body = await req.json().catch(() => ({}))
+  const ops: ScimPatchOp[] = Array.isArray(body?.Operations) ? body.Operations : []
+  const next = applyScimPatch({ active: current.active, name: current.name?.formatted ?? null }, ops)
+  const resource = await scimUpdate(auth.organizationId, id, next)
+  if (!resource) return scimJson(scimError(404, 'introuvable'), 404)
+  await auditLog('ORGANIZATION_CONFIG_UPDATED', { userId: `apikey:${auth.keyId}`, userRole: 'API', organizationId: auth.organizationId, ip: getClientIp(req), details: { scope: 'scim', action: 'patch', id, active: next.active } })
+  return scimJson(resource)
+}
+
+// DELETE /api/scim/v2/Users/[id] — déprovisionne (retire l'appartenance à l'org).
+export async function DELETE(req: NextRequest, { params }: Params) {
+  const auth = await authenticateApiRequest(req, 'provision')
+  if (!auth.ok) return scimJson(scimError(auth.status, auth.error), auth.status)
+  const { id } = await params
+  const ok = await scimDeprovision(auth.organizationId, id)
+  if (!ok) return scimJson(scimError(404, 'introuvable'), 404)
+  await auditLog('ORGANIZATION_CONFIG_UPDATED', { userId: `apikey:${auth.keyId}`, userRole: 'API', organizationId: auth.organizationId, ip: getClientIp(req), details: { scope: 'scim', action: 'deprovision', id } })
+  return new NextResponse(null, { status: 204 })
+}

--- a/src/app/api/scim/v2/Users/route.ts
+++ b/src/app/api/scim/v2/Users/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { authenticateApiRequest } from '@/lib/api-auth.server'
+import { auditLog, getClientIp } from '@/lib/logger'
+import { scimUserToAcra, parseScimUserNameFilter, scimListResponse, scimError } from '@/lib/scim'
+import { scimFindByEmail, scimProvision } from '@/lib/scim.server'
+
+export const dynamic = 'force-dynamic'
+
+const SCIM_CT = { 'Content-Type': 'application/scim+json' }
+const scimJson = (body: unknown, status = 200) => NextResponse.json(body, { status, headers: SCIM_CT })
+
+// GET /api/scim/v2/Users?filter=userName eq "x" — liste (0 ou 1) dans l'org de la clé.
+export async function GET(req: NextRequest) {
+  const auth = await authenticateApiRequest(req, 'provision')
+  if (!auth.ok) return scimJson(scimError(auth.status, auth.error), auth.status)
+
+  const filter = req.nextUrl.searchParams.get('filter')
+  const email = parseScimUserNameFilter(filter)
+  if (filter && !email) return scimJson(scimListResponse([], 0)) // filtre non supporté → vide
+  const resources = email ? [await scimFindByEmail(auth.organizationId, email)].filter(Boolean) : []
+  return scimJson(scimListResponse(resources, resources.length))
+}
+
+// POST /api/scim/v2/Users — provisionne un compte dans l'org de la clé.
+export async function POST(req: NextRequest) {
+  const auth = await authenticateApiRequest(req, 'provision')
+  if (!auth.ok) return scimJson(scimError(auth.status, auth.error), auth.status)
+
+  const body = await req.json().catch(() => ({}))
+  const fields = scimUserToAcra(body)
+  if (!fields) return scimJson(scimError(400, 'userName (e-mail) requis'), 400)
+
+  const { conflict, resource } = await scimProvision(auth.organizationId, fields)
+  if (conflict) return scimJson(scimError(409, 'utilisateur déjà présent dans l’organisation'), 409)
+  await auditLog('ORGANIZATION_CONFIG_UPDATED', {
+    userId: `apikey:${auth.keyId}`, userRole: 'API', organizationId: auth.organizationId, ip: getClientIp(req),
+    details: { scope: 'scim', action: 'provision', email: fields.email },
+  })
+  return scimJson(resource, 201)
+}

--- a/src/components/ApiKeysManager.tsx
+++ b/src/components/ApiKeysManager.tsx
@@ -16,6 +16,7 @@ export default function ApiKeysManager() {
   const [loading, setLoading] = useState(true)
   const [name, setName] = useState('')
   const [scopeWrite, setScopeWrite] = useState(false)
+  const [scopeProvision, setScopeProvision] = useState(false)
   const [expiresAt, setExpiresAt] = useState('')
   const [busy, setBusy] = useState(false)
   const [secret, setSecret] = useState<string | null>(null)
@@ -33,12 +34,12 @@ export default function ApiKeysManager() {
     setBusy(true); setSecret(null)
     const res = await fetch('/api/config/api-keys', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name || undefined, scopes: scopeWrite ? ['read', 'write'] : ['read'], expiresAt: expiresAt || undefined }),
+      body: JSON.stringify({ name: name || undefined, scopes: ['read', ...(scopeWrite ? ['write'] : []), ...(scopeProvision ? ['provision'] : [])], expiresAt: expiresAt || undefined }),
     })
     const data = await res.json().catch(() => ({}))
     setBusy(false)
     if (!res.ok) return
-    setSecret(data.secret); setName(''); setScopeWrite(false); setExpiresAt(''); reload()
+    setSecret(data.secret); setName(''); setScopeWrite(false); setScopeProvision(false); setExpiresAt(''); reload()
   }
 
   async function revoquer(id: string) {
@@ -79,6 +80,9 @@ export default function ApiKeysManager() {
         </label>
         <label className="text-xs text-gray-600 dark:text-gray-300 inline-flex items-center gap-1.5 pb-1.5">
           <input type="checkbox" checked={scopeWrite} onChange={e => setScopeWrite(e.target.checked)} /> {a.scopeWrite}
+        </label>
+        <label className="text-xs text-gray-600 dark:text-gray-300 inline-flex items-center gap-1.5 pb-1.5">
+          <input type="checkbox" checked={scopeProvision} onChange={e => setScopeProvision(e.target.checked)} /> {a.scopeProvision}
         </label>
         <button onClick={creer} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{a.create}</button>
       </div>

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -9,7 +9,7 @@ import { promisify } from 'util'
 const scryptAsync = promisify(scrypt)
 
 export const API_KEY_PREFIX = 'acra'
-export const API_SCOPES = ['read', 'write'] as const
+export const API_SCOPES = ['read', 'write', 'provision'] as const
 export type ApiScope = (typeof API_SCOPES)[number]
 
 const KEY_LEN = 32   // longueur du dérivé

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1071,6 +1071,7 @@ export const de: Translations = {
     namePlaceholder: 'z. B. BI-Integration',
     expiry: 'Ablauf',
     scopeWrite: 'Schreibzugriff erlauben',
+    scopeProvision: 'SCIM-Provisionierung erlauben (provision)',
     create: 'Schlüssel erstellen',
     empty: 'Keine API-Schlüssel.',
     colKey: 'Schlüssel',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1071,6 +1071,7 @@ export const en: Translations = {
     namePlaceholder: 'e.g. BI integration',
     expiry: 'Expiry',
     scopeWrite: 'Allow write access',
+    scopeProvision: 'Allow SCIM provisioning (provision)',
     create: 'Create key',
     empty: 'No API keys.',
     colKey: 'Key',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1071,6 +1071,7 @@ export const es: Translations = {
     namePlaceholder: 'p. ej. Integración BI',
     expiry: 'Caducidad',
     scopeWrite: 'Permitir escritura',
+    scopeProvision: 'Permitir aprovisionamiento SCIM (provision)',
     create: 'Crear clave',
     empty: 'Sin claves de API.',
     colKey: 'Clave',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1094,6 +1094,7 @@ export const fr = {
     namePlaceholder: 'ex. Intégration BI',
     expiry: 'Expiration',
     scopeWrite: 'Autoriser l’écriture (write)',
+    scopeProvision: 'Autoriser le provisioning SCIM (provision)',
     create: 'Créer une clé',
     empty: 'Aucune clé d’API.',
     colKey: 'Clé',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1071,6 +1071,7 @@ export const it: Translations = {
     namePlaceholder: 'es. Integrazione BI',
     expiry: 'Scadenza',
     scopeWrite: 'Consenti scrittura',
+    scopeProvision: 'Consentire il provisioning SCIM (provision)',
     create: 'Crea chiave',
     empty: 'Nessuna chiave API.',
     colKey: 'Chiave',

--- a/src/lib/public-paths.ts
+++ b/src/lib/public-paths.ts
@@ -21,6 +21,9 @@ export function isPublicPath(pathname: string): boolean {
     // API publique v1 : authentification propre par clé d'API (Bearer) dans le
     // handler, donc exemptée de l'auth par session du middleware.
     pathname.startsWith('/api/v1/') ||
+    // SCIM 2.0 : provisioning par l'IdP (SailPoint/Azure AD), auth Bearer (clé
+    // d'API scope provision) dans le handler → exempté de l'auth par session.
+    pathname.startsWith('/api/scim/') ||
     // Statut démo : lu par la page d'accueil (visiteur anonyme) pour afficher
     // l'encart « mode démonstration ». Ne renvoie aucune donnée sensible.
     pathname === '/api/demo/status' ||

--- a/src/lib/scim.server.ts
+++ b/src/lib/scim.server.ts
@@ -1,0 +1,74 @@
+// ─── SCIM 2.0 — couche serveur (provisioning per-org via OrgMembership) ──────
+// Un IdP (SailPoint/Azure AD/Okta) provisionne/déprovisionne les comptes d'UNE
+// organisation, authentifié par une clé d'API à scope `provision`. Le compte
+// ACRA (User) est partagé entre organisations ; l'appartenance à l'org passe par
+// OrgMembership. Déprovisionner = retirer l'appartenance à CETTE org (et
+// désactiver le compte s'il ne reste aucune appartenance).
+
+import { prisma } from '@/lib/prisma'
+import { acraUserToScim, type AcraUserFields } from '@/lib/scim'
+
+/** Rôle par défaut des comptes provisionnés par SCIM (moindre privilège). */
+export const SCIM_DEFAULT_ROLE = 'LECTEUR'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any
+
+/** Un utilisateur (avec appartenance à l'org) → ressource SCIM, ou null. */
+export async function scimGetById(orgId: string, id: string) {
+  const m = await db.orgMembership.findFirst({ where: { organizationId: orgId, userId: id }, include: { user: true } })
+  if (!m) return null
+  return acraUserToScim({ id: m.user.id, email: m.user.email, name: m.user.name, isActive: m.user.isActive })
+}
+
+/** Recherche par e-mail (filtre userName eq) dans l'org. */
+export async function scimFindByEmail(orgId: string, email: string) {
+  const m = await db.orgMembership.findFirst({ where: { organizationId: orgId, user: { email } }, include: { user: true } })
+  if (!m) return null
+  return acraUserToScim({ id: m.user.id, email: m.user.email, name: m.user.name, isActive: m.user.isActive })
+}
+
+/**
+ * Provisionne un compte dans l'org. Crée l'utilisateur si nécessaire, ajoute
+ * l'appartenance (rôle par défaut), réactive le compte. Renvoie { resource, created }.
+ * Si l'utilisateur a DÉJÀ une appartenance à cette org → conflit (created=false, existing).
+ */
+export async function scimProvision(orgId: string, fields: AcraUserFields): Promise<{ conflict: boolean; resource: ReturnType<typeof acraUserToScim> }> {
+  const existingUser = await db.user.findUnique({ where: { email: fields.email } })
+  if (existingUser) {
+    const membership = await db.orgMembership.findUnique({ where: { userId_organizationId: { userId: existingUser.id, organizationId: orgId } } })
+    if (membership) {
+      return { conflict: true, resource: acraUserToScim({ id: existingUser.id, email: existingUser.email, name: existingUser.name, isActive: existingUser.isActive }) }
+    }
+    await db.orgMembership.create({ data: { userId: existingUser.id, organizationId: orgId, role: SCIM_DEFAULT_ROLE } })
+    const u = await db.user.update({ where: { id: existingUser.id }, data: { isActive: true, ...(fields.name ? { name: fields.name } : {}) } })
+    return { conflict: false, resource: acraUserToScim({ id: u.id, email: u.email, name: u.name, isActive: u.isActive }) }
+  }
+  const user = await db.user.create({
+    data: { email: fields.email, name: fields.name, isActive: fields.active, role: SCIM_DEFAULT_ROLE, memberships: { create: { organizationId: orgId, role: SCIM_DEFAULT_ROLE } } },
+  })
+  return { conflict: false, resource: acraUserToScim({ id: user.id, email: user.email, name: user.name, isActive: user.isActive }) }
+}
+
+/** Met à jour un compte de l'org (nom, active). active=false → déprovisionne. */
+export async function scimUpdate(orgId: string, id: string, fields: { active: boolean; name: string | null }) {
+  const m = await db.orgMembership.findFirst({ where: { organizationId: orgId, userId: id }, include: { user: true } })
+  if (!m) return null
+  if (!fields.active) { await scimDeprovision(orgId, id); return acraUserToScim({ id, email: m.user.email, name: m.user.name, isActive: false }) }
+  const u = await db.user.update({ where: { id }, data: { isActive: true, ...(fields.name != null ? { name: fields.name } : {}) } })
+  return acraUserToScim({ id: u.id, email: u.email, name: u.name, isActive: u.isActive })
+}
+
+/**
+ * Déprovisionne : retire l'appartenance à CETTE org. Si c'était la dernière,
+ * désactive le compte globalement. Renvoie false si l'utilisateur n'était pas
+ * dans l'org.
+ */
+export async function scimDeprovision(orgId: string, id: string): Promise<boolean> {
+  const m = await db.orgMembership.findFirst({ where: { organizationId: orgId, userId: id } })
+  if (!m) return false
+  await db.orgMembership.delete({ where: { userId_organizationId: { userId: id, organizationId: orgId } } })
+  const remaining = await db.orgMembership.count({ where: { userId: id } })
+  if (remaining === 0) await db.user.update({ where: { id }, data: { isActive: false } }).catch(() => {})
+  return true
+}

--- a/src/lib/scim.ts
+++ b/src/lib/scim.ts
@@ -1,0 +1,114 @@
+// ─── SCIM 2.0 — cœur pur (provisioning/déprovisioning) ───────────────────────
+// Mapping entre les ressources SCIM (RFC 7643/7644) envoyées par l'IdP
+// (SailPoint / Azure AD / Okta) et le modèle utilisateur ACRA. Logique PURE et
+// testable ; la persistance + l'auth Bearer vivent dans les routes /api/scim.
+
+export const SCIM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User'
+export const SCIM_LIST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse'
+export const SCIM_ERROR_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:Error'
+export const SCIM_PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
+
+export interface AcraUserFields { email: string; name: string | null; active: boolean }
+
+const asStr = (v: unknown): string => (typeof v === 'string' ? v.trim() : '')
+const coerceBool = (v: unknown, dflt = true): boolean => {
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'string') return !/^(false|0|no)$/i.test(v.trim())
+  return dflt
+}
+
+/** Nom d'affichage : displayName, sinon name.formatted, sinon givenName + familyName. */
+function pickName(r: Record<string, any>): string | null {
+  if (asStr(r.displayName)) return asStr(r.displayName)
+  const n = r.name
+  if (n && typeof n === 'object') {
+    if (asStr(n.formatted)) return asStr(n.formatted)
+    const parts = [asStr(n.givenName), asStr(n.familyName)].filter(Boolean)
+    if (parts.length) return parts.join(' ')
+  }
+  return null
+}
+
+/** E-mail : userName (usuel), sinon emails[primary] ou premier emails[]. */
+function pickEmail(r: Record<string, any>): string | null {
+  const un = asStr(r.userName)
+  if (un.includes('@')) return un.toLowerCase()
+  if (Array.isArray(r.emails)) {
+    const primary = r.emails.find((e: any) => e && e.primary && asStr(e.value))
+    const any = r.emails.find((e: any) => e && asStr(e.value))
+    const v = asStr((primary ?? any)?.value)
+    if (v.includes('@')) return v.toLowerCase()
+  }
+  return null
+}
+
+/** Ressource SCIM User → champs ACRA. Null si aucun e-mail exploitable. */
+export function scimUserToAcra(resource: unknown): AcraUserFields | null {
+  if (!resource || typeof resource !== 'object') return null
+  const r = resource as Record<string, any>
+  const email = pickEmail(r)
+  if (!email) return null
+  return { email, name: pickName(r), active: coerceBool(r.active, true) }
+}
+
+export interface AcraUserLike { id: string; email: string; name: string | null; isActive: boolean }
+
+/** Utilisateur ACRA → ressource SCIM User. */
+export function acraUserToScim(u: AcraUserLike) {
+  return {
+    schemas: [SCIM_USER_SCHEMA],
+    id: u.id,
+    userName: u.email,
+    displayName: u.name ?? undefined,
+    name: u.name ? { formatted: u.name } : undefined,
+    emails: [{ value: u.email, primary: true }],
+    active: u.isActive,
+    meta: { resourceType: 'User' },
+  }
+}
+
+/** Parse un filtre SCIM `userName eq "valeur"` (seul filtre supporté) → e-mail. */
+export function parseScimUserNameFilter(filter: unknown): string | null {
+  if (typeof filter !== 'string') return null
+  const m = filter.match(/^\s*userName\s+eq\s+"([^"]+)"\s*$/i)
+  return m ? m[1].trim().toLowerCase() : null
+}
+
+export interface ScimPatchOp { op?: string; path?: string; value?: unknown }
+
+/**
+ * Applique des opérations SCIM PATCH aux champs ACRA (surtout `active` pour le
+ * déprovisioning). Supporte `replace` avec path='active' ou un objet value.
+ * Ops/paths inconnus ignorés (pas d'erreur).
+ */
+export function applyScimPatch(current: { active: boolean; name: string | null }, operations: ScimPatchOp[]): { active: boolean; name: string | null } {
+  let { active, name } = current
+  for (const op of operations ?? []) {
+    if (asStr(op.op).toLowerCase() !== 'replace') continue
+    const path = asStr(op.path).toLowerCase()
+    if (path === 'active') { active = coerceBool(op.value, active) }
+    else if (path === 'displayname') { name = asStr(op.value) || name }
+    else if (!path && op.value && typeof op.value === 'object') {
+      const v = op.value as Record<string, any>
+      if ('active' in v) active = coerceBool(v.active, active)
+      if (asStr(v.displayName)) name = asStr(v.displayName)
+    }
+  }
+  return { active, name }
+}
+
+/** Enveloppe SCIM ListResponse. */
+export function scimListResponse<T>(resources: T[], total?: number) {
+  return {
+    schemas: [SCIM_LIST_SCHEMA],
+    totalResults: total ?? resources.length,
+    startIndex: 1,
+    itemsPerPage: resources.length,
+    Resources: resources,
+  }
+}
+
+/** Enveloppe SCIM Error. */
+export function scimError(status: number, detail: string) {
+  return { schemas: [SCIM_ERROR_SCHEMA], status: String(status), detail }
+}


### PR DESCRIPTION
## Contexte
Dernier jalon P1 interopérabilité : **SCIM 2.0**. Un IdP/IGA (SailPoint, Azure AD, Okta) crée, met à jour et **désactive** les comptes ACRA automatiquement — le cycle de vie complet (arrivées/départs), en complément du SSO OIDC (qui authentifie et synchronise le rôle à la connexion).

## Portée & auth
**Per-organisation** (comme clés d'API et webhooks). L'IdP s'authentifie avec une **clé d'API à nouveau scope `provision`** (`Authorization: Bearer acra_<prefix>_<secret>`). Les comptes sont provisionnés **dans l'org de la clé** via `OrgMembership` ; le `User` (e-mail unique) reste partagé entre orgs. `/api/scim/` est exempté de l'auth par session (auth Bearer dans le handler).

## Endpoints `/api/scim/v2`
| Méthode | Chemin | Effet |
|---|---|---|
| GET | `/ServiceProviderConfig` | Capacités (patch, filter, bearer). |
| GET | `/Users?filter=userName eq "x"` | Recherche par e-mail (0/1). |
| POST | `/Users` | **Provisionne** (User + appartenance rôle `LECTEUR`) ; `409` si déjà membre. |
| GET/PUT/PATCH/DELETE | `/Users/{id}` | Lecture / remplacement / `active=false` (**déprovisioning** Azure AD) / suppression. |

Réponses `application/scim+json`. **Déprovisioning** = retrait de l'appartenance à l'org ; si c'était la dernière, `User.isActive=false`.

## Tests
- Cœur pur `lib/scim.ts` : 12 tests (mapping SCIM↔ACRA, filtre `userName eq`, `applyScimPatch`, enveloppes). Suite complète **1352 OK**, `tsc` clean.
- **Vérif live** (org StarBank, clé scope provision) : no-auth → 401 ; ServiceProviderConfig → 200 ; POST → 201 (User + membership) ; filtre → 1 ; POST doublon → 409 ; PATCH `active=false` → `active:false`, appartenance retirée, `User.isActive=false` ; GET après déprovisioning → 404.

## Limites / évolutions
v1 : ressource **Users**, rôle provisionné = `LECTEUR` (le rôle fin vient du mapping de groupes OIDC à la connexion). Ensuite : ressource **Groups**, mapping `roles` SCIM, pagination. Doc : `docs/specs/scim-provisioning.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)