### PR TITLE
feat(ux): autocomplétion des champs (valeurs déjà saisies, périmètre-scopé)

### DIFF
--- a/src/__tests__/unit/components/AutocompleteInput.test.tsx
+++ b/src/__tests__/unit/components/AutocompleteInput.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * AutocompleteInput.test.tsx — champ avec datalist alimenté par /api/suggestions.
+ *  - Rend la valeur et propage onChange
+ *  - Charge les suggestions au focus (une fois) et les rend en <option>
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AutocompleteInput from '@/components/AutocompleteInput'
+
+describe('AutocompleteInput', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('propage la saisie via onChange', () => {
+    const onChange = vi.fn()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ suggestions: [] }) }))
+    render(<AutocompleteInput field="organisation" value="" onChange={onChange} placeholder="Org" />)
+    fireEvent.change(screen.getByPlaceholderText('Org'), { target: { value: 'Ban' } })
+    expect(onChange).toHaveBeenCalledWith('Ban')
+  })
+
+  it('charge les suggestions au focus (une seule fois) et les rend', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ suggestions: ['Banque Populaire', 'Crédit Agricole'] }) })
+    vi.stubGlobal('fetch', fetchMock)
+    render(<AutocompleteInput field="organisation" value="" onChange={() => {}} placeholder="Org" />)
+    const input = screen.getByPlaceholderText('Org')
+    fireEvent.focus(input)
+    fireEvent.focus(input) // 2e focus : ne doit pas refetch
+    await waitFor(() => expect(document.querySelectorAll('datalist option')).toHaveLength(2))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('/api/suggestions?field=organisation')
+  })
+})

--- a/src/__tests__/unit/lib/suggestions.test.ts
+++ b/src/__tests__/unit/lib/suggestions.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { rankSuggestions, SUGGESTION_FIELDS, isSuggestionField } from '@/lib/suggestions'
+
+describe('rankSuggestions', () => {
+  it('déduplique (insensible à la casse) en gardant la 1ʳᵉ graphie', () => {
+    expect(rankSuggestions(['Acme', 'acme', 'ACME'], '')).toEqual(['Acme'])
+  })
+  it('ignore les valeurs vides / non-chaînes', () => {
+    expect(rankSuggestions(['  ', null, undefined, 'Banque', ''], '')).toEqual(['Banque'])
+  })
+  it('sans requête : tri alphabétique', () => {
+    expect(rankSuggestions(['Zeta', 'alpha', 'Béta'], '')).toEqual(['alpha', 'Béta', 'Zeta'])
+  })
+  it('avec requête : sous-chaîne, préfixes d’abord, exclut l’égalité exacte', () => {
+    const r = rankSuggestions(['Banque Populaire', 'Crédit Banque', 'banque', 'Autre'], 'banque')
+    expect(r).toEqual(['Banque Populaire', 'Crédit Banque']) // 'banque' exact exclu, préfixe avant sous-chaîne
+  })
+  it('respecte la limite', () => {
+    expect(rankSuggestions(['a', 'b', 'c', 'd'], '', 2)).toHaveLength(2)
+  })
+})
+
+describe('champs whitelistés', () => {
+  it('isSuggestionField', () => {
+    expect(isSuggestionField('organisation')).toBe(true)
+    expect(isSuggestionField('tag')).toBe(true)
+    expect(isSuggestionField('password')).toBe(false)
+    expect(SUGGESTION_FIELDS.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/src/app/analyses/new/page.tsx
+++ b/src/app/analyses/new/page.tsx
@@ -9,6 +9,7 @@ import { useEbiosData } from '@/lib/i18n/use-ebios-data'
 import { sousSecteurIdsFor } from '@/lib/sous-secteurs'
 import { parseTagsInput } from '@/lib/analyse-tags'
 import { MENTIONS_PROTECTION } from '@/lib/mention-protection'
+import AutocompleteInput from '@/components/AutocompleteInput'
 
 export default function NewAnalysePage() {
   const router = useRouter()
@@ -78,8 +79,8 @@ export default function NewAnalysePage() {
 
           <div>
             <label className="label">{t.newAnalysis.org}</label>
-            <input type="text" value={form.organisation}
-              onChange={e => setForm({ ...form, organisation: e.target.value })}
+            <AutocompleteInput field="organisation" value={form.organisation}
+              onChange={v => setForm({ ...form, organisation: v })}
               className="input" placeholder={t.newAnalysis.orgPh} />
           </div>
 

--- a/src/app/api/suggestions/route.ts
+++ b/src/app/api/suggestions/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { getAnalyseScope } from '@/lib/org-context.server'
+import { analyseWhereClause, type UserRole } from '@/lib/permissions'
+import { rankSuggestions, isSuggestionField } from '@/lib/suggestions'
+import { tagsUniques } from '@/lib/analyse-tags'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/suggestions?field=organisation|tag&q=... — valeurs déjà saisies dans
+// le périmètre visible de l'utilisateur, pour l'autocomplétion. Ne renvoie que
+// des libellés issus des analyses que l'utilisateur peut déjà voir.
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) return NextResponse.json({ suggestions: [] }, { status: 401 })
+
+  const field = req.nextUrl.searchParams.get('field')
+  const q = req.nextUrl.searchParams.get('q') ?? ''
+  if (!isSuggestionField(field)) return NextResponse.json({ suggestions: [] })
+
+  const userId = (session.user as { id: string }).id
+  const userRole = ((session.user as { role?: string }).role ?? 'ANALYSTE') as UserRole
+  const scope = await getAnalyseScope(userId, userRole)
+  const where = analyseWhereClause(userId, scope.role, scope.scope)
+
+  let candidates: (string | null | undefined)[] = []
+  if (field === 'organisation') {
+    const rows = await (prisma.analyse as unknown as {
+      findMany: (a: unknown) => Promise<{ organisation: string | null }[]>
+    }).findMany({ where, select: { organisation: true }, take: 500 })
+    candidates = rows.map(r => r.organisation)
+  } else if (field === 'tag') {
+    const rows = await (prisma.analyse as unknown as {
+      findMany: (a: unknown) => Promise<{ tags: unknown }[]>
+    }).findMany({ where, select: { tags: true }, take: 500 })
+    candidates = tagsUniques(rows.map(r => ({ tags: Array.isArray(r.tags) ? (r.tags as string[]) : [] })))
+  }
+
+  return NextResponse.json({ suggestions: rankSuggestions(candidates, q) })
+}

--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useId, useState } from 'react'
+
+interface Props {
+  field: string
+  value: string
+  onChange: (v: string) => void
+  className?: string
+  placeholder?: string
+  required?: boolean
+  id?: string
+}
+
+/**
+ * Champ texte avec autocomplétion native (<datalist>) alimentée par
+ * /api/suggestions?field=… (valeurs déjà saisies dans le périmètre de
+ * l'utilisateur). Récupère les suggestions à la 1ʳᵉ interaction (focus), une
+ * fois — les ensembles (organisations, tags) sont petits. Dégrade proprement en
+ * simple <input> si le fetch échoue.
+ */
+export default function AutocompleteInput({ field, value, onChange, className, placeholder, required, id }: Props) {
+  const listId = useId()
+  const [options, setOptions] = useState<string[]>([])
+  const [loaded, setLoaded] = useState(false)
+
+  async function loadOnce() {
+    if (loaded) return
+    setLoaded(true)
+    try {
+      const d = await fetch(`/api/suggestions?field=${encodeURIComponent(field)}`).then(r => (r.ok ? r.json() : { suggestions: [] }))
+      if (Array.isArray(d.suggestions)) setOptions(d.suggestions)
+    } catch { /* dégradation : input simple */ }
+  }
+  useEffect(() => () => { /* no-op cleanup */ }, [])
+
+  return (
+    <>
+      <input
+        type="text"
+        id={id}
+        required={required}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onFocus={loadOnce}
+        list={listId}
+        autoComplete="off"
+        className={className}
+        placeholder={placeholder}
+      />
+      <datalist id={listId}>
+        {options.map(o => <option key={o} value={o} />)}
+      </datalist>
+    </>
+  )
+}

--- a/src/lib/suggestions.ts
+++ b/src/lib/suggestions.ts
@@ -1,0 +1,46 @@
+// ─── Autocomplétion de champs — cœur pur ─────────────────────────────────────
+// Classe des valeurs candidates (valeurs déjà saisies dans l'organisation) pour
+// suggérer une saisie. Réduit la re-frappe et les doublons dans les registres.
+// Logique PURE et testable ; la collecte des candidats vit côté serveur.
+
+/** Champs texte libres proposant de l'autocomplétion (whitelist). */
+export const SUGGESTION_FIELDS = ['organisation', 'tag'] as const
+export type SuggestionField = (typeof SUGGESTION_FIELDS)[number]
+
+export function isSuggestionField(v: unknown): v is SuggestionField {
+  return typeof v === 'string' && (SUGGESTION_FIELDS as readonly string[]).includes(v)
+}
+
+/**
+ * Classe/filtre des candidats pour une requête. Déduplique (insensible à la
+ * casse, 1ʳᵉ graphie conservée). Avec requête : ne garde que les sous-chaînes,
+ * les préfixes d'abord, exclut l'égalité exacte (rien à suggérer). Sans requête :
+ * tri alphabétique. Plafonné à `limit`.
+ */
+export function rankSuggestions(candidates: readonly (string | null | undefined)[], query: string, limit = 8): string[] {
+  const q = (query ?? '').trim().toLowerCase()
+  const seen = new Map<string, string>()
+  for (const c of candidates) {
+    if (typeof c !== 'string') continue
+    const v = c.trim()
+    if (!v) continue
+    const low = v.toLowerCase()
+    if (!seen.has(low)) seen.set(low, v)
+  }
+  let items = [...seen.values()]
+  if (q) {
+    items = items.filter(v => {
+      const low = v.toLowerCase()
+      return low.includes(q) && low !== q
+    })
+    items.sort((a, b) => {
+      const ap = a.toLowerCase().startsWith(q) ? 0 : 1
+      const bp = b.toLowerCase().startsWith(q) ? 0 : 1
+      if (ap !== bp) return ap - bp
+      return a.localeCompare(b)
+    })
+  } else {
+    items.sort((a, b) => a.localeCompare(b))
+  }
+  return items.slice(0, Math.max(0, limit))
+}


### PR DESCRIPTION
## Contexte
Item **« autocomplétion des champs »** du bilan direction des risques. Objectif : réduire la re-frappe et les **doublons** dans les registres — un champ texte suggère les valeurs déjà utilisées dans le périmètre visible de l'utilisateur.

## Ce que fait la PR
- **Cœur pur testé** (`lib/suggestions.ts`) : `rankSuggestions` (déduplication insensible à la casse en gardant la 1ʳᵉ graphie, filtre sous-chaîne, **préfixes d'abord**, exclut l'égalité exacte, plafond) + whitelist de champs (`organisation`, `tag`).
- **Endpoint** `GET /api/suggestions?field=&q=` : **org-scopé** via `analyseWhereClause` → ne renvoie que des libellés issus des analyses que l'utilisateur peut déjà voir (aucune fuite inter-périmètre). Protégé par session.
- **Composant réutilisable** `AutocompleteInput` : `<datalist>` natif (accessible, sans dépendance), fetch au 1ᵉʳ focus (une fois), dégradation propre si le fetch échoue. Câblé sur le champ **« organisation »** de la création d'analyse.

## Tests
- +8 tests (cœur pur + composant avec fetch mocké). Suite complète **1360 OK**, `tsc` clean.
- **Vérif live** (session RSSI StarBank) : suggestions vides au départ, remontent la valeur saisie, filtre `q=` fonctionnel, requête non authentifiée → 307 (protégé), et **scoping** confirmé (seule l'analyse visible remonte).

## Réutilisable
Le même composant + endpoint couvrent d'autres champs libres répétitifs (tags, parties prenantes, sources de risque…) — il suffit d'ajouter le champ à la whitelist et d'alimenter les candidats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)