### PR TITLE
feat(ux): autocomplétion des sources de risque + parties prenantes

### DIFF
--- a/src/__tests__/unit/lib/suggestions.test.ts
+++ b/src/__tests__/unit/lib/suggestions.test.ts
@@ -24,7 +24,9 @@ describe('champs whitelistés', () => {
   it('isSuggestionField', () => {
     expect(isSuggestionField('organisation')).toBe(true)
     expect(isSuggestionField('tag')).toBe(true)
+    expect(isSuggestionField('sourceRisque')).toBe(true)
+    expect(isSuggestionField('partiePrenante')).toBe(true)
     expect(isSuggestionField('password')).toBe(false)
-    expect(SUGGESTION_FIELDS.length).toBeGreaterThanOrEqual(2)
+    expect(SUGGESTION_FIELDS.length).toBeGreaterThanOrEqual(4)
   })
 })

--- a/src/app/api/suggestions/route.ts
+++ b/src/app/api/suggestions/route.ts
@@ -25,17 +25,25 @@ export async function GET(req: NextRequest) {
   const scope = await getAnalyseScope(userId, userRole)
   const where = analyseWhereClause(userId, scope.role, scope.scope)
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const db = prisma as any
   let candidates: (string | null | undefined)[] = []
   if (field === 'organisation') {
-    const rows = await (prisma.analyse as unknown as {
-      findMany: (a: unknown) => Promise<{ organisation: string | null }[]>
-    }).findMany({ where, select: { organisation: true }, take: 500 })
-    candidates = rows.map(r => r.organisation)
+    const rows = await db.analyse.findMany({ where, select: { organisation: true }, take: 500 })
+    candidates = rows.map((r: { organisation: string | null }) => r.organisation)
   } else if (field === 'tag') {
-    const rows = await (prisma.analyse as unknown as {
-      findMany: (a: unknown) => Promise<{ tags: unknown }[]>
-    }).findMany({ where, select: { tags: true }, take: 500 })
-    candidates = tagsUniques(rows.map(r => ({ tags: Array.isArray(r.tags) ? (r.tags as string[]) : [] })))
+    const rows = await db.analyse.findMany({ where, select: { tags: true }, take: 500 })
+    candidates = tagsUniques(rows.map((r: { tags: unknown }) => ({ tags: Array.isArray(r.tags) ? (r.tags as string[]) : [] })))
+  } else {
+    // Champs portés par des tables liées (SourceRisque, PartiePrenante) : scopés
+    // aux analyses VISIBLES de l'utilisateur via analyseId ∈ périmètre.
+    const analyses = await db.analyse.findMany({ where, select: { id: true }, take: 1000 })
+    const ids = analyses.map((a: { id: string }) => a.id)
+    if (ids.length) {
+      const table = field === 'sourceRisque' ? db.sourceRisque : db.partiePrenante
+      const rows = await table.findMany({ where: { analyseId: { in: ids } }, select: { nom: true }, take: 1000 })
+      candidates = rows.map((r: { nom: string | null }) => r.nom)
+    }
   }
 
   return NextResponse.json({ suggestions: rankSuggestions(candidates, q) })

--- a/src/components/workshops/Atelier2.tsx
+++ b/src/components/workshops/Atelier2.tsx
@@ -38,6 +38,7 @@ import { withSectorExemples } from '@/lib/exemples-sectoriels'
 import { useEbiosData } from '@/lib/i18n/use-ebios-data'
 import { defaultExemplesFor, type ExemplesTranslations } from '@/lib/exemples-defaults'
 import SrOvRadar from '@/components/SrOvRadar'
+import AutocompleteInput from '@/components/AutocompleteInput'
 
 interface Props {
   analyseId: string
@@ -382,7 +383,7 @@ export default function Atelier2({ analyseId, initialData, analyse, flashMode }:
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                           <div>
                             <label className="label" htmlFor={`sr-nom-${s.id}`}>{t.workshop.nameLabel}</label>
-                            <input id={`sr-nom-${s.id}`} value={s.nom} onChange={e => updateSource(s.id, 'nom', e.target.value)} className="input text-sm" />
+                            <AutocompleteInput id={`sr-nom-${s.id}`} field="sourceRisque" value={s.nom} onChange={v => updateSource(s.id, 'nom', v)} className="input text-sm" />
                           </div>
                           <div>
                             <label className="label" htmlFor={`sr-cat-${s.id}`}>{t.workshop.a2.srCatLabel}</label>

--- a/src/lib/suggestions.ts
+++ b/src/lib/suggestions.ts
@@ -4,7 +4,7 @@
 // Logique PURE et testable ; la collecte des candidats vit côté serveur.
 
 /** Champs texte libres proposant de l'autocomplétion (whitelist). */
-export const SUGGESTION_FIELDS = ['organisation', 'tag'] as const
+export const SUGGESTION_FIELDS = ['organisation', 'tag', 'sourceRisque', 'partiePrenante'] as const
 export type SuggestionField = (typeof SUGGESTION_FIELDS)[number]
 
 export function isSuggestionField(v: unknown): v is SuggestionField {


### PR DESCRIPTION
## Contexte
Suite de l'autocomplétion (#56). Étend la fondation aux **champs EBIOS les plus répétitifs** d'une analyse à l'autre : sources de risque (menaces) et parties prenantes reviennent constamment — les proposer réduit la re-frappe et l'hétérogénéité des libellés.

## Ce que fait la PR
- `sourceRisque` et `partiePrenante` ajoutés à la whitelist `SUGGESTION_FIELDS` et à l'endpoint `/api/suggestions` : valeurs tirées des tables `SourceRisque`/`PartiePrenante`, **scopées aux analyses visibles** de l'utilisateur (`analyseId ∈ périmètre` via `analyseWhereClause`).
- Champ **« source de risque »** (Atelier 2) câblé sur `AutocompleteInput` (datalist natif).
- **Atelier 3 (partie prenante) laissé tel quel** : il dispose déjà de son autocomplétion via le datalist `tiers-known` (réutilisation des tiers, #46) — volontairement **non remplacé** pour ne pas régresser cette fonctionnalité. `partiePrenante` reste exposé côté endpoint (API).

## Tests
- Whitelist étendue (`isSuggestionField`). Suite complète **1361 OK**, `tsc` clean.
- **Vérif live** (session RSSI StarBank) : `sourceRisque` → sources de menace réelles, `partiePrenante` → parties prenantes réelles, filtre `q=` fonctionnel, scoping org confirmé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)