### PR TITLE
fix(security): restreindre les preuves aux types de média inertes (#129)

### DIFF
--- a/src/__tests__/unit/lib/preuves.test.ts
+++ b/src/__tests__/unit/lib/preuves.test.ts
@@ -37,4 +37,17 @@ describe('sanitizePreuves', () => {
     expect(sanitizePreuves([null, 'x', ok('bon.pdf'), 42])).toHaveLength(1)
     expect(sanitizePreuves([null, ok('bon.pdf')])[0].nom).toBe('bon.pdf')
   })
+  it('#129 — écarte les data URL à média actif (text/html, svg), garde les médias inertes', () => {
+    // text/html et svg peuvent porter du script exécutable → XSS stocké si un jour
+    // la preuve est rendue/ouverte inline. On borne le type de média de la data URL.
+    expect(sanitizePreuves([{ ...ok(), mime: 'text/html', dataUrl: 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==' }])).toEqual([])
+    expect(sanitizePreuves([{ ...ok(), mime: 'image/svg+xml', dataUrl: 'data:image/svg+xml,<svg onload=alert(1)>' }])).toEqual([])
+    expect(sanitizePreuves([{ ...ok(), dataUrl: 'data:application/xhtml+xml;base64,AA' }])).toEqual([])
+    // médias inertes conservés (screenshots, PDF, logs texte)
+    expect(sanitizePreuves([ok()])).toHaveLength(1) // application/pdf
+    expect(sanitizePreuves([{ ...ok(), dataUrl: 'data:image/png;base64,iVBORw0KGgo=' }])).toHaveLength(1)
+    expect(sanitizePreuves([{ ...ok(), dataUrl: 'data:image/jpeg;base64,/9j/4AAQ' }])).toHaveLength(1)
+    expect(sanitizePreuves([{ ...ok(), dataUrl: 'data:text/plain;base64,AA' }])).toHaveLength(1)
+    expect(sanitizePreuves([{ ...ok(), dataUrl: 'data:text/csv;base64,AA' }])).toHaveLength(1)
+  })
 })

--- a/src/lib/preuves.ts
+++ b/src/lib/preuves.ts
@@ -11,6 +11,24 @@
 export const PREUVES_MAX = 5
 export const PREUVE_DATAURL_MAX = 1_400_000
 
+// Types de média INERTES autorisés pour une preuve (data URL). Volontairement sans
+// text/html, image/svg+xml, application/xhtml+xml ni autre format à contenu actif :
+// ces formats peuvent porter du script et provoqueraient un XSS stocké si une preuve
+// était un jour rendue/ouverte inline (#129, CWE-79). Aligné sur ALLOWED_DOCUMENT_MIME.
+export const PREUVE_MIME_AUTORISES = new Set<string>([
+  'image/png',
+  'image/jpeg',
+  'application/pdf',
+  'text/plain',
+  'text/csv',
+])
+
+/** Type de média déclaré dans une data URL (`data:<média>[;...]` ), en minuscules. */
+export function dataUrlMediaType(dataUrl: string): string {
+  const m = /^data:([^;,]*)/i.exec(dataUrl)
+  return (m?.[1] ?? '').trim().toLowerCase()
+}
+
 export interface Preuve {
   nom: string
   mime: string
@@ -26,6 +44,8 @@ export function sanitizePreuves(v: unknown): Preuve[] {
     const o = p as Record<string, unknown>
     const dataUrl = typeof o.dataUrl === 'string' ? o.dataUrl : ''
     if (!/^data:/.test(dataUrl) || dataUrl.length > PREUVE_DATAURL_MAX) return []
+    // Borne le type de média au jeu inerte (anti-XSS stocké, #129).
+    if (!PREUVE_MIME_AUTORISES.has(dataUrlMediaType(dataUrl))) return []
     return [{
       nom: String(o.nom ?? 'preuve').slice(0, 200),
       mime: String(o.mime ?? '').slice(0, 100),


### PR DESCRIPTION
## Problème (issue #129, CWE-79 stored XSS)
`sanitizePreuves` acceptait n'importe quelle data URL. Un fichier de preuve au type `text/html`, `image/svg+xml` ou `application/xhtml+xml` peut porter du script → **XSS stocké** si une preuve venait à être rendue/ouverte inline.

## Correctif
`sanitizePreuves` borne désormais le type de média au **jeu inerte** `PREUVE_MIME_AUTORISES` : `image/png`, `image/jpeg`, `application/pdf`, `text/plain`, `text/csv` (aligné sur `ALLOWED_DOCUMENT_MIME`). Type extrait de la data URL via `dataUrlMediaType`. Toute preuve hors allowlist est rejetée.

## Tests
- `preuves.test.ts` étendu (data URL HTML/SVG rejetée, types inertes acceptés). **9 tests OK**, `tsc` clean.

> Ce correctif était présent dans l'arbre de travail (produit par la tâche de test continu) ; je le livre séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)