### PR TITLE
fix(security): RBAC des routes analyse sur le rôle d'org effectif (#130)

### DIFF
--- a/src/__tests__/unit/lib/permissions.test.ts
+++ b/src/__tests__/unit/lib/permissions.test.ts
@@ -13,6 +13,7 @@ import {
   canAutoValidateAnalyse,
   canManageAccess,
   canAcceptResidualRisks,
+  resolveAnalyseRole,
   analyseWhereClause,
   type SessionUser,
   type AnalyseOwnership,
@@ -390,5 +391,23 @@ describe('hasGlobalReadDispositif + analyseWhereClause (lecture globale — #126
     // ANALYSTE reste limité à ses propres analyses + partagées (pas de statuts globaux).
     const a = analyseWhereClause('u1', 'ANALYSTE') as { OR?: { statut?: string }[] }
     expect((a.OR ?? []).some(o => o.statut)).toBe(false)
+  })
+})
+
+describe('resolveAnalyseRole (#130 — rôle gouvernant les actions sur une analyse)', () => {
+  it('analyse SANS organisation (héritée/legacy) → rôle d\'instance (rétrocompat)', () => {
+    expect(resolveAnalyseRole('RISK_MANAGER', null, null)).toBe('RISK_MANAGER')
+    expect(resolveAnalyseRole('DIRECTION_METIER', undefined, 'LECTEUR')).toBe('DIRECTION_METIER')
+  })
+  it('analyse AVEC organisation → rôle EFFECTIF d\'org, pas l\'instance (#130)', () => {
+    // instance privilégié mais membre LECTEUR de l'org de l'analyse → LECTEUR gouverne (ferme le bypass)
+    expect(resolveAnalyseRole('RISK_MANAGER', 'org1', 'LECTEUR')).toBe('LECTEUR')
+    expect(resolveAnalyseRole('DIRECTION_METIER', 'org1', 'LECTEUR')).toBe('LECTEUR')
+    // instance ANALYSTE (défaut) mais membre RISK_MANAGER de l'org → RISK_MANAGER (corrige le faux-négatif)
+    expect(resolveAnalyseRole('ANALYSTE', 'org1', 'RISK_MANAGER')).toBe('RISK_MANAGER')
+  })
+  it('analyse AVEC organisation mais AUCUNE appartenance (accès par propriété/partage) → LECTEUR', () => {
+    expect(resolveAnalyseRole('DIRECTION_METIER', 'org1', null)).toBe('LECTEUR')
+    expect(resolveAnalyseRole('ADMIN', 'org1', null)).toBe('LECTEUR')
   })
 })

--- a/src/app/api/analyses/[id]/accept-residual-risks/route.ts
+++ b/src/app/api/analyses/[id]/accept-residual-risks/route.ts
@@ -1,10 +1,10 @@
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
-import { analyseAccessWhere } from '@/lib/org-context.server'
+import { analyseAccessWhere, getEffectiveRoleForOrg } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
 import { NextRequest, NextResponse } from 'next/server'
-import { canAcceptResidualRisks } from '@/lib/permissions'
+import { canAcceptResidualRisks, resolveAnalyseRole } from '@/lib/permissions'
 import { auditLog, getClientIp } from '@/lib/logger'
 
 type Params = { params: Promise<{ id: string }> }
@@ -34,7 +34,10 @@ export async function POST(req: NextRequest, { params }: Params) {
 
   // La fonctionnalité doit être activée pour l'organisation de l'analyse.
   const orgConfig = await getOrgConfig(analyse.organizationId)
-  if (!canAcceptResidualRisks({ id: userId, role: userRole }, orgConfig.acceptationRisquesActive)) {
+  // RBAC sur le rôle EFFECTIF d'org (pas l'instance) — #130.
+  const membershipRole = analyse.organizationId ? await getEffectiveRoleForOrg(userId, userRole, analyse.organizationId) : null
+  const effRole = resolveAnalyseRole(userRole, analyse.organizationId, membershipRole)
+  if (!canAcceptResidualRisks({ id: userId, role: effRole }, orgConfig.acceptationRisquesActive)) {
     return NextResponse.json(
       { error: orgConfig.acceptationRisquesActive
           ? 'Réservé à la Direction métier'

--- a/src/app/api/analyses/[id]/access/route.ts
+++ b/src/app/api/analyses/[id]/access/route.ts
@@ -1,9 +1,9 @@
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
-import { analyseAccessWhere } from '@/lib/org-context.server'
+import { analyseAccessWhere, getEffectiveRoleForOrg } from '@/lib/org-context.server'
 import { NextRequest, NextResponse } from 'next/server'
-import { canManageAccess } from '@/lib/permissions'
+import { canManageAccess, resolveAnalyseRole } from '@/lib/permissions'
 import type { AnalysePermission } from '@/lib/permissions'
 
 type Params = { params: Promise<{ id: string }> }
@@ -23,7 +23,10 @@ export async function GET(_req: NextRequest, { params }: Params) {
   })
   if (!analyse || analyse.deletedAt) return NextResponse.json({ error: 'Introuvable' }, { status: 404 })
 
-  if (!canManageAccess({ id: userId, role: userRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
+  // RBAC sur le rôle EFFECTIF d'org (pas l'instance) — #130.
+  const membershipRole = analyse.organizationId ? await getEffectiveRoleForOrg(userId, userRole, analyse.organizationId) : null
+  const effRole = resolveAnalyseRole(userRole, analyse.organizationId, membershipRole)
+  if (!canManageAccess({ id: userId, role: effRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
 
@@ -45,7 +48,10 @@ export async function POST(req: NextRequest, { params }: Params) {
   })
   if (!analyse || analyse.deletedAt) return NextResponse.json({ error: 'Introuvable' }, { status: 404 })
 
-  if (!canManageAccess({ id: userId, role: userRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
+  // RBAC sur le rôle EFFECTIF d'org (pas l'instance) — #130.
+  const membershipRole = analyse.organizationId ? await getEffectiveRoleForOrg(userId, userRole, analyse.organizationId) : null
+  const effRole = resolveAnalyseRole(userRole, analyse.organizationId, membershipRole)
+  if (!canManageAccess({ id: userId, role: effRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
 
@@ -91,7 +97,10 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   })
   if (!analyse || analyse.deletedAt) return NextResponse.json({ error: 'Introuvable' }, { status: 404 })
 
-  if (!canManageAccess({ id: userId, role: userRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
+  // RBAC sur le rôle EFFECTIF d'org (pas l'instance) — #130.
+  const membershipRole = analyse.organizationId ? await getEffectiveRoleForOrg(userId, userRole, analyse.organizationId) : null
+  const effRole = resolveAnalyseRole(userRole, analyse.organizationId, membershipRole)
+  if (!canManageAccess({ id: userId, role: effRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
 

--- a/src/app/api/analyses/[id]/approbation/route.ts
+++ b/src/app/api/analyses/[id]/approbation/route.ts
@@ -1,9 +1,9 @@
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
-import { analyseAccessWhere, countOrgMembers } from '@/lib/org-context.server'
+import { analyseAccessWhere, countOrgMembers, getEffectiveRoleForOrg } from '@/lib/org-context.server'
 import { NextRequest, NextResponse } from 'next/server'
-import { canSubmitAnalyse, canApproveAnalyse, canAutoValidateAnalyse } from '@/lib/permissions'
+import { canSubmitAnalyse, canApproveAnalyse, canAutoValidateAnalyse, resolveAnalyseRole } from '@/lib/permissions'
 import { auditLog, getClientIp } from '@/lib/logger'
 
 type Params = { params: Promise<{ id: string }> }
@@ -30,7 +30,10 @@ export async function POST(req: NextRequest, { params }: Params) {
   }
 
   const ownership = { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs }
-  const sessionUser = { id: userId, role: userRole }
+  // RBAC sur le rôle EFFECTIF d'org (pas l'instance) — #130.
+  const membershipRole = analyse.organizationId ? await getEffectiveRoleForOrg(userId, userRole, analyse.organizationId) : null
+  const effRole = resolveAnalyseRole(userRole, analyse.organizationId, membershipRole)
+  const sessionUser = { id: userId, role: effRole }
 
   // Auto-validation (organisation MONO-UTILISATEUR) : le propriétaire valide
   // directement son analyse (EN_COURS/REJETE → APPROUVE) car il n'existe aucun

--- a/src/app/api/analyses/[id]/derogations/route.ts
+++ b/src/app/api/analyses/[id]/derogations/route.ts
@@ -1,9 +1,9 @@
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
-import { analyseAccessWhere } from '@/lib/org-context.server'
+import { analyseAccessWhere, getEffectiveRoleForOrg } from '@/lib/org-context.server'
 import { getOrgConfig } from '@/lib/org-config.server'
-import { canEditAnalyse, type UserRole } from '@/lib/permissions'
+import { canEditAnalyse, resolveAnalyseRole, type UserRole } from '@/lib/permissions'
 import { validateDerogationInput, statutInitial, calcDateFin, type DerogationWorkflow } from '@/lib/derogation'
 import { auditLog, getClientIp } from '@/lib/logger'
 import { NextRequest, NextResponse } from 'next/server'
@@ -60,7 +60,10 @@ export async function POST(req: NextRequest, { params }: Params) {
   if (!orgConfig.derogationsActive) {
     return NextResponse.json({ error: 'Les dérogations ne sont pas activées pour cette organisation' }, { status: 403 })
   }
-  if (!canEditAnalyse({ id: userId, role: userRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
+  // RBAC sur le rôle EFFECTIF d'org (pas l'instance) — #130.
+  const membershipRole = analyse.organizationId ? await getEffectiveRoleForOrg(userId, userRole, analyse.organizationId) : null
+  const effRole = resolveAnalyseRole(userRole, analyse.organizationId, membershipRole)
+  if (!canEditAnalyse({ id: userId, role: effRole }, { userId: analyse.userId, accesUtilisateurs: analyse.accesUtilisateurs })) {
     return NextResponse.json({ error: 'Accès refusé — seul le porteur peut demander une dérogation' }, { status: 403 })
   }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -152,6 +152,28 @@ export function canAcceptResidualRisks(user: SessionUser, featureActive: boolean
   return user.role === 'DIRECTION_METIER' || isAdminRole(user.role)
 }
 
+/**
+ * Rôle GOUVERNANT une action sur une analyse (#130). Les routes `analyses/[id]/*`
+ * doivent gater sur le rôle EFFECTIF de l'utilisateur DANS L'ORGANISATION de
+ * l'analyse — pas sur son rôle d'INSTANCE (`User.role`), qui peut être plus élevé
+ * que son appartenance et contournerait alors le RBAC d'org (même classe que #124 /
+ * CWE-863 : autorisation calculée au mauvais niveau de rôle).
+ *   - analyse SANS organisation (héritée/legacy) → rôle d'instance (rétrocompat) ;
+ *   - analyse AVEC organisation → rôle d'appartenance effectif (`membershipRole`),
+ *     ou `LECTEUR` si l'accès provient de la propriété/du partage sans appartenance
+ *     (les droits liés à la propriété et aux accès granulaires sont gérés à part par
+ *     `canEditAnalyse`/`canSubmitAnalyse`/etc.).
+ * Pur → testable sans DB (la résolution en base est faite par `getEffectiveRoleForOrg`).
+ */
+export function resolveAnalyseRole(
+  instanceRole: UserRole,
+  organizationId: string | null | undefined,
+  membershipRole: UserRole | null,
+): UserRole {
+  if (!organizationId) return instanceRole
+  return membershipRole ?? 'LECTEUR'
+}
+
 /** L'utilisateur peut modifier les ateliers de l'analyse */
 export function canEditAnalyse(user: SessionUser, analyse: AnalyseOwnership): boolean {
   if (isAdminRole(user.role)) return true


### PR DESCRIPTION
## Problème (issue #130, CWE-863 — même classe que #124)
Les routes `analyses/[id]/{approbation, derogations, accept-residual-risks, access}` calculaient l'autorisation à partir de `User.role` (**rôle d'INSTANCE**). Or ce rôle peut être plus élevé que l'appartenance effective de l'utilisateur à **l'organisation de l'analyse** → un utilisateur pouvait approuver / gérer des dérogations / accepter des risques résiduels / gérer les accès sur une analyse d'une org où son rôle d'appartenance ne l'y autorise pas (contournement du RBAC multi-org).

## Correctif
Résolution du **rôle EFFECTIF** avant tout contrôle : `getEffectiveRoleForOrg(userId, instanceRole, orgId)` + `resolveAnalyseRole` (pur, testé) :
- analyse **sans** organisation (héritée/legacy) → rôle d'instance (rétrocompatibilité) ;
- analyse **avec** organisation → rôle d'appartenance effectif, ou `LECTEUR` si l'accès vient de la propriété/du partage sans appartenance (ces droits restent gérés par `canEditAnalyse`/`canSubmitAnalyse`/etc.).

## Tests
- `permissions.test.ts` étendu (`resolveAnalyseRole` : sans org → instance ; avec org → membership ; défaut LECTEUR). **80 tests OK**, `tsc` clean.

> Correctif présent dans l'arbre de travail (tâche de test continu, prolongé à la route `access` pour couvrir toute la surface) ; livré séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)