### PR TITLE
feat(ux): autocomplétion des valeurs métier & biens supports (champs JSON)

### DIFF
--- a/src/__tests__/unit/lib/suggestions.test.ts
+++ b/src/__tests__/unit/lib/suggestions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { rankSuggestions, SUGGESTION_FIELDS, isSuggestionField } from '@/lib/suggestions'
+import { rankSuggestions, SUGGESTION_FIELDS, isSuggestionField, extractJsonNames } from '@/lib/suggestions'
 
 describe('rankSuggestions', () => {
   it('déduplique (insensible à la casse) en gardant la 1ʳᵉ graphie', () => {
@@ -28,7 +28,24 @@ describe('champs whitelistés', () => {
     expect(isSuggestionField('partiePrenante')).toBe(true)
     expect(isSuggestionField('mesure')).toBe(true)
     expect(isSuggestionField('entite')).toBe(true)
+    expect(isSuggestionField('valeurMetier')).toBe(true)
+    expect(isSuggestionField('bienSupport')).toBe(true)
     expect(isSuggestionField('password')).toBe(false)
-    expect(SUGGESTION_FIELDS.length).toBeGreaterThanOrEqual(6)
+    expect(SUGGESTION_FIELDS.length).toBeGreaterThanOrEqual(8)
+  })
+})
+
+describe('extractJsonNames', () => {
+  it('aplati les .nom des tableaux JSON, ignore malformés', () => {
+    const rows = [
+      [{ nom: 'Données clients' }, { nom: ' Système paiement ' }],
+      null,
+      'pas un tableau',
+      [{ nom: '' }, { pasnom: 'x' }, { nom: 'Référentiel RH' }],
+    ]
+    expect(extractJsonNames(rows)).toEqual(['Données clients', 'Système paiement', 'Référentiel RH'])
+  })
+  it('liste vide → []', () => {
+    expect(extractJsonNames([])).toEqual([])
   })
 })

--- a/src/app/api/suggestions/route.ts
+++ b/src/app/api/suggestions/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { getAnalyseScope } from '@/lib/org-context.server'
 import { analyseWhereClause, type UserRole } from '@/lib/permissions'
-import { rankSuggestions, isSuggestionField } from '@/lib/suggestions'
+import { rankSuggestions, isSuggestionField, extractJsonNames } from '@/lib/suggestions'
 import { tagsUniques } from '@/lib/analyse-tags'
 
 export const dynamic = 'force-dynamic'
@@ -39,6 +39,15 @@ export async function GET(req: NextRequest) {
     if (scope.activeOrgId) {
       const rows = await db.riskItem.findMany({ where: { organizationId: scope.activeOrgId }, select: { entite: true }, take: 1000 })
       candidates = rows.map((r: { entite: string | null }) => r.entite)
+    }
+  } else if (field === 'valeurMetier' || field === 'bienSupport') {
+    // Champs stockés en JSON dans le Cadrage (tableau d'objets {nom,…}).
+    const analyses = await db.analyse.findMany({ where, select: { id: true }, take: 1000 })
+    const ids = analyses.map((a: { id: string }) => a.id)
+    if (ids.length) {
+      const col = field === 'valeurMetier' ? 'valeursMetier' : 'biensSupports'
+      const rows = await db.cadrage.findMany({ where: { analyseId: { in: ids } }, select: { [col]: true }, take: 1000 })
+      candidates = extractJsonNames(rows.map((r: Record<string, unknown>) => r[col]))
     }
   } else {
     // Champs portés par des tables liées (SourceRisque, PartiePrenante) : scopés

--- a/src/components/workshops/Atelier1.tsx
+++ b/src/components/workshops/Atelier1.tsx
@@ -45,6 +45,7 @@ import Link from 'next/link'
 import { suggestsComplianceModule, nis2Classification, doraPrevailsOverNis2 } from '@/lib/regulatory-guidance'
 import { showsHdsCaveat } from '@/lib/sous-secteurs'
 import { ETATS_SOCLE, etatSocleFromEntry, type EtatSocle } from '@/lib/socle-etat'
+import AutocompleteInput from '@/components/AutocompleteInput'
 
 // Styles statiques de l'indicateur d'état d'application du socle (EXI_M1_20).
 const ETAT_SOCLE_STYLE: Record<EtatSocle, { dot: string; active: string; idle: string }> = {
@@ -633,10 +634,11 @@ export default function Atelier1({ analyseId, initialData, analyse, flashMode, c
                   <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                     <div className="sm:col-span-2">
                       <label className="label" htmlFor={`vm-nom-${vm.id}`}>{t.workshop.a1.vmNamePh}</label>
-                      <input
-                         id={`vm-nom-${vm.id}`}
+                      <AutocompleteInput
+                        id={`vm-nom-${vm.id}`}
+                        field="valeurMetier"
                         value={vm.nom}
-                        onChange={e => updateVm(vm.id, 'nom', e.target.value)}
+                        onChange={v => updateVm(vm.id, 'nom', v)}
                         className="input text-sm"
                         placeholder={t.workshop.a1.vmNameExPh}
                       />
@@ -844,8 +846,9 @@ export default function Atelier1({ analyseId, initialData, analyse, flashMode, c
                 <div key={b.id} className="flex gap-3 items-start p-3 bg-gray-50 rounded-lg">
                   <div className="flex-1 space-y-2">
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                      <input
-                        value={b.nom} onChange={e => updateBien(b.id, 'nom', e.target.value)}
+                      <AutocompleteInput
+                        field="bienSupport"
+                        value={b.nom} onChange={v => updateBien(b.id, 'nom', v)}
                         className="input text-sm" placeholder={t.workshop.a1.bsNamePh}
                       />
                       <select

--- a/src/lib/suggestions.ts
+++ b/src/lib/suggestions.ts
@@ -4,11 +4,28 @@
 // Logique PURE et testable ; la collecte des candidats vit côté serveur.
 
 /** Champs texte libres proposant de l'autocomplétion (whitelist). */
-export const SUGGESTION_FIELDS = ['organisation', 'tag', 'sourceRisque', 'partiePrenante', 'mesure', 'entite'] as const
+export const SUGGESTION_FIELDS = ['organisation', 'tag', 'sourceRisque', 'partiePrenante', 'mesure', 'entite', 'valeurMetier', 'bienSupport'] as const
 export type SuggestionField = (typeof SUGGESTION_FIELDS)[number]
 
 export function isSuggestionField(v: unknown): v is SuggestionField {
   return typeof v === 'string' && (SUGGESTION_FIELDS as readonly string[]).includes(v)
+}
+
+/**
+ * Extrait les `.nom` (chaînes non vides) d'une liste de valeurs JSON, chacune
+ * étant un tableau d'objets (ex. Cadrage.valeursMetier, Cadrage.biensSupports).
+ * Robuste aux valeurs null / non-tableaux / éléments malformés.
+ */
+export function extractJsonNames(values: unknown[]): string[] {
+  const out: string[] = []
+  for (const v of values) {
+    if (!Array.isArray(v)) continue
+    for (const item of v) {
+      const nom = item && typeof item === 'object' ? (item as { nom?: unknown }).nom : undefined
+      if (typeof nom === 'string' && nom.trim()) out.push(nom.trim())
+    }
+  }
+  return out
 }
 
 /**


### PR DESCRIPTION
## Contexte
Dernier lot d'autocomplétion (objectif simplicité). Couvre les champs les plus structurants d'une analyse EBIOS, stockés en **JSON** dans le `Cadrage` : **valeurs métier** (biens essentiels, FM1) et **biens supports**. Ils reviennent d'une analyse à l'autre (« Données clients », « Cœur bancaire », « Active Directory »…).

## Ce que fait la PR
- Helper pur **`extractJsonNames`** : aplati les `.nom` d'une liste de tableaux JSON, robuste aux valeurs null / non-tableaux / éléments malformés.
- `valeurMetier` + `bienSupport` ajoutés à `SUGGESTION_FIELDS` + endpoint : lecture des colonnes JSON `Cadrage.valeursMetier` / `biensSupports` pour les **analyses visibles**, extraction des noms.
- Champs « nom de valeur métier » et « nom de bien support » de l'**Atelier 1** câblés sur `AutocompleteInput`.

## Tests
- `extractJsonNames` (aplatissement + robustesse) + whitelist. Suite complète **1366 OK**, `tsc` clean.
- **Vérif live** (RSSI StarBank) : `valeurMetier` → « Données clients et KYC », « Système de paiement »… ; `bienSupport` → « Cœur bancaire », « Hébergement cloud »… ; scoping org confirmé.

## Couverture d'autocomplétion — désormais complète
organisation · tag · source de risque · mesure · entité · **valeur métier** · **bien support** (+ partie prenante côté API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)