### PR TITLE
feat(ux): pré-remplir l'organisation d'une nouvelle analyse (défaut intelligent)

### DIFF
--- a/src/__tests__/unit/lib/org-active.test.ts
+++ b/src/__tests__/unit/lib/org-active.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { orgNameForPrefill } from '@/lib/org-active'
+
+describe('orgNameForPrefill', () => {
+  const memberships = [
+    { organizationId: 'o1', nom: 'StarBank' },
+    { organizationId: 'o2', nom: 'GalaxyInsurance' },
+  ]
+  it('renvoie le nom de l’org active', () => {
+    expect(orgNameForPrefill('o1', memberships)).toBe('StarBank')
+  })
+  it('null pour l’org racine générique', () => {
+    expect(orgNameForPrefill('global', memberships)).toBeNull()
+  })
+  it('null si absente, vide, ou entrées manquantes', () => {
+    expect(orgNameForPrefill('o3', memberships)).toBeNull()
+    expect(orgNameForPrefill('o1', [{ organizationId: 'o1', nom: '  ' }])).toBeNull()
+    expect(orgNameForPrefill(null, memberships)).toBeNull()
+    expect(orgNameForPrefill('o1', null)).toBeNull()
+  })
+})

--- a/src/app/analyses/new/page.tsx
+++ b/src/app/analyses/new/page.tsx
@@ -30,6 +30,18 @@ export default function NewAnalysePage() {
       .catch(() => {})
   }, [])
 
+  // Défaut intelligent : pré-remplit « organisation » avec le nom de l'org active
+  // (on analyse presque toujours sa propre organisation). N'écrase jamais une
+  // saisie déjà commencée ; null pour l'org racine générique.
+  useEffect(() => {
+    fetch('/api/analyses/default-org', { cache: 'no-store' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => {
+        if (d?.name) setForm(f => (f.organisation ? f : { ...f, organisation: d.name }))
+      })
+      .catch(() => {})
+  }, [])
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!form.nom.trim()) { setError(t.newAnalysis.nameRequired); return }

--- a/src/app/api/analyses/default-org/route.ts
+++ b/src/app/api/analyses/default-org/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { getAnalyseScope } from '@/lib/org-context.server'
+import { orgNameForPrefill } from '@/lib/org-active'
+import { type UserRole } from '@/lib/permissions'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/analyses/default-org — nom de l'org active, pour pré-remplir le champ
+// « organisation » d'une nouvelle analyse (défaut intelligent). Utilise le même
+// résolveur de périmètre que le reste de l'app (getAnalyseScope).
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) return NextResponse.json({ name: null })
+  const userId = (session.user as { id: string }).id
+  const role = ((session.user as { role?: string }).role ?? 'ANALYSTE') as UserRole
+  const scope = await getAnalyseScope(userId, role)
+  return NextResponse.json({ name: orgNameForPrefill(scope.activeOrgId, scope.memberships) })
+}

--- a/src/lib/org-active.ts
+++ b/src/lib/org-active.ts
@@ -1,0 +1,18 @@
+// ─── Organisation active — utilitaire pur ────────────────────────────────────
+
+interface NamedMembership { organizationId: string; nom: string }
+
+/**
+ * Nom de l'organisation active exploitable comme DÉFAUT de saisie, ou null.
+ * Cherche le nom dans les appartenances de l'utilisateur (source fiable :
+ * getAnalyseScope). Renvoie null pour l'org racine générique ('global') — son
+ * libellé n'est pas un nom d'organisation à pré-remplir. Pur → testable.
+ */
+export function orgNameForPrefill(
+  activeOrgId: string | null | undefined,
+  memberships: NamedMembership[] | null | undefined,
+): string | null {
+  if (!activeOrgId || activeOrgId === 'global') return null
+  const nom = (memberships ?? []).find(m => m.organizationId === activeOrgId)?.nom
+  return typeof nom === 'string' && nom.trim() ? nom.trim() : null
+}


### PR DESCRIPTION
## Contexte
Option 2 (défauts intelligents) pour simplifier l'usage. Dans une nouvelle analyse, on renseigne presque toujours **sa propre organisation** — autant la pré-remplir.

## Ce que fait la PR
- Le champ « Organisation / Entité analysée » de `/analyses/new` est **pré-rempli** avec le nom de l'organisation active.
- Source **fiable** : `getAnalyseScope` (le même résolveur de périmètre que le reste de l'app) — via l'endpoint `GET /api/analyses/default-org`. (Note : `/api/org/active` renvoyait une liste vide pour certains utilisateurs mono-org, d'où le nouvel endpoint.)
- Helper **pur** `orgNameForPrefill` : ignore l'org racine générique (`global`), renvoie null si le nom est absent/vide.
- **N'écrase jamais** une saisie déjà commencée (guard `f.organisation ? f : …`).

## Tests
- `orgNameForPrefill` (nom / global / absent / null). Suite complète **1374 OK**, `tsc` clean.
- **Vérif live** (RSSI StarBank, navigateur réel) : à l'ouverture de `/analyses/new`, le champ affiche « StarBank ». Endpoint vérifié : `{"name":"StarBank"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)