### PR TITLE
feat(ux): référentiels du socle pré-cochés selon le secteur

### DIFF
--- a/src/__tests__/unit/lib/referentiels-precoche.test.ts
+++ b/src/__tests__/unit/lib/referentiels-precoche.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { precheckReferentiels } from '@/lib/referentiels-precoche'
+
+describe('precheckReferentiels', () => {
+  const org = [
+    { nom: 'ISO/IEC 27001:2022' },
+    { nom: 'CIS Controls v8' },
+    { nom: 'Politique interne' },
+    { nom: 'DORA' },
+  ]
+  it('pré-coche les référentiels org correspondant aux cadres recommandés', () => {
+    const r = precheckReferentiels(['ISO/IEC 27001', 'DORA'], org)
+    expect(r.map(x => x.nom)).toEqual(['ISO/IEC 27001:2022', 'DORA'])
+    expect(r[0]).toEqual({ nom: 'ISO/IEC 27001:2022', applicable: true, ecarts: '', etatApplication: 'APPLIQUE' })
+  })
+  it('tolère les suffixes de version (préfixe normalisé)', () => {
+    expect(precheckReferentiels(['CIS Controls'], org).map(x => x.nom)).toEqual(['CIS Controls v8'])
+  })
+  it('insensible à la casse / espaces', () => {
+    expect(precheckReferentiels(['  dora '], org).map(x => x.nom)).toEqual(['DORA'])
+  })
+  it('ignore les recommandations sans référentiel org correspondant', () => {
+    expect(precheckReferentiels(['NIST SP 800-53'], org)).toEqual([])
+  })
+  it('aucune recommandation → []', () => {
+    expect(precheckReferentiels([], org)).toEqual([])
+    expect(precheckReferentiels(['ISO 27001'], [])).toEqual([])
+  })
+})

--- a/src/components/workshops/Atelier1.tsx
+++ b/src/components/workshops/Atelier1.tsx
@@ -23,7 +23,7 @@
  */
 
 import { AlertTriangle, BookOpen, Briefcase, Building2, Factory, Lightbulb, Link2, Lock, Monitor, Scale, ShieldCheck, Star, Target, Zap, type LucideIcon } from 'lucide-react'
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from '@/lib/i18n/context'
 import { uid } from '@/lib/uid'
@@ -46,6 +46,7 @@ import { suggestsComplianceModule, nis2Classification, doraPrevailsOverNis2 } fr
 import { showsHdsCaveat } from '@/lib/sous-secteurs'
 import { ETATS_SOCLE, etatSocleFromEntry, type EtatSocle } from '@/lib/socle-etat'
 import AutocompleteInput from '@/components/AutocompleteInput'
+import { precheckReferentiels } from '@/lib/referentiels-precoche'
 
 // Styles statiques de l'indicateur d'état d'application du socle (EXI_M1_20).
 const ETAT_SOCLE_STYLE: Record<EtatSocle, { dot: string; active: string; idle: string }> = {
@@ -222,6 +223,21 @@ export default function Atelier1({ analyseId, initialData, analyse, flashMode, c
   const [referentielMesures, setReferentielMesures] = useState<string>(analyse?.referentielMesures || 'ISO27001')
   // Référentiels recommandés selon le secteur + la taille (suggestion non bloquante)
   const recommendedFw = recommendedFrameworksForSector(analyse?.secteur, tailleAnalyse, analyse?.sousSecteur, analyse?.qualification?.statutReglementaire, analyse?.qualification?.entiteFinanciereAgreee)
+
+  // Pré-cochage des référentiels recommandés — UNE fois, seulement pour un socle
+  // VIERGE (analyse jamais enregistrée : initialData.referentiels absent). N'écrase
+  // jamais un socle déjà saisi (même vide) ; l'utilisateur reste libre de décocher.
+  const prefilledRef = useRef(false)
+  useEffect(() => {
+    if (prefilledRef.current) return
+    if (initialData?.referentiels != null) { prefilledRef.current = true; return }
+    if (!orgReferentiels) return // socle de l'org pas encore chargé
+    const recommendedNoms = recommendedFw.map(fid => FRAMEWORK_META[fid]?.nom).filter(Boolean) as string[]
+    const pre = precheckReferentiels(recommendedNoms, orgReferentiels)
+    if (pre.length) setReferentiels(pre)
+    prefilledRef.current = true
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgReferentiels])
   // Suggestion d'activer les modules Conformité/Qualification pour les secteurs
   // régulés où ils sont quasi-obligatoires (issue #73).
   const suggestCompliance = suggestsComplianceModule(analyse?.secteur, analyse?.qualification?.statutReglementaire) && (!conformiteActive || !qualificationActive)

--- a/src/lib/referentiels-precoche.ts
+++ b/src/lib/referentiels-precoche.ts
@@ -1,0 +1,33 @@
+// ─── Référentiels pré-cochés selon le secteur — cœur pur ─────────────────────
+// À l'ouverture d'un Atelier 1 vierge, on pré-sélectionne les référentiels du
+// socle de l'organisation qui correspondent aux cadres RECOMMANDÉS pour le
+// secteur de l'analyse (ISO 27001, NIS2, DORA…). L'utilisateur peut décocher.
+
+export interface OrgReferentiel { nom: string; description?: string | null }
+export interface PrecheckedRef { nom: string; applicable: boolean; ecarts: string; etatApplication: string }
+
+/** Normalise un nom de référentiel : minuscules, sans espaces ni ponctuation. */
+const norm = (s: string): string => (s ?? '').toLowerCase().replace(/[^a-z0-9]/g, '')
+
+/**
+ * Référentiels de l'org à pré-cocher : ceux dont le `nom` correspond à un cadre
+ * recommandé pour le secteur. La comparaison est **tolérante aux suffixes de
+ * version** (« ISO/IEC 27001 » ↔ « ISO/IEC 27001:2022 », « CIS Controls » ↔
+ * « CIS Controls v8 ») via un préfixe sur les noms normalisés. Retourne des
+ * entrées prêtes pour l'état `referentiels` de l'atelier (applicable=true).
+ */
+export function precheckReferentiels(recommendedNoms: string[], orgReferentiels: OrgReferentiel[]): PrecheckedRef[] {
+  const recs = (recommendedNoms ?? []).map(norm).filter(n => n.length >= 3)
+  if (recs.length === 0) return []
+  const seen = new Set<string>()
+  const out: PrecheckedRef[] = []
+  for (const r of orgReferentiels ?? []) {
+    const on = norm(r?.nom ?? '')
+    if (on.length < 3 || seen.has(on)) continue
+    if (recs.some(rn => rn === on || rn.startsWith(on) || on.startsWith(rn))) {
+      seen.add(on)
+      out.push({ nom: r.nom, applicable: true, ecarts: '', etatApplication: 'APPLIQUE' })
+    }
+  }
+  return out
+}


### PR DESCRIPTION
## Contexte
2ᵉ demande de simplification : **pré-cocher les référentiels** selon le secteur. Aujourd'hui les cadres recommandés pour le secteur sont seulement AFFICHÉS (badge) ; l'utilisateur doit les cocher un par un.

## Ce que fait la PR
- À l'ouverture d'un **Atelier 1 vierge** (analyse jamais enregistrée), les référentiels du **socle de l'organisation** qui correspondent aux **cadres recommandés pour le secteur** (ISO 27001, DORA, NIS2, HDS, PCI-DSS…) sont **pré-cochés** (`applicable: true`, appliqué).
- Helper **pur** `precheckReferentiels` : matching **normalisé + tolérant aux suffixes de version** (« ISO/IEC 27001 » ↔ « ISO/IEC 27001:2022 », « CIS Controls » ↔ « CIS Controls v8 »).
- **N'écrase jamais** un socle déjà saisi : garde `initialData.referentiels != null` + ref one-shot. L'utilisateur reste libre de décocher.

## Tests
- `precheckReferentiels` : correspondance, tolérance de version, casse/espaces, cas vides. Vérif sur **données réelles** (secteur Banque/Finance × référentiels par défaut → correspondances non vides). Suite complète verte hors dépôts annexes (voir note), `tsc` clean sur mes fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)