### PR TITLE
fix(security): webhooks — refuser un hostname résolvant vers une IP privée (#132)

### DIFF
--- a/src/__tests__/unit/lib/webhook.test.ts
+++ b/src/__tests__/unit/lib/webhook.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  isPrivateIp,
   WEBHOOK_EVENTS,
   cleanWebhookEvents,
   signWebhookPayload,
@@ -110,5 +111,28 @@ describe('resolveDeliveryUpdate', () => {
 describe('WEBHOOK_MAX_ATTEMPTS', () => {
   it('borne le nombre de tentatives', () => {
     expect(WEBHOOK_MAX_ATTEMPTS).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('isPrivateIp (#132 — validation de l\'IP RÉSOLUE, anti-SSRF)', () => {
+  it('IPv4 privées / loopback / métadonnées / this-host → true', () => {
+    for (const ip of ['127.0.0.1', '10.1.2.3', '192.168.0.1', '172.16.0.1', '172.31.255.255', '169.254.169.254', '0.0.0.0']) {
+      expect(isPrivateIp(ip)).toBe(true)
+    }
+  })
+  it('IPv4 publiques → false', () => {
+    for (const ip of ['8.8.8.8', '1.1.1.1', '93.184.216.34', '172.15.0.1', '172.32.0.1']) {
+      expect(isPrivateIp(ip)).toBe(false)
+    }
+  })
+  it('IPv6 loopback / ULA / link-local + IPv4-mapped → true', () => {
+    for (const ip of ['::1', 'fc00::1', 'fd12:3456::1', 'fe80::1', '::ffff:127.0.0.1', '::ffff:10.0.0.1']) {
+      expect(isPrivateIp(ip)).toBe(true)
+    }
+  })
+  it('IPv6 publique → false ; entrée vide → fail-closed (true)', () => {
+    expect(isPrivateIp('2606:4700:4700::1111')).toBe(false)
+    expect(isPrivateIp('')).toBe(true)
+    expect(isPrivateIp('  ')).toBe(true)
   })
 })

--- a/src/lib/webhook.server.ts
+++ b/src/lib/webhook.server.ts
@@ -1,10 +1,12 @@
 // ─── Émission & livraison des webhooks sortants (couche serveur) ─────────────
 import { prisma } from '@/lib/prisma'
+import { lookup } from 'node:dns/promises'
 import {
   webhookSubscribers,
   signWebhookPayload,
   resolveDeliveryUpdate,
   isSafeWebhookUrl,
+  isPrivateIp,
   WEBHOOK_SIGNATURE_HEADER,
   type WebhookEvent,
 } from '@/lib/webhook'
@@ -73,6 +75,17 @@ export async function dispatchDueWebhooks(limit = 50): Promise<{ traitees: numbe
 async function deliverOne(url: string, secret: string, payload: string) {
   // Garde SSRF au moment de l'envoi (l'URL a pu être posée avant durcissement).
   if (!isSafeWebhookUrl(url)) return { ok: false, error: 'url_non_autorisee' }
+  // Anti-SSRF renforcé (#132) : `isSafeWebhookUrl` ne voit que le hostname littéral.
+  // On RÉSOUT le hostname et on refuse s'il pointe vers une IP privée/interne
+  // (hostname public → IP privée). Note : une réattribution DNS active (rebinding)
+  // entre cette résolution et le fetch reste théoriquement possible (le fetch
+  // re-résout) — l'épinglage de connexion serait le cran au-dessus.
+  try {
+    const addrs = await lookup(new URL(url).hostname, { all: true })
+    if (addrs.some(a => isPrivateIp(a.address))) return { ok: false, error: 'url_resout_ip_privee' }
+  } catch {
+    return { ok: false, error: 'dns_irresolvable' }
+  }
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS)
   try {

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -115,6 +115,26 @@ function isPrivateV4(host: string): boolean {
   return false
 }
 
+/**
+ * Une IP (v4 ou v6) est-elle privée / interne (loopback, RFC1918, link-local /
+ * métadonnées cloud 169.254, ULA fc00::/7, IPv4-mapped) ? Utilisé pour valider
+ * l'IP RÉSOLUE d'un hostname de webhook au moment de l'envoi (anti-SSRF, #132) :
+ * `isSafeWebhookUrl` ne voit que le hostname littéral, pas ce vers quoi il résout.
+ * Fail-closed : une entrée vide/inconnue est considérée privée (on préfère refuser).
+ */
+export function isPrivateIp(ip: string): boolean {
+  const h = (ip ?? '').trim().toLowerCase().replace(/^\[|\]$/g, '')
+  if (!h) return true
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(h)) return isPrivateV4(h)
+  // IPv4-mapped IPv6 : ::ffff:a.b.c.d
+  const mapped = h.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/)
+  if (mapped) return isPrivateV4(mapped[1])
+  if (h === '::1' || h === '::') return true          // loopback / non spécifié
+  if (/^f[cd][0-9a-f]{2}:/.test(h)) return true       // ULA fc00::/7
+  if (/^fe80:/.test(h)) return true                   // link-local fe80::/10
+  return false
+}
+
 export function isSafeWebhookUrl(raw: unknown): boolean {
   if (typeof raw !== 'string' || raw.trim() === '') return false
   let u: URL


### PR DESCRIPTION
## Contexte
Renforce la garde SSRF des **webhooks sortants** (mergés en #50). `isSafeWebhookUrl` ne contrôle que le **hostname littéral** (https + pas d'IP privée écrite en clair). Un attaquant pouvait poser une URL avec un **hostname public** qui **résout vers une IP interne** (ex. `169.254.169.254`, `10.x`) → SSRF.

## Correctif
Au moment de l'envoi (`deliverOne`), on **résout** le hostname (`dns.lookup(..., { all: true })`) et on **refuse** si une des IP résolues est privée/interne (`url_resout_ip_privee`). DNS irrésolvable → refus (`dns_irresolvable`).
- Helper **pur** `isPrivateIp` (IPv4/IPv6 : loopback, RFC1918, link-local/metadata 169.254, ULA fc00::/7, IPv4-mapped ::ffff:) — **fail-closed** sur entrée vide.
- Limite connue documentée : rebinding DNS actif (le `fetch` re-résout) — l'épinglage de connexion serait le cran supérieur.

## Tests
- `isPrivateIp` (privées/publiques v4/v6, IPv4-mapped, fail-closed) — 19 tests `webhook` verts, `tsc` clean.

> Correctif produit par la tâche de test continu ; livré séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)