### PR TITLE
feat(dpo): cœur pur du registre des traitements (RoPA — RGPD art. 30)

### DIFF
--- a/src/__tests__/unit/lib/ropa.test.ts
+++ b/src/__tests__/unit/lib/ropa.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BASES_LEGALES,
+  sanitizeTraitement,
+  champsManquantsArt30,
+  piaRequis,
+  evaluerTraitement,
+  type Traitement,
+} from '@/lib/ropa'
+
+// Base : un traitement RGPD art. 30 complet et non sensible.
+const complet = (): Traitement => ({
+  nom: 'Gestion de la paie',
+  finalite: 'Verser les salaires et gérer les bulletins',
+  baseLegale: 'obligation_legale',
+  categoriesPersonnes: ['salariés'],
+  categoriesDonnees: ['identité', 'coordonnées bancaires (RIB)'],
+  destinataires: ['service RH', 'URSSAF'],
+  transfertHorsUE: false,
+  dureeConservation: '5 ans après le départ',
+  mesuresSecurite: ['chiffrement', 'contrôle d’accès'],
+  grandeEchelle: false,
+  surveillanceSystematique: false,
+})
+
+describe('BASES_LEGALES (art. 6 RGPD)', () => {
+  it('contient les 6 bases légales', () => {
+    expect(BASES_LEGALES).toContain('consentement')
+    expect(BASES_LEGALES).toContain('interet_legitime')
+    expect(BASES_LEGALES).toHaveLength(6)
+  })
+})
+
+describe('champsManquantsArt30 (complétude du registre)', () => {
+  it('un traitement complet → aucun champ manquant', () => {
+    expect(champsManquantsArt30(complet())).toEqual([])
+  })
+  it('signale chaque champ obligatoire art. 30 §1 manquant', () => {
+    const vide: Traitement = {
+      nom: '', finalite: '', baseLegale: '', categoriesPersonnes: [], categoriesDonnees: [],
+      destinataires: [], transfertHorsUE: false, dureeConservation: '', mesuresSecurite: [],
+    }
+    const m = champsManquantsArt30(vide)
+    for (const champ of ['finalite', 'categoriesPersonnes', 'categoriesDonnees', 'destinataires', 'dureeConservation', 'mesuresSecurite']) {
+      expect(m).toContain(champ)
+    }
+  })
+  it('un transfert hors UE sans garanties est signalé (art. 44-46)', () => {
+    const t = { ...complet(), transfertHorsUE: true, paysTransfert: 'États-Unis', garantiesTransfert: '' }
+    expect(champsManquantsArt30(t)).toContain('garantiesTransfert')
+    const t2 = { ...complet(), transfertHorsUE: true, paysTransfert: 'États-Unis', garantiesTransfert: 'clauses contractuelles types' }
+    expect(champsManquantsArt30(t2)).not.toContain('garantiesTransfert')
+  })
+})
+
+describe('piaRequis (art. 35 — analyse d’impact)', () => {
+  it('données de santé (art. 9) → PIA requis', () => {
+    const t = { ...complet(), categoriesDonnees: ['données de santé des patients', 'diagnostic'] }
+    const r = piaRequis(t)
+    expect(r.requis).toBe(true)
+    expect(r.motifs).toContain('donnees_sensibles_art9')
+  })
+  it('surveillance systématique à grande échelle → PIA requis', () => {
+    const t = { ...complet(), grandeEchelle: true, surveillanceSystematique: true }
+    const r = piaRequis(t)
+    expect(r.requis).toBe(true)
+    expect(r.motifs).toContain('surveillance_systematique_grande_echelle')
+  })
+  it('traitement ordinaire non sensible → PIA non requis', () => {
+    expect(piaRequis(complet()).requis).toBe(false)
+  })
+})
+
+describe('sanitizeTraitement (normalisation d’entrée)', () => {
+  it('borne les chaînes, force les tableaux, valide la base légale', () => {
+    const t = sanitizeTraitement({
+      nom: 'x'.repeat(500), finalite: 'f', baseLegale: 'INVALIDE',
+      categoriesDonnees: 'pas un tableau', destinataires: ['a', 2, null, 'b'],
+      transfertHorsUE: 'oui', dureeConservation: 'd', mesuresSecurite: ['m'],
+    })
+    expect(t.nom.length).toBeLessThanOrEqual(200)
+    expect(t.baseLegale).toBe('') // base invalide → vide
+    expect(Array.isArray(t.categoriesDonnees)).toBe(true)
+    expect(t.destinataires).toEqual(['a', 'b']) // non-strings écartés
+    expect(t.transfertHorsUE).toBe(true) // coercition booléenne
+  })
+  it('entrée non-objet → traitement vide sûr', () => {
+    const t = sanitizeTraitement(null)
+    expect(t.nom).toBe('')
+    expect(t.categoriesDonnees).toEqual([])
+  })
+})
+
+describe('evaluerTraitement (synthèse pour le DPO)', () => {
+  it('assemble complétude + PIA', () => {
+    const r = evaluerTraitement({ ...complet(), categoriesDonnees: ['données de santé'] })
+    expect(r.pia.requis).toBe(true)
+    expect(r.complet).toBe(true) // tous les champs art.30 présents
+    expect(r.champsManquants).toEqual([])
+  })
+  it('un traitement incomplet est signalé', () => {
+    const r = evaluerTraitement({ ...complet(), dureeConservation: '' })
+    expect(r.complet).toBe(false)
+    expect(r.champsManquants).toContain('dureeConservation')
+  })
+})

--- a/src/lib/ropa.ts
+++ b/src/lib/ropa.ts
@@ -1,0 +1,117 @@
+// ─── Registre des activités de traitement (RoPA — RGPD art. 30) ──────────────
+// Cœur métier PUR du module DPO : modèle d'un traitement de données personnelles,
+// contrôle de complétude (art. 30 §1), déclenchement d'une analyse d'impact (PIA /
+// AIPD, art. 35). Aucune dépendance base — testable directement. L'UI/les routes/le
+// modèle Prisma s'appuieront dessus (registre par organisation, réservé au DPO).
+
+import { detectRgpdArt9 } from '@/lib/rgpd-sensitive'
+
+/** Bases légales du traitement (RGPD art. 6 §1 a–f). */
+export const BASES_LEGALES = [
+  'consentement',
+  'contrat',
+  'obligation_legale',
+  'interet_vital',
+  'mission_service_public',
+  'interet_legitime',
+] as const
+export type BaseLegale = (typeof BASES_LEGALES)[number]
+
+export interface Traitement {
+  id?: string
+  nom: string
+  finalite: string
+  baseLegale: BaseLegale | ''
+  categoriesPersonnes: string[]
+  categoriesDonnees: string[]
+  destinataires: string[]
+  transfertHorsUE: boolean
+  paysTransfert?: string
+  garantiesTransfert?: string
+  dureeConservation: string
+  mesuresSecurite: string[]
+  // Critères PIA (art. 35 §3) — renseignés par le DPO.
+  grandeEchelle?: boolean
+  surveillanceSystematique?: boolean
+}
+
+const S_MAX = 200
+const T_MAX = 2000
+const str = (v: unknown, max = S_MAX): string =>
+  (typeof v === 'string' ? v : '').slice(0, max)
+const strArr = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string' && x.trim() !== '').map(x => x.slice(0, S_MAX)).slice(0, 50) : []
+const bool = (v: unknown): boolean => v === true || v === 'true' || v === 'oui' || v === 1
+const asBase = (v: unknown): BaseLegale | '' =>
+  (BASES_LEGALES as readonly string[]).includes(v as string) ? (v as BaseLegale) : ''
+
+/** Normalise et borne un traitement fourni par le client (jamais de throw). */
+export function sanitizeTraitement(v: unknown): Traitement {
+  const o = (v && typeof v === 'object' ? v : {}) as Record<string, unknown>
+  return {
+    id: typeof o.id === 'string' ? o.id : undefined,
+    nom: str(o.nom),
+    finalite: str(o.finalite, T_MAX),
+    baseLegale: asBase(o.baseLegale),
+    categoriesPersonnes: strArr(o.categoriesPersonnes),
+    categoriesDonnees: strArr(o.categoriesDonnees),
+    destinataires: strArr(o.destinataires),
+    transfertHorsUE: bool(o.transfertHorsUE),
+    paysTransfert: str(o.paysTransfert),
+    garantiesTransfert: str(o.garantiesTransfert, T_MAX),
+    dureeConservation: str(o.dureeConservation),
+    mesuresSecurite: strArr(o.mesuresSecurite),
+    grandeEchelle: bool(o.grandeEchelle),
+    surveillanceSystematique: bool(o.surveillanceSystematique),
+  }
+}
+
+/**
+ * Champs OBLIGATOIRES manquants au sens de l'art. 30 §1 (par traitement) : finalité,
+ * catégories de personnes, catégories de données, destinataires, durée de conservation,
+ * description des mesures de sécurité (art. 32). En cas de transfert hors UE, les
+ * garanties (art. 44-46) sont exigées. `nom` est requis comme libellé du registre.
+ */
+export function champsManquantsArt30(t: Traitement): string[] {
+  const manquants: string[] = []
+  if (!t.nom?.trim()) manquants.push('nom')
+  if (!t.finalite?.trim()) manquants.push('finalite')
+  if (t.categoriesPersonnes.length === 0) manquants.push('categoriesPersonnes')
+  if (t.categoriesDonnees.length === 0) manquants.push('categoriesDonnees')
+  if (t.destinataires.length === 0) manquants.push('destinataires')
+  if (!t.dureeConservation?.trim()) manquants.push('dureeConservation')
+  if (t.mesuresSecurite.length === 0) manquants.push('mesuresSecurite')
+  if (t.transfertHorsUE && !t.garantiesTransfert?.trim()) manquants.push('garantiesTransfert')
+  return manquants
+}
+
+export interface PiaVerdict {
+  requis: boolean
+  motifs: string[]
+}
+
+/**
+ * Une analyse d'impact (PIA / AIPD, art. 35) est-elle requise ? Modèle simplifié
+ * (aide à la décision, pas un avis juridique) : (b) traitement de données sensibles
+ * art. 9 → oui ; (c) surveillance systématique à grande échelle → oui. Le DPO reste
+ * décisionnaire ; renvoie les motifs pour justification.
+ */
+export function piaRequis(t: Traitement): PiaVerdict {
+  const motifs: string[] = []
+  const sensibles = detectRgpdArt9(t.categoriesDonnees.map(nom => ({ nom })))
+  if (sensibles.length > 0) motifs.push('donnees_sensibles_art9')
+  if (t.grandeEchelle && t.surveillanceSystematique) motifs.push('surveillance_systematique_grande_echelle')
+  return { requis: motifs.length > 0, motifs }
+}
+
+export interface TraitementEvaluation {
+  complet: boolean
+  champsManquants: string[]
+  pia: PiaVerdict
+}
+
+/** Synthèse par traitement pour le tableau de bord DPO. */
+export function evaluerTraitement(t: Traitement): TraitementEvaluation {
+  const champsManquants = champsManquantsArt30(t)
+  return { complet: champsManquants.length === 0, champsManquants, pia: piaRequis(t) }
+}


### PR DESCRIPTION
## Contexte
Fondation métier du **module DPO** : le registre des activités de traitement (**RoPA**, RGPD **art. 30**). Cœur PUR, sans dépendance base — l'UI, les routes et le modèle Prisma (registre par organisation, réservé au DPO) s'appuieront dessus.

## Ce que fait la PR
- Modèle `Traitement` (données personnelles) + `sanitizeTraitement`.
- `champsManquantsArt30` : contrôle de complétude (art. 30 §1).
- `piaRequis` : déclenchement d'une analyse d'impact (PIA/AIPD, art. 35).
- `evaluerTraitement` : évaluation consolidée. `BASES_LEGALES` (bases de licéité).
- Réutilise `detectRgpdArt9` (catégories de données sensibles).

## Tests
- 11 tests (complétude art. 30, PIA, bases légales, sanitisation). `tsc` clean.

> Cœur produit par la tâche de test continu ; livré séparément. Le câblage UI/route/modèle viendra ensuite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)