### PR TITLE
polish(reporting): « dans l'appétit » en vert sur le RAS PDF (#134)

### DIFF
--- a/src/lib/ras-pdf-template.tsx
+++ b/src/lib/ras-pdf-template.tsx
@@ -109,7 +109,7 @@ function RasPDF({ data, locale, orgNom, dateStr }: { data: RasExportData; locale
         <View style={s.kpiRow}>
           <View style={s.kpi}><Text style={s.kpiLabel}>{S.compliance}</Text><Text style={[s.kpiValue, { color: data.tauxConformite >= 80 ? COLORS.ok : COLORS.danger }]}>{`${data.tauxConformite}%`}</Text></View>
           <View style={s.kpi}><Text style={s.kpiLabel}>{S.outside}</Text><Text style={[s.kpiValue, { color: data.synthese.horsAppetit > 0 ? COLORS.danger : COLORS.ok }]}>{String(data.synthese.horsAppetit)}</Text></View>
-          <View style={s.kpi}><Text style={s.kpiLabel}>{S.inside}</Text><Text style={s.kpiValue}>{String(data.synthese.dansAppetit)}</Text></View>
+          <View style={s.kpi}><Text style={s.kpiLabel}>{S.inside}</Text><Text style={[s.kpiValue, data.synthese.dansAppetit > 0 ? { color: COLORS.ok } : {}]}>{String(data.synthese.dansAppetit)}</Text></View>
           <View style={s.kpi}><Text style={s.kpiLabel}>{S.evaluated}</Text><Text style={s.kpiValue}>{String(data.synthese.evalues)}</Text></View>
         </View>
 


### PR DESCRIPTION
Cohérence avec #70/#71 : la métrique « risques dans l'appétit » s'affiche en vert (`COLORS.ok`) quand > 0 dans le **rapport annuel de sécurité (RAS)**, comme les packs comités et le rapport de contrôle interne. Une ligne, `tsc` clean.

> Suite de la tâche de test continu (#134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)