### PR TITLE
feat(reporting): heatmap gravité × vraisemblance dans les PDF (cartographie, #134)

### DIFF
--- a/src/lib/carto-pdf-template.tsx
+++ b/src/lib/carto-pdf-template.tsx
@@ -11,6 +11,7 @@
 
 import { Document, Page, Text, View, StyleSheet, renderToBuffer } from '@react-pdf/renderer'
 import type { CartoExportData } from '@/lib/carto-export'
+import { HeatmapGrid } from '@/lib/pdf-heatmap'
 import { isNonEmptyText } from '@/lib/pdf-guards'
 
 const COLORS = {
@@ -63,13 +64,6 @@ const STRINGS: Record<string, Strings> = {
   it: { title: 'Mappatura dei rischi', subtitle: 'Sintesi del registro: heat map gravità × probabilità e ripartizioni', mode: 'Modalità', inherent: 'Inerente', residual: 'Residuo', total: 'Rischi', eleve: 'Alti', moyen: 'Medi', faible: 'Bassi', nonCote: 'Non valutati', heatmap: 'Heat map gravità × probabilità', gravite: 'Gravità', vraisemblance: 'Probabilità', byCategory: 'Ripartizione per categoria', byProcess: 'Ripartizione per processo', byEntity: 'Ripartizione per entità', colLabel: 'Etichetta', colCount: 'Numero', colMax: 'Livello max', notSet: 'Non indicato', generatedOn: 'Generato il' },
 }
 
-function bucketColor(b: string | undefined): string {
-  if (b === 'eleve') return COLORS.eleve
-  if (b === 'moyen') return COLORS.moyen
-  if (b === 'faible') return COLORS.faible
-  return '#F3F4F6'
-}
-
 function Breakdown({ titre, rows, S }: { titre: string; rows: { key: string; label?: string | null; count: number; maxNiveau: number | null }[]; S: Strings }) {
   return (
     <View wrap={false}>
@@ -119,30 +113,7 @@ function CartographiePDF({ data, locale, orgNom, dateStr }: { data: CartoExportD
         {/* Heat map */}
         <View wrap={false}>
           <Text style={s.h2}>{S.heatmap}</Text>
-          {data.grid.gravites.map(g => (
-            <View key={`g${g}`} style={s.gridRow}>
-              <View style={s.axisCell}><Text style={s.axisText}>{String(g)}</Text></View>
-              {data.grid.vraisemblances.map(v => {
-                const n = data.grid.counts[g][v]
-                return (
-                  <View key={`c${g}-${v}`} style={[s.cell, { backgroundColor: bucketColor(data.grid.buckets[g][v]) }]}>
-                    <Text style={s.cellText}>{n > 0 ? String(n) : ''}</Text>
-                  </View>
-                )
-              })}
-            </View>
-          ))}
-          <View style={s.gridRow}>
-            <View style={s.axisCell}><Text style={s.axisText}>{''}</Text></View>
-            {data.grid.vraisemblances.map(v => (
-              <View key={`v${v}`} style={[s.cell, { borderColor: '#FFFFFF', backgroundColor: '#FFFFFF' }]}>
-                <Text style={s.axisText}>{String(v)}</Text>
-              </View>
-            ))}
-          </View>
-          {/* Libellés d'axes en ASCII : la police par défaut (Helvetica) ne
-              contient pas les flèches Unicode (elles s'affichent en apostrophes). */}
-          <Text style={s.axisLabel}>{`${S.vraisemblance} (1-5) - ${S.gravite} (1-5)`}</Text>
+          <HeatmapGrid grid={data.grid} axisLabel={`${S.vraisemblance} (1-5) - ${S.gravite} (1-5)`} />
         </View>
 
         <Breakdown titre={S.byCategory} rows={data.parCategorie} S={S} />

--- a/src/lib/comite-pack.ts
+++ b/src/lib/comite-pack.ts
@@ -4,11 +4,13 @@
 // et remonte des points d'alerte. PURE et testée ; le PDF ne fait que rendre.
 // Les libellés restent au template (i18n) : ce module ne produit que des CLÉS.
 
+import type { HeatGrid } from '@/lib/carto-export'
+
 export const COMITE_TYPES = ['RISQUES', 'CONFORMITE', 'INCIDENTS'] as const
 export type ComiteType = (typeof COMITE_TYPES)[number]
 
 export interface ComiteConsolide {
-  risques?: { total: number; eleve: number; moyen: number; faible: number; nonCote: number }
+  risques?: { total: number; eleve: number; moyen: number; faible: number; nonCote: number; grid?: HeatGrid }
   actions?: { total: number; faits: number; enRetard: number; tauxAvancement: number }
   appetit?: { horsAppetit: number; dansAppetit: number; evalues: number }
   incidents?: { total: number; ouverts: number; perteNette: number }
@@ -36,6 +38,8 @@ export interface ComitePack {
   type: ComiteType
   sections: ComiteSection[]
   highlights: ComiteHighlight[]
+  /** Heatmap gravité × vraisemblance (si le consolidé la fournit) — rendu décideur (#134). */
+  heatmap?: HeatGrid
 }
 
 const CONFORMITE_SEUIL = 80
@@ -140,7 +144,7 @@ export function buildComitePack(type: ComiteType, c: ComiteConsolide, m: ComiteM
   if (m.dora && c.dora) push(c.dora.majeurs > 0, 'doraMajeurs', 'alerte', c.dora.majeurs)
   if (m.incidents && c.incidents) push(c.incidents.ouverts > 0, 'incidentsOuverts', 'info', c.incidents.ouverts)
 
-  return { type, sections, highlights }
+  return { type, sections, highlights, ...(c.risques?.grid ? { heatmap: c.risques.grid } : {}) }
 }
 
 // Signaux d'alerte considérés comme « de crise » pour le verdict global (#134 M5).

--- a/src/lib/pdf-heatmap.tsx
+++ b/src/lib/pdf-heatmap.tsx
@@ -1,0 +1,57 @@
+// ─── Heatmap gravité × vraisemblance — composant PDF RÉUTILISABLE (#134 M5) ──
+// Matrice colorée (vert/orange/rouge) partagée par le PDF cartographie ET le pack
+// comité, pour que le décideur voie la carte des risques, pas seulement des chiffres.
+// Compilé dans chaque template par esbuild (compile-pdf-template.mjs).
+
+import { View, Text, StyleSheet } from '@react-pdf/renderer'
+import type { HeatGrid } from '@/lib/carto-export'
+
+const HEAT = { eleve: '#DC2626', moyen: '#D97706', faible: '#16A34A', empty: '#F3F4F6' }
+
+/** Couleur d'une cellule de heatmap selon son palier de risque. Pur → testable. */
+export function heatCellColor(bucket: string | undefined): string {
+  if (bucket === 'eleve') return HEAT.eleve
+  if (bucket === 'moyen') return HEAT.moyen
+  if (bucket === 'faible') return HEAT.faible
+  return HEAT.empty
+}
+
+/**
+ * Rend la matrice gravité (lignes, forte→faible) × vraisemblance (colonnes, 1→N),
+ * cellules colorées par palier avec le compte. `cellWidth`/`cellHeight` permettent
+ * une version compacte (pack comité) ou large (cartographie).
+ */
+export function HeatmapGrid({ grid, axisLabel, cellWidth = 46, cellHeight = 26 }: {
+  grid: HeatGrid; axisLabel: string; cellWidth?: number; cellHeight?: number
+}) {
+  const axisW = 18
+  const fs = cellHeight <= 20 ? 8 : 9
+  return (
+    <View wrap={false}>
+      {grid.gravites.map(g => (
+        <View key={`g${g}`} style={{ flexDirection: 'row' }}>
+          <View style={{ width: axisW, height: cellHeight, alignItems: 'center', justifyContent: 'center' }}>
+            <Text style={{ fontSize: 7, color: '#6B7280' }}>{String(g)}</Text>
+          </View>
+          {grid.vraisemblances.map(v => {
+            const n = grid.counts[g]?.[v] ?? 0
+            return (
+              <View key={`c${g}-${v}`} style={{ width: cellWidth, height: cellHeight, borderWidth: 1, borderColor: '#FFFFFF', backgroundColor: heatCellColor(grid.buckets[g]?.[v]), alignItems: 'center', justifyContent: 'center' }}>
+                <Text style={{ fontSize: fs, fontWeight: 'bold', color: '#FFFFFF' }}>{n > 0 ? String(n) : ' '}</Text>
+              </View>
+            )
+          })}
+        </View>
+      ))}
+      <View style={{ flexDirection: 'row' }}>
+        <View style={{ width: axisW, height: cellHeight }}><Text style={{ fontSize: 7 }}>{' '}</Text></View>
+        {grid.vraisemblances.map(v => (
+          <View key={`v${v}`} style={{ width: cellWidth, height: cellHeight, alignItems: 'center', justifyContent: 'center' }}>
+            <Text style={{ fontSize: 7, color: '#6B7280' }}>{String(v)}</Text>
+          </View>
+        ))}
+      </View>
+      <Text style={{ fontSize: 7, color: '#6B7280', marginTop: 3, marginLeft: axisW }}>{axisLabel}</Text>
+    </View>
+  )
+}


### PR DESCRIPTION
## Ce que fait la PR
Ajoute une **matrice de risque (heatmap) gravité × vraisemblance** en couleurs dans les exports PDF, pour un rendu plus parlant côté décideur (#134).
- Composant **pur** `HeatmapGrid` + `heatCellColor` (`lib/pdf-heatmap.tsx`, react-pdf).
- Intégré au **PDF de cartographie** des risques.
- `buildComitePack` expose un champ optionnel `heatmap` (issu de `c.risques.grid`) pour réutilisation dans les packs comités.

## Tests
- `comite-pack` (10) inchangés ; suite complète **1407 OK**, `tsc` clean.

> Suite de la tâche de test continu (#134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)