### PR TITLE
feat(reporting): heatmap dans le pack comité + alimentation GRC consolidé (#134)

### DIFF
--- a/src/__tests__/unit/lib/comite-pack.test.ts
+++ b/src/__tests__/unit/lib/comite-pack.test.ts
@@ -84,6 +84,16 @@ describe('verdictGlobal (#134 M5 — verdict RAG en tête du pack décideur)', (
   })
 })
 
+describe('buildComitePack — heatmap (#134 M5)', () => {
+  it('passe la grille heatmap du consolidé au pack ; absente si non fournie', () => {
+    const grid = { gravites: [5, 4, 3, 2, 1], vraisemblances: [1, 2, 3, 4, 5], counts: {}, buckets: {} } as never
+    const avec = buildComitePack('RISQUES', { risques: { total: 1, eleve: 0, moyen: 0, faible: 1, nonCote: 0, grid } }, MODULES_ON)
+    expect(avec.heatmap).toBe(grid)
+    const sans = buildComitePack('RISQUES', { risques: { total: 1, eleve: 0, moyen: 0, faible: 1, nonCote: 0 } }, MODULES_ON)
+    expect(sans.heatmap).toBeUndefined()
+  })
+})
+
 describe('buildComitePack — flag positif (RAG vert, #134)', () => {
   it('« dans l’appétit » positif ; conformité ≥ seuil positif, < seuil alerte', () => {
     const pack = buildComitePack('RISQUES', {

--- a/src/__tests__/unit/lib/pdf-heatmap.test.ts
+++ b/src/__tests__/unit/lib/pdf-heatmap.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { heatCellColor } from '@/lib/pdf-heatmap'
+
+describe('heatCellColor (#134 — couleur RAG d\'une cellule de heatmap)', () => {
+  it('mappe chaque palier vers sa couleur, vide pour l\'inconnu', () => {
+    expect(heatCellColor('eleve')).toBe('#DC2626')
+    expect(heatCellColor('moyen')).toBe('#D97706')
+    expect(heatCellColor('faible')).toBe('#16A34A')
+    expect(heatCellColor(undefined)).toBe('#F3F4F6')
+    expect(heatCellColor('autre')).toBe('#F3F4F6')
+  })
+})

--- a/src/lib/comite-pack-pdf-template.tsx
+++ b/src/lib/comite-pack-pdf-template.tsx
@@ -9,7 +9,14 @@
 import { Document, Page, Text, View, StyleSheet, renderToBuffer } from '@react-pdf/renderer'
 import { verdictGlobal, type ComitePack, type VerdictNiveau } from '@/lib/comite-pack'
 import { formatNumber } from '@/lib/format'
+import { HeatmapGrid } from '@/lib/pdf-heatmap'
 import { isNonEmptyText } from '@/lib/pdf-guards'
+
+// Libellé d'axe de la heatmap (compacte) — évite d'alourdir le type Strings.
+const HEATMAP_AXIS: Record<string, string> = {
+  fr: 'Vraisemblance × Gravité (1-5)', en: 'Likelihood × Severity (1-5)', de: 'Wahrscheinlichkeit × Schwere (1-5)',
+  es: 'Probabilidad × Gravedad (1-5)', it: 'Probabilità × Gravità (1-5)',
+}
 
 const COLORS = {
   primary: '#4338CA', danger: '#DC2626', warn: '#EA580C', info: '#2563EB',
@@ -142,6 +149,11 @@ function ComitePackPDF({ pack, locale, orgNom, dateStr }: { pack: ComitePack; lo
         {pack.sections.map((sec, si) => (
           <View key={`s-${si}`} wrap={false}>
             <Text style={s.h2}>{S.section[sec.id] ?? sec.id}</Text>
+            {sec.id === 'risques' && pack.heatmap ? (
+              <View style={{ marginBottom: 6 }}>
+                <HeatmapGrid grid={pack.heatmap} axisLabel={HEATMAP_AXIS[locale] ?? HEATMAP_AXIS.fr} cellWidth={26} cellHeight={18} />
+              </View>
+            ) : null}
             <View style={s.kpiRow}>
               {sec.metrics.map((mt, mi) => (
                 <View key={`m-${si}-${mi}`} style={s.kpi}>

--- a/src/lib/grc-consolide.server.ts
+++ b/src/lib/grc-consolide.server.ts
@@ -9,6 +9,8 @@ import { prisma } from './prisma'
 import { niveauRisque } from './risk-item'
 import { summarizeActions } from './risk-action'
 import { rollupRisks, type RiskLite } from './grc-rollup'
+import { buildHeatGrid } from './carto-export'
+import type { CartoRisk } from './cartographie'
 import { rollupIncidents, rollupControles, rollupControlesParNiveau, rollupAudit, type CockpitIncident, type CockpitExecution, type CockpitConstat } from './grc-cockpit'
 import { synthetiserAppetit, cleanAppetitConfig, type RiskAppetitLite } from './appetit'
 import { evaluerKri, synthetiserKri, type KriSens } from './kri'
@@ -58,7 +60,15 @@ export async function gatherGrcConsolide(
   const appetitDefini = appetit.seuilGlobal != null || Object.keys(appetit.parCategorie).length > 0
   const appetitRows: RiskAppetitLite[] = riskRows.map(r => ({ taxonomieCode: r.taxonomieCode, niveauResiduel: niveauRisque(r.graviteResiduelle, r.vraisemblanceResiduelle) }))
 
-  const consolide: ComiteConsolide = { risques: rollupRisks(risks) }
+  // Heatmap gravité × vraisemblance (mode résiduel) pour le rendu décideur (#134).
+  const cartoRisks: CartoRisk[] = riskRows.map((r, i) => ({
+    id: String(i), intitule: '', taxonomieCode: r.taxonomieCode, processusId: null, processusNom: null, entite: null,
+    graviteInherente: r.graviteInherente, vraisemblanceInherente: r.vraisemblanceInherente,
+    graviteResiduelle: r.graviteResiduelle, vraisemblanceResiduelle: r.vraisemblanceResiduelle,
+  }))
+  const grid = buildHeatGrid(cartoRisks, 'residual')
+
+  const consolide: ComiteConsolide = { risques: { ...rollupRisks(risks), grid } }
   const act = summarizeActions(actionRows, now)
   consolide.actions = { total: act.total, faits: act.faits, enRetard: act.enRetard, tauxAvancement: act.tauxAvancement }
 


### PR DESCRIPTION
Complète la heatmap décideur (#74) : `grc-consolide.server` construit la grille gravité × vraisemblance (résiduel, `buildHeatGrid`) et l'expose via `ComiteConsolide.risques.grid` ; le **PDF de pack comité** rend la `HeatmapGrid`. Tests `pdf-heatmap` + `comite-pack`. `tsc` clean.

> Suite de la tâche de test continu (#134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)