### PR TITLE
docs(readme): synchronise EN/DE/ES/IT avec les fonctionnalités récentes

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -76,12 +76,12 @@ ACRA ändert das: Es ist ein **interaktiver methodischer Assistent**, der Schrit
 - Sicherheitsmaßnahmen aus **14 Frameworks**: ISO 27001:2022 · NIST CSF 2.0 · NIST 800-53 · CIS Controls v8 · ANSSI-Hygiene · HDS · PCI-DSS · DORA · IEC 62443 · SOC 2 · NIST SSDF · RGS · ReCyF · TISAX/VDA-ISA + benutzerdefinierte Kontrollen — Kontrollen **in 5 Sprachen lokalisiert**
 - Konfigurierbare Passwortrichtlinie (Länge, Komplexität, Ablauf, Verlauf, Sperrung)
 - Konfigurierbare **MFA** (Einmalcode per **E-Mail** oder **SMS**) mit 60-Minuten-Bestätigungsfenster zur Vermeidung versehentlicher Sperrung
-- Konfigurierbares **SSO** (SAML 2.0 oder OIDC) — automatische Kontobereitstellung
+- **Unternehmens-SSO OIDC** (Azure AD, Okta, Google Workspace…) in NextAuth integriert — automatische (JIT) Kontobereitstellung und **IdP-gesteuertes RBAC**: Zuordnung von IdP-**Gruppen** (AD / SailPoint) zu ACRA-Rollen, bei jeder Anmeldung synchronisiert. **SAML 2.0** im Wartungsmodus. **SCIM 2.0** (Bereitstellung/Deprovisionierung durch den IdP)
 - Vollständiger, exportierbarer Audit-Trail (CSV)
 
 ### 👥 Zusammenarbeit & Governance
 
-- **7-stufiges RBAC**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · FACHBEREICHSLEITUNG · ANALYST · LESER
+- **RBAC mit 12 Rollen** über die **3 Verteidigungslinien**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · FACHBEREICHSLEITUNG · ANALYST · LESER · **CONTROLLER** (permanente Kontrolle) · **COMPLIANCE** · **DSB** (Datenschutz) · **AUDITOR** (3. Linie) · **OPERATIV** (1. Linie)
 - **Multi-Organisation**: Organisationsbaum mit hierarchischen Bereichen (Knoten / Teilbaum); ein ADMIN verwaltet **nur die Konten seiner Organisation**, ein SUPER_ADMIN die Instanz
 - Freigabe-Workflow: Einreichung → Prüfung → Freigabe (CISO oder Risk Manager), mit **Funktionstrennung** — ein Genehmiger kann **seine eigene** Analyse nicht freigeben (Vier-Augen-Prinzip) — und **Selbstfreigabe** für Ein-Personen-Organisationen (wo Vier-Augen unmöglich ist)
 - **Restrisiko-Akzeptanz** durch die **Fachbereichsleitung** (dedizierte Nur-Lese-Rolle), getrennt von der Validierung der Analyse
@@ -96,11 +96,26 @@ ACRA ändert das: Es ist ein **interaktiver methodischer Assistent**, der Schrit
 - **Excel (.xlsx)**-Export mit allen tabellarischen Daten pro Blatt
 - **JSON**-Export (vollständiges, re-importierbares Backup) und **CSV** (tabellarische Daten)
 - Analyse-Import aus JSON oder CSV
+- **Gremien-Pakete** (PDF) mit einem **Banner „Gesamtrisikoniveau"** (Ampel HOCH / MITTEL / BEHERRSCHT) sowie einer **Risiko-Heatmap** (Schwere × Eintrittswahrscheinlichkeit) — die Kernaussage einer Vorstandsvorlage auf einen Blick
+
+### 🗄️ Datenschutz (DSB / DSGVO)
+
+- **Verzeichnis von Verarbeitungstätigkeiten (VVT — DSGVO Art. 30)**: organisationsbezogenes, dem **DSB** vorbehaltenes Register mit **Vollständigkeitsprüfung** (Zweck, Kategorien betroffener Personen/Daten, Empfänger, Speicherdauer, Sicherheitsmaßnahmen, Garantien bei Drittlandtransfer)
+- **DSFA-Entscheidungshilfe (Art. 35)**: automatische Erkennung von Verarbeitungen, die eine Folgenabschätzung erfordern (besondere Datenkategorien Art. 9, systematische Überwachung in großem Umfang)
+
+### 🔌 Interoperabilität & API
+
+- **Öffentliche v1-API** (REST, schlüsselbasierte Bearer-Authentifizierung): Lesen von **Risikoregister**, **Kontrollen** und **Vorfällen**; integrierte **OpenAPI**-Spezifikation
+- **Massenimport** per API (Risikoregister, Kontrollen), mit zeilenweiser Fehlermeldung
+- **Signierte ausgehende Webhooks** (HMAC): Benachrichtigung eines Drittsystems (SOAR/SIEM/ITSM) bei Ereignissen (Risiko erstellt, Vorfall gemeldet…), mit Wiederholungen und Anti-SSRF-Schutz
+- **OIDC-SSO + SCIM** (siehe *Sicherheit*) zur Anbindung von Authentifizierung und Bereitstellung an das Unternehmensverzeichnis
 
 ### 🌐 UX & Barrierefreiheit
 
 - Oberfläche in **5 Sprachen**: Français · English · Deutsch · Español · Italiano
 - **Auto-Speichern** bei jeder Änderung (kein Datenverlust)
+- **Autovervollständigung** wiederkehrender Felder (Organisation, Risikoquellen, Stakeholder, Maßnahmen, Geschäftswerte, unterstützende Werte, Einheit) aus bereits erfassten Werten im Bereich — vereinheitlicht Bezeichnungen und spart Tipparbeit
+- **Intelligente Standardwerte**: Organisation bei einer neuen Analyse vorausgefüllt; **Maßnahmenfristen nach Priorität berechnet** (Kritisch / Hoch / Mittel), pro Organisation konfigurierbare Fristen; Basis-Frameworks **nach Branche vorausgewählt**
 - Dashboard mit KPIs, Diagrammen, Warnungen zu kritischen Risiken, globaler Suche
 - Helles / dunkles / automatisches Theme
 - RGAA-konform: Tastaturnavigation, ARIA, barrierefreie Kontraste
@@ -664,7 +679,19 @@ Zum Hinzufügen einer Sprache `src/lib/i18n/fr.ts` kopieren, alle Schlüssel üb
 | `RSSI` (CISO) | ✅ | ✅ eigene + geteilte | ✅ | ❌ |
 | `RISK_MANAGER` | ✅ | ✅ eigene + geteilte | ✅ | ❌ |
 | `ANALYSTE` (Analyst) | ✅ | ✅ eigene + geteilte | ❌ | ❌ |
+| `DIRECTION_METIER` (Fachbereich) | ❌ | ❌ (Lesen) | ❌ | ❌ — *akzeptiert Restrisiken* |
+| `ANALYSTE` (Analyst) | ✅ | ✅ eigene + geteilte | ❌ | ❌ |
 | `LECTEUR` (Leser) | ❌ | ❌ | ❌ | ❌ |
+
+**GRC-Rollen / 3 Verteidigungslinien** (globaler Lesezugriff auf das Dispositiv + Schreibzugriff auf ihr Modul):
+
+| Rolle | Bereich |
+|------|-----------|
+| `CONTROLEUR` | Permanente Kontrolle (1./2. Linie) — Ausführung & Definition der Kontrollen |
+| `CONFORMITE` | 2. Linie — Compliance, Ausnahmegenehmigungen, RCSA-Kampagnen |
+| `DPO` | Datenschutz — **Verzeichnis von Verarbeitungstätigkeiten (VVT, DSGVO Art. 30)** |
+| `AUDITEUR` | 3. Linie — interne Revision (Prüfungen, Feststellungen, Empfehlungen) |
+| `METIER` | Operativ 1. Linie — Vorfallmeldung, Kontrollausführung |
 
 Zugriffe können auch **analyseweise** gewährt werden (punktuelles Teilen mit jedem Benutzer).
 

--- a/README.en.md
+++ b/README.en.md
@@ -76,12 +76,12 @@ ACRA changes that: it is an **interactive methodological assistant** that guides
 - Security measures from **14 frameworks**: ISO 27001:2022 · NIST CSF 2.0 · NIST 800-53 · CIS Controls v8 · ANSSI Hygiene · HDS · PCI-DSS · DORA · IEC 62443 · SOC 2 · NIST SSDF · RGS · ReCyF · TISAX/VDA-ISA + custom controls — controls **localized in 5 languages**
 - Configurable password policy (length, complexity, expiry, history, lockout)
 - Configurable **MFA** (one-time passcode by **email** or **SMS**) with a 60-min confirmation window to avoid accidental lockout
-- Configurable **SSO** (SAML 2.0 or OIDC) — automatic account provisioning
+- **Enterprise OIDC SSO** (Azure AD, Okta, Google Workspace…) wired into NextAuth — automatic (JIT) account provisioning and **IdP-driven RBAC**: map IdP **groups** (AD / SailPoint) to ACRA roles, re-synced on every sign-in. **SAML 2.0** built in maintenance mode. **SCIM 2.0** (provisioning/deprovisioning by the IdP)
 - Full, exportable audit trail (CSV)
 
 ### 👥 Collaboration & governance
 
-- **7-level RBAC**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · BUSINESS_MANAGEMENT · ANALYST · READER
+- **12-role RBAC** covering the **3 lines of defense**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · BUSINESS_MANAGEMENT · ANALYST · READER · **CONTROLLER** (permanent control) · **COMPLIANCE** · **DPO** (data protection) · **AUDITOR** (3rd line) · **OPERATIONAL** (1st line)
 - **Multi-organisation**: organisation tree with hierarchical scopes (node / subtree); an ADMIN manages **only the accounts of their organisation**, a SUPER_ADMIN manages the instance
 - Approval workflow: submission → review → approval (CISO or Risk Manager), with **separation of duties** — an approver cannot approve **their own** analysis (four-eyes principle) — and **self-validation** for single-user organisations (solo practices, where four-eyes is impossible)
 - **Residual risk acceptance** by **Business management** (dedicated read-only role), distinct from analysis validation (deliverable acceptance)
@@ -96,11 +96,26 @@ ACRA changes that: it is an **interactive methodological assistant** that guides
 - **Excel (.xlsx)** export with all tabular data per sheet
 - **JSON** export (full, re-importable backup) and **CSV** (tabular data)
 - Analysis import from JSON or CSV
+- **Committee packs** (PDF) with an **"overall risk level" banner** (traffic-light HIGH / MODERATE / UNDER CONTROL) plus a gravity × likelihood **risk heatmap** — the message of a board file at a glance
+
+### 🗄️ Data protection (DPO / GDPR)
+
+- **Record of Processing Activities (RoPA — GDPR Art. 30)**: per-organisation register reserved for the **DPO**, with **completeness checks** (purpose, categories of persons/data, recipients, retention period, security measures, non-EU transfer safeguards)
+- **DPIA decision support (Art. 35)**: automatic detection of processing needing an impact assessment (special-category data Art. 9, large-scale systematic monitoring)
+
+### 🔌 Interoperability & API
+
+- **Public v1 API** (REST, key-based Bearer auth): read the **risk register**, **controls** and **incidents**; built-in **OpenAPI** spec
+- **Bulk import** via API (risk register, controls), with per-row error reporting
+- **Signed outbound webhooks** (HMAC): notify a third-party system (SOAR/SIEM/ITSM) on events (risk created, incident declared…), with retries and an anti-SSRF guard
+- **OIDC SSO + SCIM** (see *Security*) to plug authentication and provisioning into the corporate directory
 
 ### 🌐 UX & accessibility
 
 - Interface in **5 languages**: Français · English · Deutsch · Español · Italiano
 - **Auto-save** on every change (no data loss)
+- **Autocomplete** on repetitive fields (organisation, risk sources, stakeholders, measures, business values, supporting assets, entity) from values already entered in scope — harmonises labels and cuts re-typing
+- **Smart defaults**: organisation pre-filled on a new analysis; **action due dates computed from priority** (Critical / Major / Moderate), per-organisation configurable delays; baseline frameworks **pre-ticked by sector**
 - Dashboard with KPIs, charts, critical-risk alerts, global search
 - Light / dark / automatic theme
 - RGAA-compliant: keyboard navigation, ARIA, accessible contrasts
@@ -663,8 +678,19 @@ To add a language, copy `src/lib/i18n/fr.ts`, translate all keys and save the fi
 | `ADMIN` | ✅ | ✅ all | ✅ | ✅ |
 | `RSSI` (CISO) | ✅ | ✅ own + shared | ✅ | ❌ |
 | `RISK_MANAGER` | ✅ | ✅ own + shared | ✅ | ❌ |
+| `DIRECTION_METIER` (Business mgmt) | ❌ | ❌ (read) | ❌ | ❌ — *accepts residual risks* |
 | `ANALYSTE` (Analyst) | ✅ | ✅ own + shared | ❌ | ❌ |
 | `LECTEUR` (Reader) | ❌ | ❌ | ❌ | ❌ |
+
+**GRC roles / 3 lines of defense** (global read of the framework + write on their module):
+
+| Role | Scope |
+|------|-------|
+| `CONTROLEUR` | Permanent control (1st/2nd line) — running & defining controls |
+| `CONFORMITE` | 2nd line — compliance, waivers, RCSA campaigns |
+| `DPO` | Data protection — **Record of Processing Activities (RoPA, GDPR Art. 30)** |
+| `AUDITEUR` | 3rd line — internal audit (missions, findings, recommendations) |
+| `METIER` | 1st-line operational — incident reporting, control execution |
 
 Access can also be granted **analysis by analysis** (ad-hoc sharing with any user).
 

--- a/README.es.md
+++ b/README.es.md
@@ -76,12 +76,12 @@ ACRA cambia esto: es un **asistente metodológico interactivo** que guía paso a
 - Medidas de seguridad de **14 marcos**: ISO 27001:2022 · NIST CSF 2.0 · NIST 800-53 · CIS Controls v8 · Higiene ANSSI · HDS · PCI-DSS · DORA · IEC 62443 · SOC 2 · NIST SSDF · RGS · ReCyF · TISAX/VDA-ISA + controles personalizados — controles **localizados en 5 idiomas**
 - Política de contraseñas configurable (longitud, complejidad, caducidad, historial, bloqueo)
 - **MFA** configurable (código de un solo uso por **correo electrónico** o **SMS**) con ventana de confirmación de 60 min para evitar bloqueos accidentales
-- **SSO** configurable (SAML 2.0 u OIDC) — aprovisionamiento automático de cuentas
+- **SSO de empresa OIDC** (Azure AD, Okta, Google Workspace…) integrado en NextAuth — aprovisionamiento automático (JIT) de cuentas y **RBAC gobernado por el IdP**: asignación de **grupos** del IdP (AD / SailPoint) a los roles de ACRA, resincronizados en cada inicio de sesión. **SAML 2.0** en modo mantenimiento. **SCIM 2.0** (aprovisionamiento/desaprovisionamiento por el IdP)
 - Pista de auditoría completa exportable (CSV)
 
 ### 👥 Colaboración y gobernanza
 
-- **RBAC de 7 niveles**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · DIRECCIÓN_DE_NEGOCIO · ANALISTA · LECTOR
+- **RBAC de 12 roles** que cubre las **3 líneas de defensa**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · DIRECCIÓN_DE_NEGOCIO · ANALISTA · LECTOR · **CONTROLADOR** (control permanente) · **CUMPLIMIENTO** · **DPD** (protección de datos) · **AUDITOR** (3ª línea) · **OPERATIVO** (1ª línea)
 - **Multiorganización**: árbol de organizaciones con perímetros jerárquicos (nodo / subárbol); un ADMIN administra **solo las cuentas de su organización**, un SUPER_ADMIN gestiona la instancia
 - Flujo de aprobación: envío → revisión → aprobación (CISO o Risk Manager), con **separación de funciones** — un aprobador no puede aprobar **su propio** análisis (principio de cuatro ojos) — y **autovalidación** para organizaciones de un solo usuario (despachos individuales, donde los cuatro ojos son imposibles)
 - **Aceptación de riesgos residuales** por la **Dirección de negocio** (rol dedicado de solo lectura), distinta de la validación del análisis
@@ -96,11 +96,26 @@ ACRA cambia esto: es un **asistente metodológico interactivo** que guía paso a
 - Exportación **Excel (.xlsx)** con todos los datos tabulares por pestaña
 - Exportación **JSON** (copia de seguridad completa, reimportable) y **CSV** (datos tabulares)
 - Importación de análisis desde JSON o CSV
+- **Paquetes de comité** (PDF) con un **banner de «nivel de riesgo global»** (semáforo ALTO / MODERADO / CONTROLADO) y un **mapa de calor** de riesgo (gravedad × probabilidad) — el mensaje de un expediente de un vistazo
+
+### 🗄️ Protección de datos (DPD / RGPD)
+
+- **Registro de actividades de tratamiento (RAT — RGPD art. 30)**: registro por organización reservado al **DPD**, con **control de exhaustividad** (finalidad, categorías de personas/datos, destinatarios, plazo de conservación, medidas de seguridad, garantías de transferencia fuera de la UE)
+- **Ayuda a la decisión EIPD (art. 35)**: detección automática de tratamientos que requieren una evaluación de impacto (datos de categorías especiales art. 9, observación sistemática a gran escala)
+
+### 🔌 Interoperabilidad y API
+
+- **API pública v1** (REST, autenticación por clave — Bearer): lectura del **registro de riesgos**, los **controles** y los **incidentes**; especificación **OpenAPI** integrada
+- **Importación masiva** por API (registro de riesgos, controles), con notificación de errores por línea
+- **Webhooks salientes firmados** (HMAC): notificación a un sistema externo (SOAR/SIEM/ITSM) ante eventos (riesgo creado, incidente declarado…), con reintentos y protección anti-SSRF
+- **SSO OIDC + SCIM** (véase *Seguridad*) para conectar la autenticación y el aprovisionamiento al directorio de la empresa
 
 ### 🌐 UX y accesibilidad
 
 - Interfaz en **5 idiomas**: Français · English · Deutsch · Español · Italiano
 - **Autoguardado** en cada modificación (sin pérdida de datos)
+- **Autocompletado** de campos repetitivos (organización, fuentes de riesgo, partes interesadas, medidas, valores de negocio, activos de soporte, entidad) a partir de los valores ya introducidos en el ámbito — homogeneiza las etiquetas y reduce la reescritura
+- **Valores por defecto inteligentes**: organización precargada en un nuevo análisis; **vencimiento de las acciones calculado según su prioridad** (Crítica / Mayor / Moderada), plazos configurables por organización; marcos de referencia **premarcados según el sector**
 - Panel con KPIs, gráficos, alertas de riesgos críticos, búsqueda global
 - Tema claro / oscuro / automático
 - Conforme a RGAA: navegación por teclado, ARIA, contrastes accesibles
@@ -664,7 +679,19 @@ Para añadir un idioma, copia `src/lib/i18n/fr.ts`, traduce todas las claves y g
 | `RSSI` (CISO) | ✅ | ✅ propios + compartidos | ✅ | ❌ |
 | `RISK_MANAGER` | ✅ | ✅ propios + compartidos | ✅ | ❌ |
 | `ANALYSTE` (Analista) | ✅ | ✅ propios + compartidos | ❌ | ❌ |
+| `DIRECTION_METIER` (Dir. de negocio) | ❌ | ❌ (lectura) | ❌ | ❌ — *acepta los riesgos residuales* |
+| `ANALYSTE` (Analista) | ✅ | ✅ propios + compartidos | ❌ | ❌ |
 | `LECTEUR` (Lector) | ❌ | ❌ | ❌ | ❌ |
+
+**Roles GRC / 3 líneas de defensa** (lectura global del dispositivo + escritura en su módulo):
+
+| Rol | Ámbito |
+|------|-----------|
+| `CONTROLEUR` | Control permanente (1ª/2ª línea) — ejecución y definición de controles |
+| `CONFORMITE` | 2ª línea — cumplimiento, exenciones, campañas RCSA |
+| `DPO` | Protección de datos — **Registro de actividades de tratamiento (RAT, RGPD art. 30)** |
+| `AUDITEUR` | 3ª línea — auditoría interna (misiones, constataciones, recomendaciones) |
+| `METIER` | Operativo 1ª línea — declaración de incidentes, ejecución de controles |
 
 Los accesos también pueden concederse **análisis por análisis** (compartición puntual con cualquier usuario).
 

--- a/README.it.md
+++ b/README.it.md
@@ -76,12 +76,12 @@ ACRA cambia tutto questo: è un **assistente metodologico interattivo** che guid
 - Misure di sicurezza da **14 framework**: ISO 27001:2022 · NIST CSF 2.0 · NIST 800-53 · CIS Controls v8 · Igiene ANSSI · HDS · PCI-DSS · DORA · IEC 62443 · SOC 2 · NIST SSDF · RGS · ReCyF · TISAX/VDA-ISA + controlli personalizzati — controlli **localizzati in 5 lingue**
 - Politica delle password configurabile (lunghezza, complessità, scadenza, cronologia, blocco)
 - **MFA** configurabile (codice monouso via **e-mail** o **SMS**) con finestra di conferma di 60 min per evitare blocchi accidentali
-- **SSO** configurabile (SAML 2.0 o OIDC) — provisioning automatico degli account
+- **SSO aziendale OIDC** (Azure AD, Okta, Google Workspace…) integrato in NextAuth — provisioning automatico (JIT) degli account e **RBAC guidato dall'IdP**: mappatura dei **gruppi** dell'IdP (AD / SailPoint) sui ruoli ACRA, risincronizzati a ogni accesso. **SAML 2.0** sviluppato in modalità manutenzione. **SCIM 2.0** (provisioning/deprovisioning da parte dell'IdP)
 - Audit trail completo esportabile (CSV)
 
 ### 👥 Collaborazione e governance
 
-- **RBAC a 7 livelli**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · DIREZIONE_AZIENDALE · ANALISTA · LETTORE
+- **RBAC a 12 ruoli** che copre le **3 linee di difesa**: SUPER_ADMIN · ADMIN · CISO · RISK_MANAGER · DIREZIONE_AZIENDALE · ANALISTA · LETTORE · **CONTROLLORE** (controllo permanente) · **CONFORMITÀ** · **DPO** (protezione dei dati) · **AUDITOR** (3ª linea) · **OPERATIVO** (1ª linea)
 - **Multi-organizzazione**: albero delle organizzazioni con perimetri gerarchici (nodo / sottoalbero); un ADMIN amministra **solo gli account della propria organizzazione**, un SUPER_ADMIN gestisce l'istanza
 - Flusso di approvazione: invio → revisione → approvazione (CISO o Risk Manager), con **separazione dei compiti** — un approvatore non può approvare la **propria** analisi (principio dei quattro occhi) — e **autovalidazione** per le organizzazioni mono-utente (studi individuali, dove i quattro occhi sono impossibili)
 - **Accettazione dei rischi residui** da parte della **Direzione aziendale** (ruolo dedicato in sola lettura), distinta dalla validazione dell'analisi
@@ -96,11 +96,26 @@ ACRA cambia tutto questo: è un **assistente metodologico interattivo** che guid
 - Esportazione **Excel (.xlsx)** con tutti i dati tabellari per foglio
 - Esportazione **JSON** (backup completo, reimportabile) e **CSV** (dati tabellari)
 - Importazione di analisi da JSON o CSV
+- **Pacchetti per i comitati** (PDF) con un **banner «livello di rischio complessivo»** (semaforo ALTO / MODERATO / SOTTO CONTROLLO) e una **heatmap** di rischio (gravità × probabilità) — il messaggio di un dossier a colpo d'occhio
+
+### 🗄️ Protezione dei dati (DPO / GDPR)
+
+- **Registro delle attività di trattamento (RoPA — GDPR art. 30)**: registro per organizzazione riservato al **DPO**, con **controllo di completezza** (finalità, categorie di persone/dati, destinatari, periodo di conservazione, misure di sicurezza, garanzie per il trasferimento extra-UE)
+- **Supporto alla decisione DPIA (art. 35)**: rilevamento automatico dei trattamenti che richiedono una valutazione d'impatto (dati particolari art. 9, monitoraggio sistematico su larga scala)
+
+### 🔌 Interoperabilità e API
+
+- **API pubblica v1** (REST, autenticazione tramite chiave — Bearer): lettura del **registro dei rischi**, dei **controlli** e degli **incidenti**; specifica **OpenAPI** integrata
+- **Importazione massiva** tramite API (registro dei rischi, controlli), con segnalazione degli errori per riga
+- **Webhook in uscita firmati** (HMAC): notifica a un sistema esterno (SOAR/SIEM/ITSM) al verificarsi di eventi (rischio creato, incidente dichiarato…), con ritentativi e protezione anti-SSRF
+- **SSO OIDC + SCIM** (vedi *Sicurezza*) per collegare l'autenticazione e il provisioning alla directory aziendale
 
 ### 🌐 UX e accessibilità
 
 - Interfaccia in **5 lingue**: Français · English · Deutsch · Español · Italiano
 - **Salvataggio automatico** a ogni modifica (nessuna perdita di dati)
+- **Autocompletamento** dei campi ripetitivi (organizzazione, sorgenti di rischio, parti interessate, misure, valori aziendali, beni di supporto, entità) a partire dai valori già inseriti nel perimetro — uniforma le etichette e riduce la ridigitazione
+- **Valori predefiniti intelligenti**: organizzazione precompilata in una nuova analisi; **scadenza delle azioni calcolata in base alla priorità** (Critica / Maggiore / Moderata), tempi configurabili per organizzazione; framework di riferimento **preselezionati in base al settore**
 - Dashboard con KPI, grafici, avvisi sui rischi critici, ricerca globale
 - Tema chiaro / scuro / automatico
 - Conforme a RGAA: navigazione da tastiera, ARIA, contrasti accessibili
@@ -663,8 +678,19 @@ Per aggiungere una lingua, copia `src/lib/i18n/fr.ts`, traduci tutte le chiavi e
 | `ADMIN` | ✅ | ✅ tutte | ✅ | ✅ |
 | `RSSI` (CISO) | ✅ | ✅ proprie + condivise | ✅ | ❌ |
 | `RISK_MANAGER` | ✅ | ✅ proprie + condivise | ✅ | ❌ |
+| `DIRECTION_METIER` (Direzione az.) | ❌ | ❌ (lettura) | ❌ | ❌ — *accetta i rischi residui* |
 | `ANALYSTE` (Analista) | ✅ | ✅ proprie + condivise | ❌ | ❌ |
 | `LECTEUR` (Lettore) | ❌ | ❌ | ❌ | ❌ |
+
+**Ruoli GRC / 3 linee di difesa** (lettura globale del dispositivo + scrittura sul proprio modulo):
+
+| Ruolo | Perimetro |
+|------|-----------|
+| `CONTROLEUR` | Controllo permanente (1ª/2ª linea) — esecuzione e definizione dei controlli |
+| `CONFORMITE` | 2ª linea — conformità, deroghe, campagne RCSA |
+| `DPO` | Protezione dei dati — **Registro delle attività di trattamento (RoPA, GDPR art. 30)** |
+| `AUDITEUR` | 3ª linea — audit interno (missioni, constatazioni, raccomandazioni) |
+| `METIER` | Operativo 1ª linea — dichiarazione degli incidenti, esecuzione dei controlli |
 
 Gli accessi possono anche essere concessi **analisi per analisi** (condivisione puntuale con qualsiasi utente).
 


### PR DESCRIPTION
## Contexte
Synchronisation des READMEs traduits avec les fonctionnalités récentes (celles ajoutées au README FR en #72), avant la démo / le comité.

## Ce qui est porté dans EN / DE / ES / IT
- **Sécurité** : SSO d'entreprise **OIDC** + **RBAC piloté par les groupes IdP** (AD/SailPoint) + **SCIM** ; SAML en maintenance.
- **RBAC** : 7 → **12 rôles** couvrant les **3 lignes de défense** + tableau des rôles GRC (CONTROLEUR, CONFORMITE, DPO, AUDITEUR, METIER) + ligne DIRECTION_METIER.
- Nouvelle section **Protection des données (DPO/RGPD)** : registre RoPA (art. 30) + aide AIPD (art. 35).
- Nouvelle section **Interopérabilité & API** : API v1, import en masse, webhooks signés.
- **UX** : autocomplétion, défauts intelligents (échéance par priorité, référentiels pré-cochés) ; packs comités (bandeau de risque global + heatmap).

## Portée
Sync **ciblée sur les fonctionnalités phares**. Les traductions accusaient un retard plus ancien (toute la section détaillée « Module GRC » n'a jamais été traduite depuis l'été) — ce **rattrapage complet reste à faire** séparément. Docs uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)