### PR TITLE
docs(readme): rattrapage — traduction de la section « Module GRC » (EN/DE/ES/IT)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -142,6 +142,61 @@ ACRA ändert das: Es ist ein **interaktiver methodischer Assistent**, der Schrit
 
 ---
 
+## 🏛️ GRC-Modul — Governance, Risk & Compliance
+
+Über die EBIOS-RM-Analyse hinaus bringt ACRA eine **vollständige GRC-Basis** mit, die nach dem Modell der **drei Verteidigungslinien** strukturiert ist, für regulierte Einheiten (Banken, Versicherungen, Gesundheitswesen) konzipiert und an **DORA**, **NIS2** und **ISO/IEC 27001/27002** ausgerichtet. Jedes Modul ist pro Organisation aktivierbar; die Navigation wechselt automatisch in den „GRC-Modus", sobald ein Modul der 2./3. Linie aktiv ist.
+
+> Die folgenden Screenshots stammen aus dem **realistischen Demo-Datensatz** (Bankensektor), verankert an öffentlichen Bedrohungen (ENISA Threat Landscape). Ladbar und wieder löschbar: `npm run db:seed:demo` / `npm run db:seed:demo:purge`.
+
+### 📊 GRC-Steuerung — konsolidiertes Cockpit
+
+Führungssicht, die je Organisations-Teilbaum die **Risikolage** und den Fortschritt der Maßnahmenpläne aggregiert: Register (hoch/mittel/niedrig), Nettoverluste (LDC), offene Vorfälle, Konformitätsgrad, Kontrollanomalien, kritische Feststellungen, Risikoappetit, KRIs und **schwere DORA-IKT-Vorfälle**. Ein-Klick-Erzeugung von **Gremien-Paketen** und des **internen Kontrollberichts** (PDF/PPTX).
+
+<img src="docs/screenshots/grc-pilotage-light.png" width="49%"> <img src="docs/screenshots/grc-pilotage-dark.png" width="49%">
+
+### 📚 Frameworks & Anforderungen — *nachgewiesene* Konformität
+
+Die **mitgelieferten Frameworks** (ISO 27001, NIST CSF/800-53, CIS, ANSSI, HDS, PCI-DSS, DORA, IEC 62443, SOC 2, RGS, ReCyF…) und Ihre **eigenen Frameworks** (ISMS-Richtlinie, interne Richtlinien), heruntergebrochen auf **kontrollierbare und prüfbare Kontrollpunkte**. Eine **Standard-Sicherheitsrichtlinie** (DORA- + ISO-27001/27002-Basis, mit ihren Aufgaben) wird per Klick initialisiert. Die **Abdeckung** jeder Anforderung wird **aus den realen Kontrollen** und Prüffeststellungen **abgeleitet** — Konformität wird *nachgewiesen*, nicht nur behauptet.
+
+<img src="docs/screenshots/grc-referentiels-light.png" width="49%"> <img src="docs/screenshots/grc-referentiels-dark.png" width="49%">
+
+Die **abgeleitete Abdeckung** eines Frameworks: der Status jeder Anforderung (konform / teilweise / Anomalie / nicht abgedeckt) wird aus den **realen Kontrollen**, die sie abdecken, und aus Prüffeststellungen berechnet — hier die StarBank-ISMS-Richtlinie, abgedeckt durch permanente Kontrollen.
+
+<img src="docs/screenshots/grc-couverture-light.png" width="49%"> <img src="docs/screenshots/grc-couverture-dark.png" width="49%">
+
+### 🚨 Vorfälle & Verluste — DORA-Meldung (Art. 19)
+
+Meldung in der 1. Linie, Qualifizierung in der 2. Linie, Verluste in **LDC**-Logik (brutto, Rückflüsse, netto). Jeder Vorfall wird **automatisch nach DORA klassifiziert** (gering / erheblich / schwer); für schwere Vorfälle werden die **Meldefristen nach Art. 19** (erste / Zwischen- / Abschlussmeldung) berechnet und verfolgt, und das **ITS-Register** ist exportierbar.
+
+<img src="docs/screenshots/grc-incidents-light.png" width="49%"> <img src="docs/screenshots/grc-incidents-dark.png" width="49%">
+
+### ✅ Permanente Kontrolle (N1/N2) & 🔎 Interne Revision (3. Linie)
+
+Bibliothek **permanenter Kontrollen**, an das Raster (Risiko / Prozess / Framework-Anforderung) gebunden, periodisch ausgeführt, mit **beobachteter Wirksamkeit** (RCSA-Schleife) und **N1-Kontrollkampagnen**. In der 3. Linie plant die **interne Revision** Prüfungen, formuliert **Feststellungen** (Kritikalität + Empfehlung) und verfolgt deren Behebung; die Empfehlungen der **Aufsichtsbehörde** (ACPR/EZB) werden im selben Ablauf verfolgt.
+
+<img src="docs/screenshots/grc-controles-light.png" width="49%"> <img src="docs/screenshots/grc-audit-light.png" width="49%">
+
+### 🛡️ Konformität & 🗂️ Dokumentenbibliothek
+
+Verfolgung der **Konformität** je Framework (Multi-Organisations-Heatmap, **SoA**-Export CSV/PDF) und GRC-**Dokumentenbibliothek** (ISMS-Richtlinie, Strategien, Richtlinien): versionierter Upload, an ein Framework / Risiko / eine Organisation gebunden, authentifizierter Download.
+
+<img src="docs/screenshots/grc-conformite-light.png" width="49%"> <img src="docs/screenshots/grc-documents-light.png" width="49%">
+
+### 📄 Gebrauchsfertige regulatorische Ergebnisse
+
+- **RAS** — Risk Appetite Statement (PDF)
+- **SoA** — Statement of Applicability / Anwendbarkeitserklärung (PDF)
+- **Gremien-Pakete** — Risiken / Konformität / Vorfälle (PDF)
+- **Jährlicher interner Kontrollbericht** — 3 Verteidigungslinien + DORA-Resilienzteil (PDF **und PPTX**)
+- **DORA-ITS-Register** schwerer Vorfälle (Art. 19) und **Informationsregister der IKT-Drittparteien** (Art. 28) — CSV
+- **Risiko-Landkarte** (PDF)
+
+Beispiel — **jährlicher interner Kontrollbericht** (aus den StarBank-Demodaten erzeugt): Gesamtbeurteilung, Aufmerksamkeitspunkte, dann Zusammenfassung je Verteidigungslinie (permanente Kontrolle, Risikomanagement & Konformität, Revision) und DORA-Resilienzteil.
+
+<img src="docs/screenshots/grc-rapport-controle-interne.png" width="60%">
+
+---
+
 ## 🚀 Schnellstart (Docker)
 
 **Keine lokale Installation von Node, npm oder Prisma erforderlich**: Das Docker-Image

--- a/README.en.md
+++ b/README.en.md
@@ -142,6 +142,61 @@ ACRA changes that: it is an **interactive methodological assistant** that guides
 
 ---
 
+## 🏛️ GRC module — Governance, Risk & Compliance
+
+Beyond the EBIOS RM analysis, ACRA ships a **complete GRC foundation** structured around the **three lines of defense** model, designed for regulated entities (banking, insurance, healthcare) and aligned with **DORA**, **NIS2** and **ISO/IEC 27001/27002**. Each module is enabled per organisation; the navigation automatically switches to "GRC mode" as soon as a 2nd/3rd-line module is active.
+
+> The screenshots below come from the **realistic demo dataset** (banking sector), anchored on public threats (ENISA Threat Landscape). Loadable then purgeable: `npm run db:seed:demo` / `npm run db:seed:demo:purge`.
+
+### 📊 GRC steering — consolidated cockpit
+
+Executive view aggregating, per organisation subtree, the **risk posture** and action-plan progress: register (high/medium/low), net losses (LDC), open incidents, compliance rate, control anomalies, critical findings, appetite, KRIs and **major DORA ICT** incidents. One-click generation of **committee packs** and the **internal control report** (PDF/PPTX).
+
+<img src="docs/screenshots/grc-pilotage-light.png" width="49%"> <img src="docs/screenshots/grc-pilotage-dark.png" width="49%">
+
+### 📚 Frameworks & requirements — *proven* compliance
+
+The **shipped frameworks** (ISO 27001, NIST CSF/800-53, CIS, ANSSI, HDS, PCI-DSS, DORA, IEC 62443, SOC 2, RGS, ReCyF…) and your **own frameworks** (ISSP, internal policies) broken down into **controllable, auditable control points**. A **default security policy** (DORA + ISO 27001/27002 baseline, with its missions) initialises in one click. Each requirement's **coverage** is **derived from real controls** and audit findings — compliance is *proven*, not merely declared.
+
+<img src="docs/screenshots/grc-referentiels-light.png" width="49%"> <img src="docs/screenshots/grc-referentiels-dark.png" width="49%">
+
+A framework's **derived coverage**: each requirement's status (compliant / partial / anomaly / not covered) is computed from the **real controls** that cover it and from audit findings — here StarBank's ISSP covered by permanent controls.
+
+<img src="docs/screenshots/grc-couverture-light.png" width="49%"> <img src="docs/screenshots/grc-couverture-dark.png" width="49%">
+
+### 🚨 Incidents & losses — DORA reporting (Art. 19)
+
+1st-line declaration, 2nd-line qualification, losses in **LDC** logic (gross, recoveries, net). Each incident is **automatically classified under DORA** (minor / significant / major); for major incidents the **Art. 19 notification deadlines** (initial / intermediate / final) are computed and tracked, and the **ITS register** is exportable.
+
+<img src="docs/screenshots/grc-incidents-light.png" width="49%"> <img src="docs/screenshots/grc-incidents-dark.png" width="49%">
+
+### ✅ Permanent control (L1/L2) & 🔎 Internal audit (3rd line)
+
+A library of **permanent controls** attached to the mesh (risk / process / framework requirement), run periodically, with **observed effectiveness** (RCSA loop) and **L1 control campaigns**. On the 3rd line, **internal audit** plans missions, issues **findings** (criticality + recommendation) and tracks their resolution; **regulator** recommendations (ACPR/ECB) are tracked in the same flow.
+
+<img src="docs/screenshots/grc-controles-light.png" width="49%"> <img src="docs/screenshots/grc-audit-light.png" width="49%">
+
+### 🛡️ Compliance & 🗂️ Document library
+
+Tracking of **compliance** per framework (multi-organisation heatmap, **SoA** CSV/PDF export) and a GRC **document library** (ISSP, strategies, policies): versioned upload, linked to a framework / risk / organisation, authenticated download.
+
+<img src="docs/screenshots/grc-conformite-light.png" width="49%"> <img src="docs/screenshots/grc-documents-light.png" width="49%">
+
+### 📄 Ready-to-use regulatory outputs
+
+- **RAS** — Risk Appetite Statement (PDF)
+- **SoA** — Statement of Applicability (PDF)
+- **Committee packs** — Risk / Compliance / Incidents (PDF)
+- **Annual internal control report** — 3 lines of defense + DORA resilience section (PDF **and PPTX**)
+- **DORA ITS register** of major incidents (Art. 19) and **ICT third-party information register** (Art. 28) — CSV
+- **Risk map** (PDF)
+
+Example — **annual internal control report** (generated from the StarBank demo data): overall assessment, points of attention, then summary by line of defense (permanent control, risk management & compliance, audit) and DORA resilience section.
+
+<img src="docs/screenshots/grc-rapport-controle-interne.png" width="60%">
+
+---
+
 ## 🚀 Quick Start (Docker)
 
 **No local install of Node, npm or Prisma is required**: the Docker image bundles all

--- a/README.es.md
+++ b/README.es.md
@@ -142,6 +142,61 @@ ACRA cambia esto: es un **asistente metodológico interactivo** que guía paso a
 
 ---
 
+## 🏛️ Módulo GRC — Gobernanza, Riesgos y Cumplimiento
+
+Más allá del análisis EBIOS RM, ACRA incorpora una **base GRC completa** estructurada según el modelo de las **tres líneas de defensa**, pensada para entidades reguladas (banca, seguros, salud) y alineada con **DORA**, **NIS2** e **ISO/IEC 27001/27002**. Cada módulo se activa por organización; la navegación cambia automáticamente al «modo GRC» en cuanto un módulo de 2.ª/3.ª línea está activo.
+
+> Las capturas siguientes proceden del **conjunto de demostración realista** (sector bancario), anclado en amenazas públicas (ENISA Threat Landscape). Cargable y purgable: `npm run db:seed:demo` / `npm run db:seed:demo:purge`.
+
+### 📊 Pilotaje GRC — cuadro de mando consolidado
+
+Vista de dirección que agrega, por subárbol de organizaciones, la **postura de riesgo** y el avance de los planes de acción: registro (altos/medios/bajos), pérdidas netas (LDC), incidentes abiertos, tasa de cumplimiento, anomalías de control, constataciones críticas, apetito, KRIs e incidentes **TIC mayores DORA**. Generación con un clic de los **paquetes de comité** y del **informe de control interno** (PDF/PPTX).
+
+<img src="docs/screenshots/grc-pilotage-light.png" width="49%"> <img src="docs/screenshots/grc-pilotage-dark.png" width="49%">
+
+### 📚 Marcos y requisitos — cumplimiento *demostrado*
+
+Los **marcos incluidos** (ISO 27001, NIST CSF/800-53, CIS, ANSSI, HDS, PCI-DSS, DORA, IEC 62443, SOC 2, RGS, ReCyF…) y sus **marcos propios** (PSSI, políticas internas) desglosados en **puntos de control controlables y auditables**. Una **política de seguridad por defecto** (base DORA + ISO 27001/27002, con sus misiones) se inicializa con un clic. La **cobertura** de cada requisito se **deriva de los controles reales** y de las constataciones de auditoría — el cumplimiento se *demuestra*, no solo se declara.
+
+<img src="docs/screenshots/grc-referentiels-light.png" width="49%"> <img src="docs/screenshots/grc-referentiels-dark.png" width="49%">
+
+La **cobertura derivada** de un marco: el estado de cada requisito (conforme / parcial / anomalía / no cubierto) se calcula a partir de los **controles reales** que lo cubren y de las constataciones de auditoría — aquí la PSSI de StarBank cubierta por los controles permanentes.
+
+<img src="docs/screenshots/grc-couverture-light.png" width="49%"> <img src="docs/screenshots/grc-couverture-dark.png" width="49%">
+
+### 🚨 Incidentes y pérdidas — reporting DORA (art. 19)
+
+Declaración en 1.ª línea, calificación en 2.ª línea, pérdidas en lógica **LDC** (bruto, recuperaciones, neto). Cada incidente se **clasifica automáticamente según DORA** (menor / significativo / mayor); para los incidentes mayores, los **plazos de notificación del art. 19** (inicial / intermedio / final) se calculan y se siguen, y el **registro ITS** es exportable.
+
+<img src="docs/screenshots/grc-incidents-light.png" width="49%"> <img src="docs/screenshots/grc-incidents-dark.png" width="49%">
+
+### ✅ Control permanente (N1/N2) & 🔎 Auditoría interna (3.ª línea)
+
+Biblioteca de **controles permanentes** vinculados a la malla (riesgo / proceso / requisito de marco), ejecutados periódicamente, con **eficacia observada** (bucle RCSA) y **campañas de control N1**. En la 3.ª línea, la **auditoría interna** planifica misiones, formula **constataciones** (criticidad + recomendación) y sigue su resolución; las recomendaciones del **regulador** (ACPR/BCE) se siguen en el mismo flujo.
+
+<img src="docs/screenshots/grc-controles-light.png" width="49%"> <img src="docs/screenshots/grc-audit-light.png" width="49%">
+
+### 🛡️ Cumplimiento & 🗂️ Biblioteca documental
+
+Seguimiento del **cumplimiento** por marco (mapa de calor multi-organizaciones, exportación **SoA** CSV/PDF) y **biblioteca documental** GRC (PSSI, estrategias, políticas): depósito versionado, vinculado a un marco / riesgo / organización, descarga autenticada.
+
+<img src="docs/screenshots/grc-conformite-light.png" width="49%"> <img src="docs/screenshots/grc-documents-light.png" width="49%">
+
+### 📄 Producciones regulatorias listas para usar
+
+- **RAS** — Risk Appetite Statement (PDF)
+- **SoA** — Statement of Applicability / declaración de aplicabilidad (PDF)
+- **Paquetes de comité** — Riesgos / Cumplimiento / Incidentes (PDF)
+- **Informe anual de control interno** — 3 líneas de defensa + apartado de resiliencia DORA (PDF **y PPTX**)
+- **Registro DORA ITS** de incidentes mayores (art. 19) y **registro de información de terceros TIC** (art. 28) — CSV
+- **Mapa de riesgos** (PDF)
+
+Ejemplo — **informe anual de control interno** (generado a partir de los datos de demostración de StarBank): valoración de conjunto, puntos de atención, luego síntesis por línea de defensa (control permanente, gestión de riesgos y cumplimiento, auditoría) y apartado de resiliencia DORA.
+
+<img src="docs/screenshots/grc-rapport-controle-interne.png" width="60%">
+
+---
+
 ## 🚀 Inicio rápido (Docker)
 
 **No se requiere ninguna instalación local de Node, npm o Prisma**: la imagen Docker

--- a/README.it.md
+++ b/README.it.md
@@ -142,6 +142,61 @@ ACRA cambia tutto questo: è un **assistente metodologico interattivo** che guid
 
 ---
 
+## 🏛️ Modulo GRC — Governance, Rischi e Conformità
+
+Oltre all'analisi EBIOS RM, ACRA integra una **base GRC completa** strutturata secondo il modello delle **tre linee di difesa**, pensata per le entità regolamentate (banche, assicurazioni, sanità) e allineata a **DORA**, **NIS2** e **ISO/IEC 27001/27002**. Ogni modulo è attivabile per organizzazione; la navigazione passa automaticamente alla «modalità GRC» non appena un modulo di 2ª/3ª linea è attivo.
+
+> Gli screenshot seguenti provengono dal **set di dati demo realistico** (settore bancario), ancorato a minacce pubbliche (ENISA Threat Landscape). Caricabile e poi eliminabile: `npm run db:seed:demo` / `npm run db:seed:demo:purge`.
+
+### 📊 Pilotaggio GRC — cruscotto consolidato
+
+Vista direzionale che aggrega, per sottoalbero di organizzazioni, la **postura di rischio** e l'avanzamento dei piani d'azione: registro (alti/medi/bassi), perdite nette (LDC), incidenti aperti, tasso di conformità, anomalie di controllo, constatazioni critiche, appetito, KRI e incidenti **TIC gravi DORA**. Generazione con un clic dei **pacchetti per i comitati** e del **rapporto di controllo interno** (PDF/PPTX).
+
+<img src="docs/screenshots/grc-pilotage-light.png" width="49%"> <img src="docs/screenshots/grc-pilotage-dark.png" width="49%">
+
+### 📚 Framework e requisiti — conformità *dimostrata*
+
+I **framework forniti** (ISO 27001, NIST CSF/800-53, CIS, ANSSI, HDS, PCI-DSS, DORA, IEC 62443, SOC 2, RGS, ReCyF…) e i vostri **framework propri** (PSSI, politiche interne) declinati in **punti di controllo controllabili e verificabili**. Una **politica di sicurezza predefinita** (base DORA + ISO 27001/27002, con le sue missioni) si inizializza con un clic. La **copertura** di ogni requisito è **derivata dai controlli reali** e dalle constatazioni di audit — la conformità è *dimostrata*, non solo dichiarata.
+
+<img src="docs/screenshots/grc-referentiels-light.png" width="49%"> <img src="docs/screenshots/grc-referentiels-dark.png" width="49%">
+
+La **copertura derivata** di un framework: lo stato di ogni requisito (conforme / parziale / anomalia / non coperto) è calcolato a partire dai **controlli reali** che lo coprono e dalle constatazioni di audit — qui la PSSI di StarBank coperta dai controlli permanenti.
+
+<img src="docs/screenshots/grc-couverture-light.png" width="49%"> <img src="docs/screenshots/grc-couverture-dark.png" width="49%">
+
+### 🚨 Incidenti e perdite — reporting DORA (art. 19)
+
+Dichiarazione in 1ª linea, qualificazione in 2ª linea, perdite in logica **LDC** (lordo, recuperi, netto). Ogni incidente è **classificato automaticamente secondo DORA** (minore / significativo / grave); per gli incidenti gravi, le **scadenze di notifica dell'art. 19** (iniziale / intermedia / finale) sono calcolate e monitorate, e il **registro ITS** è esportabile.
+
+<img src="docs/screenshots/grc-incidents-light.png" width="49%"> <img src="docs/screenshots/grc-incidents-dark.png" width="49%">
+
+### ✅ Controllo permanente (N1/N2) & 🔎 Audit interno (3ª linea)
+
+Biblioteca di **controlli permanenti** collegati alla maglia (rischio / processo / requisito di framework), eseguiti periodicamente, con **efficacia osservata** (ciclo RCSA) e **campagne di controllo N1**. In 3ª linea, l'**audit interno** pianifica missioni, formula **constatazioni** (criticità + raccomandazione) e ne segue la risoluzione; le raccomandazioni del **regolatore** (ACPR/BCE) sono monitorate nello stesso flusso.
+
+<img src="docs/screenshots/grc-controles-light.png" width="49%"> <img src="docs/screenshots/grc-audit-light.png" width="49%">
+
+### 🛡️ Conformità & 🗂️ Biblioteca documentale
+
+Monitoraggio della **conformità** per framework (heatmap multi-organizzazione, esportazione **SoA** CSV/PDF) e **biblioteca documentale** GRC (PSSI, strategie, politiche): deposito versionato, collegato a un framework / rischio / organizzazione, download autenticato.
+
+<img src="docs/screenshots/grc-conformite-light.png" width="49%"> <img src="docs/screenshots/grc-documents-light.png" width="49%">
+
+### 📄 Produzioni regolamentari pronte all'uso
+
+- **RAS** — Risk Appetite Statement (PDF)
+- **SoA** — Statement of Applicability / dichiarazione di applicabilità (PDF)
+- **Pacchetti per i comitati** — Rischi / Conformità / Incidenti (PDF)
+- **Rapporto annuale di controllo interno** — 3 linee di difesa + sezione resilienza DORA (PDF **e PPTX**)
+- **Registro DORA ITS** degli incidenti gravi (art. 19) e **registro informativo dei terzi TIC** (art. 28) — CSV
+- **Cartografia dei rischi** (PDF)
+
+Esempio — **rapporto annuale di controllo interno** (generato dai dati demo StarBank): valutazione complessiva, punti di attenzione, poi sintesi per linea di difesa (controllo permanente, gestione dei rischi e conformità, audit) e sezione resilienza DORA.
+
+<img src="docs/screenshots/grc-rapport-controle-interne.png" width="60%">
+
+---
+
 ## 🚀 Avvio rapido (Docker)
 
 **Non è richiesta alcuna installazione locale di Node, npm o Prisma**: l'immagine Docker


### PR DESCRIPTION
## Contexte
Rattrapage de la traduction des READMEs : la section détaillée **« Module GRC — Gouvernance, Risques & Conformité »** (ajoutée au README FR cet été) n'avait **jamais été traduite**. Elle est maintenant portée dans les 4 langues.

## Contenu traduit (EN / DE / ES / IT)
- **Pilotage GRC** — cockpit consolidé (posture de risque, plans d'action, DORA)
- **Référentiels & exigences** — conformité *prouvée* / couverture dérivée des contrôles réels
- **Incidents & pertes** — reporting DORA art. 19 (classement auto, échéances, registre ITS)
- **Contrôle permanent N1/N2 & audit interne** (3ᵉ ligne)
- **Conformité & bibliothèque documentaire** (heatmap, SoA)
- **Productions réglementaires** (RAS, SoA, packs comités, rapport annuel de contrôle interne, registres DORA)

Captures d'écran partagées conservées à l'identique. **Parité structurelle rétablie** : 20 sections H2 dans chaque README (fr = en = de = es = it), section GRC présente partout.

Docs uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)