### PR TITLE
docs: runbook d'exploitation (reprise d'accès, P3009, backup, résilience)

### DIFF
--- a/docs/runbook-exploitation.md
+++ b/docs/runbook-exploitation.md
@@ -1,0 +1,147 @@
+# Runbook d'exploitation ACRA — récupération & résilience
+
+Procédures destinées à un **administrateur système** pour reprendre la main sur une
+instance ACRA en cas d'incident (perte d'accès, défaut base de données, crash Docker),
+**y compris lorsqu'aucune sauvegarde n'est disponible à restaurer**.
+
+Toutes les commandes supposent d'être à la racine du dépôt (là où se trouvent
+`docker-compose.yml` et `package.json`).
+
+---
+
+## 1. Reprendre un accès administrateur (aucun mot de passe valide)
+
+Les mots de passe sont hachés en **bcrypt (12 tours)** : une injection SQL directe est
+impraticable (il faudrait fabriquer un hash valide à la main). Utiliser le script fourni,
+qui hache avec le **même algorithme que l'application** puis fait un `upsert` du compte.
+
+```bash
+# Depuis l'hôte (base accessible en local via Docker) :
+DATABASE_URL="postgresql://<user>:<mdp>@localhost:5432/<db>" \
+  node scripts/create-admin.mjs <email> '<motdepasse>' SUPER_ADMIN
+
+# OU depuis le conteneur applicatif (utilise la DATABASE_URL interne) :
+docker compose exec app node scripts/create-admin.mjs <email> '<motdepasse>' SUPER_ADMIN
+```
+
+- **Crée** le compte s'il n'existe pas, ou **réinitialise** son mot de passe s'il existe
+  (met aussi `isActive=true`, `emailVerified`, et enlève `mustChangePassword`).
+- Rôle en 3ᵉ argument (défaut `SUPER_ADMIN`) parmi les 12 rôles RBAC :
+  `SUPER_ADMIN, ADMIN, RSSI, RISK_MANAGER, ANALYSTE, LECTEUR, DIRECTION_METIER,
+  AUDITEUR, CONTROLEUR, METIER, CONFORMITE, DPO`.
+- **SUPER_ADMIN** = accès instance complet (toutes organisations, configuration,
+  gestion des comptes) → le rôle à privilégier pour reprendre la main.
+- ⚠️ Le script **contourne volontairement la politique de mot de passe** (outil
+  d'administration hors bande) : choisir un mot de passe robuste.
+
+Un compte SUPER_ADMIN ainsi rétabli permet ensuite, depuis l'UI, de recréer/rehausser
+les autres comptes proprement (page `/admin/users`).
+
+---
+
+## 2. Base de données : migration Prisma en échec (P3009) bloquant le démarrage
+
+**Symptôme** : `ebios_migrator` sort en erreur (1), `ebios_app` reste en `Created`
+(il attend `migrator: service_completed_successfully`). Logs du migrator :
+`Error: P3009 — migrate found failed migrations…`.
+
+**Cause** : une migration est enregistrée « failed » dans `_prisma_migrations`
+(`finished_at` NULL, `rolled_back_at` NULL). Prisma refuse d'appliquer quoi que ce soit
+tant qu'elle n'est pas résolue — même si le schéma réel de la base est correct.
+
+**Diagnostic — le schéma est-il réellement en défaut ou seule la comptabilité l'est ?**
+
+```bash
+export DATABASE_URL="postgresql://<user>:<mdp>@localhost:5432/<db>"
+# 1) migrations bloquantes :
+docker compose exec db psql -U <user> -d <db> -tAc \
+  "select migration_name from \"_prisma_migrations\" where finished_at is null and rolled_back_at is null;"
+# 2) écart base ↔ schéma cible (vide OU seulement des DROP INDEX = schéma déjà conforme) :
+npx prisma migrate diff --from-url "$DATABASE_URL" --to-schema-datamodel prisma/schema.prisma --script
+```
+
+**Réparation quand le schéma est déjà conforme** (cas le plus courant après des
+migrations appliquées hors Prisma) — marquer les migrations comme appliquées **sans
+rejouer** leur DDL :
+
+```bash
+npx prisma migrate resolve --applied <nom_migration_en_echec>
+# puis, pour chaque migration listée « not yet applied » par :
+npx prisma migrate status
+npx prisma migrate resolve --applied <chaque_migration>
+# vérifier :
+npx prisma migrate status   # → "Database schema is up to date!"
+docker compose up -d app    # migrator repasse en exit 0, l'app démarre
+```
+
+Si le diff révèle de **vraies** différences (tables/colonnes manquantes), appliquer
+d'abord le SQL manquant (via `psql`) **avant** de marquer la migration appliquée.
+
+---
+
+## 3. PostgreSQL en crash-loop après un arrêt Docker sale
+
+**Symptôme** : `ebios_db` redémarre en boucle ; logs :
+`FATAL: bogus data in lock file "/var/run/postgresql/.s.PGSQL.5432.lock": ""`.
+
+**Cause** : un fichier de verrou résiduel (arrêt non propre). `restart: unless-stopped`
+relance le conteneur mais le verrou persiste → boucle.
+
+**Réparation** (le volume de **données** est préservé) :
+
+```bash
+docker compose up -d --force-recreate db   # /var/run est recréé, le verrou disparaît
+# attendre "healthy" :
+docker compose exec db psql -U <user> -d <db> -tAc "select 1;"
+```
+
+---
+
+## 4. Sauvegarde & restauration
+
+**Sauvegarde** (`scripts/backup.sh`, service `backup`) — dump `pg_dump` compressé avec
+rétention configurable (`BACKUP_RETENTION`, 7 jours par défaut) :
+
+```bash
+docker compose run --rm backup        # crée /backups/ebios_<horodatage>.sql.gz
+```
+
+⚠️ **Le service backup est « one-shot » (non planifié)** : rien ne le déclenche
+automatiquement. Voir §5.
+
+**Restauration** d'un dump :
+
+```bash
+gunzip -c backup_data/ebios_<horodatage>.sql.gz | \
+  docker compose exec -T db psql -U <user> -d <db>
+```
+
+---
+
+## 5. Améliorer la résilience (recommandations)
+
+Constats tirés d'incidents réels (crash Docker, migration P3009, verrou Postgres) :
+
+1. **Automatiser les sauvegardes** — le service `backup` est manuel. L'ajouter au
+   planificateur (`scripts/scheduler.sh`, qui exécute déjà les crons applicatifs) en
+   déclenchement quotidien, ou via un cron hôte. **Un backup non planifié ≈ pas de backup.**
+2. **Copie hors-site** — les dumps vivent dans un volume Docker local ; si le disque/hôte
+   meurt, ils meurent avec. Pousser vers un stockage distant (le projet a déjà une
+   intégration **OVH S3/Swift** pour la bibliothèque documentaire — la réutiliser).
+3. **Tester la restauration** régulièrement (un backup jamais restauré n'est pas fiable).
+   Rétention étagée : quotidiens 7 j + hebdomadaires 4 + mensuels 6.
+4. **Robustesse des migrations** — le démarrage de l'app est bloqué dur par le migrator
+   (`depends_on: service_completed_successfully`). Traiter P3009 dans le pipeline de
+   déploiement (`deploy.sh`) : détecter une migration failed et faire `migrate resolve`
+   (ou alerter) plutôt que d'échouer en boucle. Migrations idempotentes et testées.
+5. **tmpfs pour `/var/run/postgresql`** — monter ce répertoire en tmpfs dans le service
+   `db` pour qu'un verrou ne survive jamais à un redémarrage (évite le crash-loop du §3).
+6. **Base managée en production** — pour l'instance publique, une base PostgreSQL managée
+   (sauvegardes automatiques + PITR + réplication) est plus résiliente qu'un conteneur.
+   À défaut : WAL archiving + PITR côté conteneur.
+7. Les `healthcheck` (DB `pg_isready`, app `/api/health`) et `restart: unless-stopped`
+   sont déjà en place — bon socle ; les points ci-dessus les complètent côté **données**.
+
+> Rappel : en développement macOS, **Docker Desktop lui-même** peut s'arrêter
+> (instabilité hôte, pas ACRA). En production sur VPS Linux, Docker Engine est nettement
+> plus stable — mais les sauvegardes automatiques + hors-site restent indispensables.


### PR DESCRIPTION
## Contexte
Documentation d'exploitation demandée : rendre `scripts/create-admin.mjs` (PR #80) utilisable par un **admin système** pour reprendre la main en cas de défaut BDD et **sans sauvegarde à restaurer** — et capitaliser les procédures de récupération découvertes cette semaine.

## `docs/runbook-exploitation.md`
1. **Reprise d'accès admin** — script create-admin (local + conteneur), rôles, SUPER_ADMIN.
2. **Migration Prisma en échec (P3009)** — diagnostic (le schéma est-il réellement en défaut ?) via `migrate diff`, puis réparation par `migrate resolve --applied` sans rejouer le DDL.
3. **PostgreSQL en crash-loop** sur verrou résiduel — `--force-recreate db`.
4. **Sauvegarde / restauration** (`backup.sh`, service `backup`).
5. **Recommandations de résilience** — backups **automatisés + hors-site** (le service backup est aujourd'hui manuel), test de restauration, robustesse des migrations dans le pipeline, tmpfs pour le verrou Postgres, base managée en prod.

Docs uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)