### PR TITLE
feat(ops): sauvegardes PostgreSQL automatiques quotidiennes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,23 +121,30 @@ services:
   # Lancer manuellement : docker compose run --rm backup
   # En prod, déclencher via cron host ou un scheduler (ex: ofelia, supercronic)
   # ---------------------------------------------------------------------------
+  # Sauvegarde AUTOMATIQUE : le planificateur exécute backup.sh au démarrage puis
+  # chaque jour à BACKUP_HOUR (dump compressé + rotation + copie hors-site optionnelle).
+  # Sauvegarde ponctuelle à la demande : docker compose run --rm backup /backup.sh
   backup:
     image: postgres:16-alpine
     container_name: ebios_backup
-    restart: "no"
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_HOST: db
       BACKUP_RETENTION: ${BACKUP_RETENTION:-7}
+      BACKUP_HOUR: ${BACKUP_HOUR:-02}
+      # Copie hors-site (optionnelle) : commande recevant le chemin du dump en argument.
+      BACKUP_OFFSITE_CMD: ${BACKUP_OFFSITE_CMD:-}
     volumes:
       - ./scripts/backup.sh:/backup.sh:ro
+      - ./scripts/backup-scheduler.sh:/backup-scheduler.sh:ro
       - backup_data:/backups
     depends_on:
       db:
         condition: service_healthy
-    command: ["/bin/sh", "/backup.sh"]
+    command: ["/bin/sh", "/backup-scheduler.sh"]
 
 volumes:
   postgres_data:

--- a/docs/runbook-exploitation.md
+++ b/docs/runbook-exploitation.md
@@ -107,15 +107,19 @@ docker compose exec db psql -U <user> -d <db> -tAc "select 1;"
 
 ## 4. Sauvegarde & restauration
 
-**Sauvegarde** (`scripts/backup.sh`, service `backup`) — dump `pg_dump` compressé avec
-rétention configurable (`BACKUP_RETENTION`, 7 jours par défaut) :
+**Sauvegarde AUTOMATIQUE** — le service `backup` (démarré avec la stack) exécute
+`scripts/backup-scheduler.sh` : un dump `pg_dump` compressé **au démarrage** puis
+**chaque jour à `BACKUP_HOUR`** (défaut 02h), avec rotation (`BACKUP_RETENTION`,
+7 jours par défaut) et **copie hors-site optionnelle** (`BACKUP_OFFSITE_CMD`).
 
 ```bash
-docker compose run --rm backup        # crée /backups/ebios_<horodatage>.sql.gz
+docker compose logs backup            # vérifier les sauvegardes récentes
+docker compose run --rm backup /backup.sh   # sauvegarde PONCTUELLE à la demande
 ```
 
-⚠️ **Le service backup est « one-shot » (non planifié)** : rien ne le déclenche
-automatiquement. Voir §5.
+**Copie hors-site** (recommandée) : définir `BACKUP_OFFSITE_CMD` dans `.env` — la
+commande reçoit le chemin du dump en argument. Ex. `BACKUP_OFFSITE_CMD="rclone copy"`
+(config rclone vers OVH S3/Swift) pousse chaque dump hors du serveur.
 
 **Restauration** d'un dump :
 

--- a/scripts/backup-scheduler.sh
+++ b/scripts/backup-scheduler.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# ─── Planificateur de sauvegardes PostgreSQL ─────────────────────────────────
+# Exécute /backup.sh :
+#   • une fois immédiatement au démarrage (garantit un backup récent) ;
+#   • puis une fois par jour à l'heure BACKUP_HOUR (défaut 02h).
+# Sémantique proche de cron via un tick régulier + garde par jour (anti-doublon).
+# Utilisé par le service `backup` de docker-compose.yml (restart: unless-stopped).
+#
+# Variables :
+#   BACKUP_HOUR       heure (0-23, 2 chiffres) de la sauvegarde quotidienne (défaut 02)
+#   BACKUP_TICK       intervalle de vérification en secondes (défaut 1800 = 30 min)
+#   BACKUP_RETENTION  jours de rétention (transmis à backup.sh, défaut 7)
+#   BACKUP_OFFSITE_CMD commande de copie hors-site (voir backup.sh)
+set -u
+
+BACKUP_HOUR="${BACKUP_HOUR:-02}"
+TICK="${BACKUP_TICK:-1800}"
+
+echo "[backup-sched] démarre — sauvegarde quotidienne à ${BACKUP_HOUR}h (tick ${TICK}s, rétention ${BACKUP_RETENTION:-7}j)"
+
+# Sauvegarde immédiate au démarrage (ne jamais rester sans backup récent).
+sh /backup.sh || echo "[backup-sched] $(date '+%F %T') backup initial en échec (poursuite)"
+
+last_day=""
+while true; do
+  day="$(date +%Y%m%d)"
+  hour="$(date +%H)"
+  if [ "$hour" = "$BACKUP_HOUR" ] && [ "$last_day" != "$day" ]; then
+    if sh /backup.sh; then
+      last_day="$day"
+    else
+      echo "[backup-sched] $(date '+%F %T') backup quotidien en échec (nouvelle tentative au prochain tick)"
+    fi
+  fi
+  sleep "$TICK"
+done

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -77,4 +77,21 @@ find "${BACKUP_DIR}" -maxdepth 1 -name "ebios_*.sql.gz" \
 
 REMAINING="$(find "${BACKUP_DIR}" -maxdepth 1 -name "ebios_*.sql.gz" | wc -l | tr -d ' ')"
 echo "[backup] Backups conservés : ${REMAINING}"
+
+# --- Copie hors-site (optionnelle) ------------------------------------------
+# Si BACKUP_OFFSITE_CMD est défini, il est exécuté avec le chemin du dump en
+# argument → permet de pousser le backup vers un stockage distant (OVH S3/Swift,
+# rsync, scp…). Exemples :
+#   BACKUP_OFFSITE_CMD="rclone copy"          → rclone copy "<fichier>" (config rclone requise)
+#   BACKUP_OFFSITE_CMD="aws s3 cp - s3://acra-backups/"   (adapter)
+# L'échec de la copie hors-site N'INVALIDE PAS le backup local (log d'alerte).
+if [ -n "${BACKUP_OFFSITE_CMD:-}" ]; then
+  echo "[backup] Copie hors-site : ${BACKUP_OFFSITE_CMD} ${FILENAME}"
+  if sh -c "${BACKUP_OFFSITE_CMD} \"${FILENAME}\""; then
+    echo "[backup] Copie hors-site OK."
+  else
+    echo "[backup] ⚠ Copie hors-site ÉCHOUÉE — le backup local est conservé."
+  fi
+fi
+
 echo "[backup] Terminé — $(date '+%Y-%m-%d %H:%M:%S')"


### PR DESCRIPTION
## Contexte
Suite à la stabilisation pré-comité : renforcer la résilience des données. Le service `backup` existait mais était **one-shot manuel** — « un backup non planifié ≈ pas de backup ». Il devient un **planificateur persistant**.

## Changements
- **`scripts/backup-scheduler.sh`** (nouveau) : exécute `backup.sh` **au démarrage** puis **chaque jour à `BACKUP_HOUR`** (défaut 02h), avec garde anti-doublon par jour.
- **`scripts/backup.sh`** : hook de **copie hors-site optionnelle** via `BACKUP_OFFSITE_CMD` (reçoit le chemin du dump ; échec non bloquant → le backup local est conservé).
- **`docker-compose.yml`** (service `backup`) : `restart: unless-stopped`, monte le scheduler, ajoute env `BACKUP_HOUR` + `BACKUP_OFFSITE_CMD`. Sauvegarde ponctuelle toujours possible : `docker compose run --rm backup /backup.sh`.
- **`docs/runbook-exploitation.md`** §4/§5 : documente l'automatisation + la copie hors-site (ex. rclone → OVH S3/Swift).

## Test
`docker compose up -d backup` → dump immédiat créé (`ebios_2026-09-02_08-29-39.sql.gz`, 84K), rotation rétention OK, service reste `Up` (boucle quotidienne). `docker compose config` valide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)