### PR TITLE
feat(referentiels): Phase 1 — socle unifié + domaine de filière

### DIFF
--- a/docs/referentiels-univers-grc.md
+++ b/docs/referentiels-univers-grc.md
@@ -1,0 +1,268 @@
+# Univers des référentiels GRC — étude & cible d'unification
+
+> Étude préalable au chantier **« unification des référentiels »**. Objectif : un
+> seul objet « référentiel » par organisation, partagé par les **analyses de
+> risques**, les **contrôles**, la **conformité** et l'**audit** — et ouvert au-delà
+> du cyber (LCB-FT, gel des avoirs, déontologie, comptable, octroi de crédit…).
+>
+> Décisions actées (cf. session) :
+> - **Cadres livrés** = catalogue **canonique**, maintenu en code, **sélectionnable**
+>   par l'organisation (une seule version). L'org ne réécrit pas ISO/DORA.
+> - **PSSI & référentiels internes** = **un par organisation, éditables** (table
+>   `Referentiel` existante).
+> - Livraison **phasée en PRs**.
+
+---
+
+## 1. Constat : trois notions parallèles aujourd'hui
+
+| # | Emplacement | Forme | Exigences ? | Consommé par |
+|---|---|---|---|---|
+| 1 | `OrganizationConfig.referentielsActifs` (`ReferentielActif{nom,description,actif}`) | **étiquettes (noms)** | ❌ | **Analyses de risques** (Atelier 1, cadrage, PDF) |
+| 2 | `FRAMEWORK_META` + contrôles (`frameworks-data.ts`) — 15 cadres cyber | code + exigences | ✅ | **Conformité / contrôles / audit** (via `referentiel.server.ts`) |
+| 3 | Table `Referentiel` (CUSTOM, par org) | code + exigences | ✅ | idem |
+
+`referentiel.server.ts` unifie déjà **#2 + #3** derrière un résolveur unique
+(`listReferentiels`, `getExigencesFor`). **La rupture est #1** : la liste côté analyse
+est *nominale* et déconnectée — « DORA » y est une chaîne sans rapport avec le « DORA »
+porteur d'exigences côté contrôle. D'où DORA / ISO 27001 présents dans ~3 endroits avec
+3 orthographes (`'DORA'` vs `'DORA'` (FRAMEWORK_META) vs `'DORA'` (catalogue) ;
+`'ISO/IEC 27001:2022'` vs `'ISO/IEC 27001'` vs `'ISO27001'`).
+
+**Deux limites structurelles :**
+1. **Pas d'unification RA ↔ GRC** : les analyses ne pointent pas les mêmes objets que
+   les contrôles/conformité.
+2. **Verrou cyber** : le `type` d'exigence est figé aux 4 catégories ISO 27001
+   (`ORGANISATIONNELLE | HUMAINE | PHYSIQUE | TECHNOLOGIQUE`) ; le référentiel n'a pas
+   de **domaine** (compta, crédit, LCB-FT…) ; les catalogues de contrôle/audit ne
+   proposent que ISO/DORA.
+
+---
+
+## 2. Cible : un référentiel = { identité, domaine, exigences } — une source unique
+
+Un **référentiel** devient l'unité partagée par tous les métiers :
+
+```
+Référentiel
+  code        slug unique par org (ISO27001, DORA, LCB-FT, PSSI-2026, OCTROI-CREDIT…)
+  nom         libellé
+  domaine     ← NOUVEAU : famille de risque/contrôle (§4)
+  nature      NORME | REGLEMENTATION | POLITIQUE_INTERNE | PROCEDURE | STANDARD
+  source      BUILTIN (canonique, code) | CUSTOM (par org, éditable)
+  version     une seule par org
+  exigences   points de contrôle { ref, nom, description, categorie, type? }
+  missions    objectifs (politiques/stratégies)
+```
+
+- **Sélection unique par org** : `OrganizationConfig.referentielsActifs` cesse d'être
+  une liste de noms → devient une **liste de codes** choisis dans le catalogue unifié
+  (builtin + custom). Cette sélection pilote **à la fois** :
+  les cadres proposés en atelier (RA), les référentiels évalués en conformité, les
+  catalogues de contrôle/audit offerts. → *une liste, une version chacun.*
+- **`referentiel.server.ts` reste le point de résolution unique** ; on y ajoute le
+  `domaine` et on branche la sélection d'org.
+- **Exigence `type`** : garder les 4 catégories ISO comme défaut **du domaine cyber**,
+  mais rendre le champ **optionnel/libre** pour les autres domaines (une exigence
+  comptable ou LCB-FT n'est pas « physique/technologique »).
+
+---
+
+## 3. Le référentiel réglementaire n'est pas toujours une check-list
+
+Point de conception important : beaucoup de textes (CMF LCB-FT, arrêté du 3 nov. 2014,
+règlement gel des avoirs) **ne sont pas** des listes d'exigences prêtes à cocher comme
+ISO 27001. Le modèle doit accepter deux régimes :
+
+- **Référentiel « à exigences »** (ISO, DORA, PCI-DSS, SOC 2) → exigences numérotées
+  livrées → conformité/contrôle par exigence, immédiat.
+- **Référentiel « cadre »** (une réglementation) → on livre l'**ossature** (articles /
+  thèmes / obligations clés) comme exigences de haut niveau, et l'organisation
+  **rattache ses propres points de contrôle** (custom) sous ce cadre. C'est déjà ce que
+  permet la table `Referentiel` — on l'étend aux domaines non-cyber.
+
+→ Conséquence : on **seed les en-têtes canoniques** (code, nom, domaine, nature, base
+réglementaire) + un **jeu d'exigences de départ** quand c'est pertinent, et l'org
+enrichit. Pas besoin de retranscrire un code entier pour être utile.
+
+---
+
+## 4. Taxonomie de DOMAINE proposée (univers de contrôle & audit)
+
+Alignée sur les **filières de risques** du contrôle interne bancaire
+(arrêté du 3 novembre 2014 **modifié**, notamment par l'arrêté du 25 février 2021) et
+élargie assurance/entreprise. Enum stable, extensible.
+
+> ℹ️ Référence : « arrêté du 3 nov. 2014 » ci-dessous désigne le texte **dans sa version
+> consolidée** (amendé en 2021). Les libellés de référentiels seedés porteront la
+> version consolidée.
+
+| Code domaine | Intitulé | Couvre |
+|---|---|---|
+| `SECURITE_SI` | Sécurité SI & résilience numérique | Cyber, SSI, DORA, continuité TIC *(cadres actuels)* |
+| `PROTECTION_DONNEES` | Protection des données | RGPD, secret bancaire, données de santé |
+| `LCB_FT` | Lutte anti-blanchiment & financement du terrorisme | KYC, vigilance, déclarations de soupçon |
+| `SANCTIONS_GEL` | Sanctions & gel des avoirs | Mesures restrictives UE/OFAC, gel, embargos |
+| `PROTECTION_CLIENTELE` | Protection de la clientèle & commercialisation | MIF 2, DSP2, IDD (assurance), information client |
+| `DEONTOLOGIE` | Déontologie, conflits d'intérêts, anticorruption | Sapin II, abus de marché, cadeaux, transactions perso |
+| `COMPTABLE_FINANCIER` | Fiabilité comptable & financière | Piste d'audit, arrêté 3 nov. 2014, IFRS, reporting |
+| `CREDIT_CONTREPARTIE` | Octroi & suivi des crédits | Procédures d'octroi, notation, EBA LOM, provisionnement |
+| `RISQUE_OPERATIONNEL` | Risque opérationnel & externalisation | PCA, pertes op., prestataires critiques, Bâle |
+| `GOUVERNANCE_CONTROLE` | Gouvernance & dispositif de contrôle interne | Arrêté 3 nov. 2014, CRD/CRR, Solvabilité II |
+| `AUTRE` | Autre / interne non classé | Référentiels internes hors catégories |
+
+> Les domaines `LCB_FT`, `SANCTIONS_GEL`, `DEONTOLOGIE`, `PROTECTION_CLIENTELE` sont
+> volontairement distincts (et non un seul « conformité ») car ce sont des **filières
+> de contrôle permanent séparées**, avec responsables, plans de contrôle et reporting
+> distincts en banque/assurance.
+
+---
+
+## 5. Catalogue des référentiels/réglementations à intégrer
+
+Priorité : **P1** = à seeder en canonique (en-tête + exigences de départ) ;
+**P2** = en-tête canonique seul (org enrichit) ; **P3** = laissé en custom/plus tard.
+« Livré ? » = déjà présent dans `frameworks-data.ts`.
+
+### 5.1 `SECURITE_SI` — déjà couvert (rebrancher, pas recréer)
+| Réf. | Base | Livré ? | Prio |
+|---|---|---|---|
+| ISO/IEC 27001:2022 | Norme SMSI | ✅ | — |
+| ISO/IEC 27002:2022 | Mesures | ✅ (via 27001) | — |
+| DORA | Règl. UE 2022/2554 | ✅ | — |
+| NIS2 / ReCyF | Dir. UE 2022/2555 ; ANSSI | ✅ | — |
+| PCI-DSS v4, HDS, RGS, ANSSI hygiène, CIS v8, NIST CSF/800-53/SSDF, IEC 62443, TISAX, SOC 2 | divers | ✅ | — |
+
+→ **Aucun contenu à créer** : juste rattacher `domaine = SECURITE_SI` et faire pointer
+la sélection d'org dessus.
+
+### 5.2 `PROTECTION_DONNEES`
+| Réf. | Base réglementaire | Livré ? | Prio |
+|---|---|---|---|
+| RGPD | Règl. UE 2016/679 | ⚠️ (RoPA existe, pas en référentiel d'exigences) | **P1** |
+| Recommandations CNIL (sécurité) | CNIL | ❌ | P2 |
+
+### 5.3 `LCB_FT`
+| Réf. | Base | Prio |
+|---|---|---|
+| Dispositif LCB-FT (CMF art. L.561-1 s.) | Code monétaire et financier | **P1** |
+| Lignes directrices ACPR LCB-FT | ACPR | P2 |
+| Orientations EBA LCB-FT (ML/TF risk factors) | EBA/2021/02 | P2 |
+| Recommandations GAFI (40 recommandations) | GAFI/FATF | P2 |
+
+*Exigences de départ P1* : approche par les risques, KYC/entrée en relation, vigilance
+constante, personnes politiquement exposées, déclaration de soupçon (Tracfin),
+conservation des documents, formation, gel interne.
+
+### 5.4 `SANCTIONS_GEL`
+| Réf. | Base | Prio |
+|---|---|---|
+| Gel des avoirs / mesures restrictives | Règl. UE + Direction générale du Trésor | **P1** |
+| Sanctions OFAC | US Treasury | P2 |
+
+*Exigences de départ* : filtrage des listes (UE/ONU/OFAC), filtrage des transactions,
+détection des correspondances, procédure de gel sans délai, déclaration DG Trésor.
+
+### 5.5 `PROTECTION_CLIENTELE`
+| Réf. | Base | Prio |
+|---|---|---|
+| DSP2 (services de paiement) | Dir. UE 2015/2366 | **P1** |
+| MIF 2 / MiFID II | Dir. UE 2014/65 | P2 |
+| IDD (distribution assurance) | Dir. UE 2016/97 | P2 |
+| Abus de marché (MAR) | Règl. UE 596/2014 | P3 |
+
+### 5.6 `DEONTOLOGIE`
+| Réf. | Base | Prio |
+|---|---|---|
+| Anticorruption (Sapin II) | Loi 2016-1691 | **P1** |
+| Déontologie / conflits d'intérêts (interne) | Politique interne | P2 (custom) |
+
+*Exigences Sapin II* : code de conduite, dispositif d'alerte, cartographie des risques
+de corruption, évaluation des tiers, contrôles comptables, formation, régime
+disciplinaire, dispositif de contrôle/évaluation.
+
+### 5.7 `COMPTABLE_FINANCIER`
+| Réf. | Base | Prio |
+|---|---|---|
+| Contrôle interne comptable | Arrêté 3 nov. 2014 (titre comptabilité) | **P1** |
+| Piste d'audit fiable | — | P2 |
+
+### 5.8 `CREDIT_CONTREPARTIE`
+| Réf. | Base | Prio |
+|---|---|---|
+| Octroi & suivi des crédits | Procédures internes + EBA LOM (EBA/GL/2020/06) | **P1** |
+| Dispositif de notation / provisionnement | Bâle / IFRS 9 | P3 |
+
+*Exigences octroi* : analyse de solvabilité, respect des délégations, complétude du
+dossier, garanties, revue périodique, détection des impayés, comité des engagements.
+
+### 5.9 `RISQUE_OPERATIONNEL`
+| Réf. | Base | Prio |
+|---|---|---|
+| Externalisation / prestataires | EBA/GL/2019/02 + DORA art. 28 | **P1** (croise le registre TIC existant) |
+| PCA / continuité d'activité | Arrêté 3 nov. 2014 | P2 |
+| Risque opérationnel (Bâle) | CRR / Bâle | P3 |
+
+### 5.10 `GOUVERNANCE_CONTROLE`
+| Réf. | Base | Prio |
+|---|---|---|
+| Dispositif de contrôle interne | Arrêté 3 nov. 2014 | **P1** |
+| Solvabilité II (assurance) | Dir. UE 2009/138 | P3 |
+
+---
+
+## 6. Impact modèle de données
+
+### 6.1 Migration `Referentiel` (custom, par org)
+- **+ `domaine String @default("SECURITE_SI")`** (borné applicativement à l'enum §4).
+- `type` (`PSSI|POLITIQUE|REGLEMENTAIRE|STANDARD|CUSTOM`) devient la **`nature`** ;
+  conserver la colonne, élargir le libellé si besoin. Rétrocompatible.
+- Exigence `type` : rendre optionnel côté validation pour domaines ≠ `SECURITE_SI`.
+
+### 6.2 Cadres livrés (`frameworks-data.ts`)
+- **+ `domaine`** dans `FRAMEWORK_META` (tous les cadres actuels = `SECURITE_SI`).
+- Ajouter les **en-têtes canoniques non-cyber P1** (RGPD, LCB-FT, SANCTIONS_GEL, DSP2,
+  Sapin II, comptable, octroi crédit, externalisation, contrôle interne) avec un jeu
+  d'exigences de départ. Restent en code = « une version canonique ».
+
+### 6.3 Config org
+- `referentielsActifs` : `ReferentielActif[]` (noms) → **`string[]` de codes** résolus
+  par `referentiel.server.ts`. Migration des noms existants → codes (table de
+  correspondance ; noms inconnus → référentiel custom conservé).
+
+### 6.4 Consommateurs à rebrancher (phase 2/3)
+Analyses (Atelier 1, cadrage, `socle-etat`, PDF), conformité, `controles-catalogue`,
+`audit-programmes-catalogue` (aujourd'hui ISO/DORA seuls → ouvrir par domaine),
+`ReferentielsManager` (filtre + colonne domaine), i18n ×5.
+
+---
+
+## 7. Découpage en PRs
+
+- **Phase 1 — socle unifié (non cassant)**
+  - Migration : `Referentiel.domaine` (+ nature).
+  - `DOMAINES` enum (lib pure + tests) ; `domaine` sur `FRAMEWORK_META`.
+  - `referentiel.server.ts` : exposer `domaine`, filtrer par domaine.
+  - Exigence `type` optionnel hors cyber (validation).
+  - **Aucun consommateur cassé** : la sélection d'org et les catalogues restent tels
+    quels ; on ajoute la dimension.
+- **Phase 2 — unification RA ↔ GRC**
+  - `referentielsActifs` = codes ; migration des noms ; Atelier 1 / cadrage / PDF lisent
+    la sélection unifiée. Conformité évalue la même sélection.
+- **Phase 3 — ouverture non-cyber**
+  - Seed des en-têtes + exigences P1 (RGPD, LCB-FT, SANCTIONS_GEL, DSP2, Sapin II,
+    comptable, octroi crédit, externalisation, contrôle interne).
+  - `controles-catalogue` / `audit-programmes-catalogue` ouverts par domaine + catalogues
+    de départ non-cyber.
+  - UI : filtre par domaine dans `ReferentielsManager`, contrôles, audit ; i18n ×5.
+
+---
+
+## 8. Points ouverts / à valider
+
+1. **Enum domaine** (§4) : le jeu de 11 convient-il, ou faut-il fusionner/scinder
+   (ex. regrouper `PROTECTION_CLIENTELE` + `DEONTOLOGIE`) ?
+2. **Profondeur du seed P1** : en-têtes seuls d'abord (org enrichit) vs en-têtes +
+   exigences de départ dès la phase 3 ?
+3. **Assurance vs banque** : cibler d'abord la banque (arrêté 3 nov. 2014) puis
+   Solvabilité II, ou les deux d'emblée ?

--- a/prisma/migrations/20260902110000_referentiel_domaine/migration.sql
+++ b/prisma/migrations/20260902110000_referentiel_domaine/migration.sql
@@ -1,0 +1,5 @@
+-- Domaine de filière (contrôle/audit) sur les référentiels custom.
+-- Défaut SECURITE_SI : l'existant est cyber → rétrocompatible, aucune donnée à muter.
+-- Ouvre les référentiels non-cyber (LCB-FT, gel des avoirs, comptable, octroi crédit…).
+ALTER TABLE "Referentiel" ADD COLUMN "domaine" TEXT NOT NULL DEFAULT 'SECURITE_SI';
+CREATE INDEX "Referentiel_organizationId_domaine_idx" ON "Referentiel"("organizationId", "domaine");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -570,8 +570,12 @@ model Referentiel {
 
   code        String // slug MAJUSCULES, unique par organisation (ex. PSSI-2026)
   nom         String
-  // PSSI | POLITIQUE | REGLEMENTAIRE | STANDARD | CUSTOM
+  // Nature du référentiel : PSSI | POLITIQUE | REGLEMENTAIRE | STANDARD | CUSTOM
   type        String  @default("CUSTOM")
+  // Filière de contrôle/audit (cf. lib/referentiel-domaines.ts). Défaut SECURITE_SI
+  // pour rétrocompatibilité (l'existant est cyber). Ouvre le non-cyber (LCB-FT,
+  // gel des avoirs, comptable, octroi de crédit…).
+  domaine     String  @default("SECURITE_SI")
   version     String?
   description String? @db.Text
   // Exigences : FrameworkControl[] { ref, nom, description, type, categorie }.
@@ -586,6 +590,7 @@ model Referentiel {
 
   @@unique([organizationId, code])
   @@index([organizationId])
+  @@index([organizationId, domaine])
 }
 
 // ─── Bibliothèque documentaire GRC (PSSI, stratégies, politiques…) ───────────

--- a/src/__tests__/unit/lib/referentiel-domaines.test.ts
+++ b/src/__tests__/unit/lib/referentiel-domaines.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DOMAINES,
+  DOMAINE_META,
+  DEFAULT_DOMAINE,
+  isDomaine,
+  coerceDomaine,
+  domaineLabel,
+} from '../../../lib/referentiel-domaines'
+
+describe('DOMAINES (univers de contrôle & audit)', () => {
+  it('contient les 11 domaines de la taxonomie GRC', () => {
+    expect(DOMAINES).toEqual([
+      'SECURITE_SI',
+      'PROTECTION_DONNEES',
+      'LCB_FT',
+      'SANCTIONS_GEL',
+      'PROTECTION_CLIENTELE',
+      'DEONTOLOGIE',
+      'COMPTABLE_FINANCIER',
+      'CREDIT_CONTREPARTIE',
+      'RISQUE_OPERATIONNEL',
+      'GOUVERNANCE_CONTROLE',
+      'AUTRE',
+    ])
+  })
+
+  it('a une métadonnée (label + description) pour chaque domaine', () => {
+    for (const d of DOMAINES) {
+      expect(DOMAINE_META[d]).toBeDefined()
+      expect(DOMAINE_META[d].label.length).toBeGreaterThan(0)
+      expect(DOMAINE_META[d].description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('utilise SECURITE_SI comme domaine par défaut (rétrocompatibilité cyber)', () => {
+    expect(DEFAULT_DOMAINE).toBe('SECURITE_SI')
+  })
+})
+
+describe('isDomaine', () => {
+  it('reconnaît un code de domaine valide', () => {
+    expect(isDomaine('LCB_FT')).toBe(true)
+    expect(isDomaine('SECURITE_SI')).toBe(true)
+  })
+  it('rejette une valeur inconnue', () => {
+    expect(isDomaine('CYBER')).toBe(false)
+    expect(isDomaine('')).toBe(false)
+    expect(isDomaine(null)).toBe(false)
+    expect(isDomaine(42)).toBe(false)
+  })
+})
+
+describe('coerceDomaine', () => {
+  it('retourne le domaine s’il est valide', () => {
+    expect(coerceDomaine('SANCTIONS_GEL')).toBe('SANCTIONS_GEL')
+  })
+  it('retombe sur le défaut pour une valeur invalide (rétrocompatible)', () => {
+    expect(coerceDomaine(undefined)).toBe('SECURITE_SI')
+    expect(coerceDomaine('n’importe quoi')).toBe('SECURITE_SI')
+  })
+})
+
+describe('domaineLabel', () => {
+  it('retourne le libellé lisible d’un domaine', () => {
+    expect(domaineLabel('LCB_FT')).toBe(DOMAINE_META.LCB_FT.label)
+  })
+  it('retombe sur le label du défaut pour un code inconnu', () => {
+    expect(domaineLabel('ZZZ')).toBe(DOMAINE_META.SECURITE_SI.label)
+  })
+})

--- a/src/__tests__/unit/lib/referentiel.test.ts
+++ b/src/__tests__/unit/lib/referentiel.test.ts
@@ -74,6 +74,12 @@ describe('cleanReferentielInput', () => {
     expect(cleanReferentielInput({ code: 'x', nom: 'x', type: 'ZZZ' }).type).toBe('CUSTOM')
   })
 
+  it('borne le domaine ; domaine absent/invalide → SECURITE_SI (rétrocompatible)', () => {
+    expect(cleanReferentielInput({ code: 'x', nom: 'x', domaine: 'LCB_FT' }).domaine).toBe('LCB_FT')
+    expect(cleanReferentielInput({ code: 'x', nom: 'x' }).domaine).toBe('SECURITE_SI')
+    expect(cleanReferentielInput({ code: 'x', nom: 'x', domaine: 'CYBER' }).domaine).toBe('SECURITE_SI')
+  })
+
   it('expose la liste des types', () => {
     expect(REFERENTIEL_TYPES).toContain('PSSI')
     expect(REFERENTIEL_TYPES).toContain('CUSTOM')

--- a/src/app/api/referentiels/[id]/route.ts
+++ b/src/app/api/referentiels/[id]/route.ts
@@ -62,7 +62,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   const updated = await prisma.referentiel.update({
     where: { id },
     data: {
-      code: data.code, nom: data.nom, type: data.type, version: data.version, description: data.description,
+      code: data.code, nom: data.nom, type: data.type, domaine: data.domaine, version: data.version, description: data.description,
       exigences: data.exigences as unknown as Prisma.InputJsonValue,
       missions: data.missions as unknown as Prisma.InputJsonValue,
     },

--- a/src/app/api/referentiels/route.ts
+++ b/src/app/api/referentiels/route.ts
@@ -60,7 +60,7 @@ export async function POST(req: NextRequest) {
   const created = await prisma.referentiel.create({
     data: {
       organizationId: orgId, createdBy: userId,
-      code: data.code, nom: data.nom, type: data.type, version: data.version, description: data.description,
+      code: data.code, nom: data.nom, type: data.type, domaine: data.domaine, version: data.version, description: data.description,
       exigences: data.exigences as unknown as Prisma.InputJsonValue,
       missions: data.missions as unknown as Prisma.InputJsonValue,
     },

--- a/src/components/ReferentielsManager.tsx
+++ b/src/components/ReferentielsManager.tsx
@@ -5,17 +5,18 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { parseExigences, parseMissions, REFERENTIEL_TYPES } from '@/lib/referentiel'
+import { DOMAINES, DOMAINE_META } from '@/lib/referentiel-domaines'
 
 interface CouvExigence { ref: string; nom: string; statut: string; nbControles: number; nbAnomaliesAudit: number }
 interface CouvSynthese { total: number; couverts: number; conformes: number; anomalies: number; nonCouverts: number; tauxCouverture: number; tauxConformite: number }
 
 interface Ref {
   id?: string; code: string; nom: string; source: 'BUILTIN' | 'CUSTOM'
-  type: string; version: string | null; nbExigences: number; actif: boolean
+  type: string; domaine: string; version: string | null; nbExigences: number; actif: boolean
 }
-interface RefDetail { id: string; code: string; nom: string; type: string; version: string | null; description: string | null; exigences: { ref: string; nom: string; categorie?: string; type?: string }[]; missions?: { intitule: string; description?: string }[] }
+interface RefDetail { id: string; code: string; nom: string; type: string; domaine?: string; version: string | null; description: string | null; exigences: { ref: string; nom: string; categorie?: string; type?: string }[]; missions?: { intitule: string; description?: string }[] }
 
-const emptyForm = { code: '', nom: '', type: 'PSSI', version: '', description: '', exigencesText: '', missionsText: '' }
+const emptyForm = { code: '', nom: '', type: 'PSSI', domaine: 'SECURITE_SI', version: '', description: '', exigencesText: '', missionsText: '' }
 
 export default function ReferentielsManager({ canManage }: { canManage: boolean }) {
   const { t } = useTranslation()
@@ -54,7 +55,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
     if (!ref) return
     setEditing(id)
     setForm({
-      code: ref.code, nom: ref.nom, type: ref.type, version: ref.version ?? '', description: ref.description ?? '',
+      code: ref.code, nom: ref.nom, type: ref.type, domaine: ref.domaine ?? 'SECURITE_SI', version: ref.version ?? '', description: ref.description ?? '',
       exigencesText: (ref.exigences ?? []).map(e => [e.ref, e.nom, e.categorie ?? '', e.type ?? ''].filter(Boolean).join(' | ')).join('\n'),
       missionsText: (ref.missions ?? []).map(m => [m.intitule, m.description ?? ''].filter(Boolean).join(' | ')).join('\n'),
     })
@@ -66,7 +67,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
     const url = editing ? `/api/referentiels/${editing}` : '/api/referentiels'
     const res = await fetch(url, {
       method: editing ? 'PATCH' : 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code: form.code, nom: form.nom, type: form.type, version: form.version, description: form.description, exigences: exigencesParsed, missions: parseMissions(form.missionsText) }),
+      body: JSON.stringify({ code: form.code, nom: form.nom, type: form.type, domaine: form.domaine, version: form.version, description: form.description, exigences: exigencesParsed, missions: parseMissions(form.missionsText) }),
     })
     if (!res.ok) {
       const d = await res.json().catch(() => ({}))
@@ -146,6 +147,10 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
               <select className={`mt-1 ${inputCls}`} value={form.type} onChange={e => setForm({ ...form, type: e.target.value })}>
                 {REFERENTIEL_TYPES.map(ty => <option key={ty} value={ty}>{r.typeOpt[ty]}</option>)}
               </select></label>
+            <label className="block"><span className="text-sm text-gray-700 dark:text-gray-300">{r.champ.domaine}</span>
+              <select className={`mt-1 ${inputCls}`} value={form.domaine} onChange={e => setForm({ ...form, domaine: e.target.value })}>
+                {DOMAINES.map(d => <option key={d} value={d}>{DOMAINE_META[d].label}</option>)}
+              </select></label>
             <label className="block"><span className="text-sm text-gray-700 dark:text-gray-300">{r.champ.version}</span>
               <input className={`mt-1 ${inputCls}`} value={form.version} onChange={e => setForm({ ...form, version: e.target.value })} placeholder="v1.0" /></label>
             <label className="block sm:col-span-2"><span className="text-sm text-gray-700 dark:text-gray-300">{r.champ.description}</span>
@@ -197,7 +202,16 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
                       <div className="font-medium text-gray-800 dark:text-gray-100">{x.nom}</div>
                       <div className="text-[11px] text-gray-400 font-mono">{x.code}</div>
                     </td>
-                    <td className="px-3 py-2">{typeBadge(x.type, x.source)}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex flex-wrap items-center gap-1">
+                        {typeBadge(x.type, x.source)}
+                        {x.domaine && x.domaine !== 'SECURITE_SI' && (
+                          <span className="text-[11px] px-2 py-0.5 rounded-full font-medium bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
+                            {DOMAINE_META[x.domaine as keyof typeof DOMAINE_META]?.label ?? x.domaine}
+                          </span>
+                        )}
+                      </div>
+                    </td>
                     <td className="px-3 py-2 text-gray-500 dark:text-gray-400">{x.version ?? '—'}</td>
                     <td className="px-3 py-2 text-right tabular-nums text-gray-700 dark:text-gray-200">{x.nbExigences}</td>
                     <td className="px-3 py-2 text-right whitespace-nowrap">

--- a/src/lib/frameworks-data.ts
+++ b/src/lib/frameworks-data.ts
@@ -18,6 +18,7 @@
  *  • CUSTOM                        (contrôles définis par l'analyste)
  */
 import type { Locale } from '@/lib/i18n'
+import type { Domaine } from '@/lib/referentiel-domaines'
 import { getEbiosData } from '@/lib/ebios-data-i18n'
 import {
   DORA_CONTROLES, DORA_CATEGORIES,
@@ -68,7 +69,10 @@ export interface Framework {
 export const FRAMEWORK_IDS = ['ISO27001', 'NIST_CSF', 'NIST_800_53', 'CIS_V8', 'ANSSI_HYG', 'HDS', 'PCI_DSS', 'DORA', 'IEC_62443', 'SOC2', 'NIST_SSDF', 'RGS', 'RECYF', 'TISAX', 'CUSTOM'] as const
 export type FrameworkId = typeof FRAMEWORK_IDS[number]
 
-export const FRAMEWORK_META: Record<FrameworkId, { nom: string; version: string; icon: string; cible: string }> = {
+// `domaine` (optionnel) classe le cadre dans une filière de contrôle/audit
+// (cf. referentiel-domaines.ts). Absent ⇒ SECURITE_SI (tous les cadres cyber livrés).
+// Les cadres non-cyber (phase 3 : LCB-FT, gel des avoirs, comptable…) le renseignent.
+export const FRAMEWORK_META: Record<FrameworkId, { nom: string; version: string; icon: string; cible: string; domaine?: Domaine }> = {
   ISO27001:   { nom: 'ISO/IEC 27001',        version: '2022',     icon: '🌐', cible: 'Tout secteur — certification SMSI' },
   NIST_CSF:   { nom: 'NIST CSF',             version: '2.0',      icon: '🇺🇸', cible: 'Organisations US et internationales' },
   NIST_800_53:{ nom: 'NIST SP 800-53',       version: 'Rév. 5',   icon: '🔐', cible: 'Systèmes fédéraux US, secteur défense' },

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1630,7 +1630,7 @@ export const de: Translations = {
     builtin: 'Gelieferte Rahmenwerke (nur Lesen)',
     empty: 'Noch kein eigener Referenzrahmen. Erstellen Sie Ihre Sicherheitsleitlinie oder interne Richtlinien und deren Anforderungen.',
     readOnly: 'Nur Lesezugriff — die Pflege der Referenzrahmen obliegt der Governance (CISO / Compliance).',
-    champ: { code: 'Code', nom: 'Name', type: 'Typ', version: 'Version', description: 'Beschreibung', exigences: 'Anforderungen (Kontrollpunkte)', missions: 'Missionen (Sicherheitsziele)' },
+    champ: { code: 'Code', nom: 'Name', type: 'Typ', domaine: 'Bereich', version: 'Version', description: 'Beschreibung', exigences: 'Anforderungen (Kontrollpunkte)', missions: 'Missionen (Sicherheitsziele)' },
     typeOpt: { PSSI: 'Sicherheitsleitlinie', POLITIQUE: 'Richtlinie', REGLEMENTAIRE: 'Regulatorisch', STANDARD: 'Standard', CUSTOM: 'Eigen' },
     exigencesHint: 'Eine Anforderung pro Zeile: Ref | Titel | Kategorie | Typ. Leerzeilen und # ignoriert.',
     exigencesCount: '{n} Anforderung(en) erkannt',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1630,7 +1630,7 @@ export const en: Translations = {
     builtin: 'Built-in frameworks (read only)',
     empty: 'No custom framework yet. Create your ISSP or internal policies and their requirements.',
     readOnly: 'Read only — framework management belongs to governance (CISO / compliance).',
-    champ: { code: 'Code', nom: 'Name', type: 'Type', version: 'Version', description: 'Description', exigences: 'Requirements (control points)', missions: 'Missions (security objectives)' },
+    champ: { code: 'Code', nom: 'Name', type: 'Type', domaine: 'Domain', version: 'Version', description: 'Description', exigences: 'Requirements (control points)', missions: 'Missions (security objectives)' },
     typeOpt: { PSSI: 'ISSP', POLITIQUE: 'Policy', REGLEMENTAIRE: 'Regulatory', STANDARD: 'Standard', CUSTOM: 'Custom' },
     exigencesHint: 'One requirement per line: ref | title | category | type. Blank lines and # ignored.',
     exigencesCount: '{n} requirement(s) detected',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1630,7 +1630,7 @@ export const es: Translations = {
     builtin: 'Marcos incluidos (solo lectura)',
     empty: 'Ningún marco propio. Cree su PSSI o sus políticas internas y sus requisitos.',
     readOnly: 'Solo lectura — la gestión de los marcos corresponde a la gobernanza (RSSI / cumplimiento).',
-    champ: { code: 'Código', nom: 'Nombre', type: 'Tipo', version: 'Versión', description: 'Descripción', exigences: 'Requisitos (puntos de control)', missions: 'Misiones (objetivos de seguridad)' },
+    champ: { code: 'Código', nom: 'Nombre', type: 'Tipo', domaine: 'Dominio', version: 'Versión', description: 'Descripción', exigences: 'Requisitos (puntos de control)', missions: 'Misiones (objetivos de seguridad)' },
     typeOpt: { PSSI: 'PSSI', POLITIQUE: 'Política', REGLEMENTAIRE: 'Regulatorio', STANDARD: 'Estándar', CUSTOM: 'Propio' },
     exigencesHint: 'Un requisito por línea: ref | título | categoría | tipo. Líneas vacías y # ignoradas.',
     exigencesCount: '{n} requisito(s) detectado(s)',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1653,7 +1653,7 @@ export const fr = {
     builtin: 'Cadres livrés (lecture seule)',
     empty: 'Aucun référentiel propre. Créez votre PSSI ou vos politiques internes et leurs exigences.',
     readOnly: 'Lecture seule — la tenue des référentiels relève de la gouvernance (RSSI / conformité).',
-    champ: { code: 'Code', nom: 'Nom', type: 'Type', version: 'Version', description: 'Description', exigences: 'Exigences (points de contrôle)', missions: 'Missions (objectifs de sécurité)' },
+    champ: { code: 'Code', nom: 'Nom', type: 'Type', domaine: 'Domaine', version: 'Version', description: 'Description', exigences: 'Exigences (points de contrôle)', missions: 'Missions (objectifs de sécurité)' },
     typeOpt: { PSSI: 'PSSI', POLITIQUE: 'Politique', REGLEMENTAIRE: 'Réglementaire', STANDARD: 'Standard', CUSTOM: 'Custom' },
     exigencesHint: 'Une exigence par ligne : réf | intitulé | catégorie | type. Lignes vides et # ignorées.',
     exigencesCount: '{n} exigence(s) détectée(s)',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1630,7 +1630,7 @@ export const it: Translations = {
     builtin: 'Quadri forniti (sola lettura)',
     empty: 'Nessun riferimento proprio. Crea la tua PSSI o le tue politiche interne e i loro requisiti.',
     readOnly: 'Sola lettura — la gestione dei riferimenti spetta alla governance (RSSI / conformità).',
-    champ: { code: 'Codice', nom: 'Nome', type: 'Tipo', version: 'Versione', description: 'Descrizione', exigences: 'Requisiti (punti di controllo)', missions: 'Missioni (obiettivi di sicurezza)' },
+    champ: { code: 'Codice', nom: 'Nome', type: 'Tipo', domaine: 'Dominio', version: 'Versione', description: 'Descrizione', exigences: 'Requisiti (punti di controllo)', missions: 'Missioni (obiettivi di sicurezza)' },
     typeOpt: { PSSI: 'PSSI', POLITIQUE: 'Politica', REGLEMENTAIRE: 'Regolamentare', STANDARD: 'Standard', CUSTOM: 'Personalizzato' },
     exigencesHint: 'Un requisito per riga: rif | titolo | categoria | tipo. Righe vuote e # ignorate.',
     exigencesCount: '{n} requisito/i rilevato/i',

--- a/src/lib/referentiel-domaines.ts
+++ b/src/lib/referentiel-domaines.ts
@@ -1,0 +1,95 @@
+// ─── Domaines de référentiel (univers de contrôle & audit GRC) ───────────────
+// Un « domaine » classe un référentiel dans une FILIÈRE de risque/contrôle, pour
+// permettre les contrôles et audits AU-DELÀ du cyber (LCB-FT, gel des avoirs,
+// déontologie, comptable, octroi de crédit…). Aligné sur les filières du contrôle
+// interne bancaire (arrêté du 3 nov. 2014 modifié) + assurance/entreprise.
+// Enum stable et EXTENSIBLE ; logique PURE et testée. Cf. docs/referentiels-univers-grc.md.
+
+export const DOMAINES = [
+  'SECURITE_SI',
+  'PROTECTION_DONNEES',
+  'LCB_FT',
+  'SANCTIONS_GEL',
+  'PROTECTION_CLIENTELE',
+  'DEONTOLOGIE',
+  'COMPTABLE_FINANCIER',
+  'CREDIT_CONTREPARTIE',
+  'RISQUE_OPERATIONNEL',
+  'GOUVERNANCE_CONTROLE',
+  'AUTRE',
+] as const
+
+export type Domaine = (typeof DOMAINES)[number]
+
+// Défaut : SECURITE_SI — tous les référentiels existants (cyber) y sont rattachés,
+// donc l'ajout du domaine est rétrocompatible (rien à migrer côté sens métier).
+export const DEFAULT_DOMAINE: Domaine = 'SECURITE_SI'
+
+export interface DomaineMeta {
+  /** Libellé lisible (FR). L'UI localisée passera par les clés i18n en phase 3. */
+  label: string
+  /** Ce que le domaine couvre (aide à la classification). */
+  description: string
+}
+
+export const DOMAINE_META: Record<Domaine, DomaineMeta> = {
+  SECURITE_SI: {
+    label: 'Sécurité SI & résilience numérique',
+    description: 'Cyber, SSI, DORA, continuité TIC — cadres de sécurité de l’information.',
+  },
+  PROTECTION_DONNEES: {
+    label: 'Protection des données',
+    description: 'RGPD, secret bancaire, données de santé — traitement des données personnelles.',
+  },
+  LCB_FT: {
+    label: 'Lutte anti-blanchiment & financement du terrorisme',
+    description: 'KYC, vigilance, PPE, déclarations de soupçon (Tracfin), conservation, formation.',
+  },
+  SANCTIONS_GEL: {
+    label: 'Sanctions & gel des avoirs',
+    description: 'Mesures restrictives UE/ONU/OFAC, filtrage des listes, gel sans délai, embargos.',
+  },
+  PROTECTION_CLIENTELE: {
+    label: 'Protection de la clientèle & commercialisation',
+    description: 'DSP2, MIF 2, IDD (assurance), information et conseil au client.',
+  },
+  DEONTOLOGIE: {
+    label: 'Déontologie, conflits d’intérêts & anticorruption',
+    description: 'Sapin II, abus de marché, cadeaux/avantages, transactions personnelles.',
+  },
+  COMPTABLE_FINANCIER: {
+    label: 'Fiabilité comptable & financière',
+    description: 'Piste d’audit, contrôle interne comptable (arrêté 3 nov. 2014), IFRS, reporting.',
+  },
+  CREDIT_CONTREPARTIE: {
+    label: 'Octroi & suivi des crédits',
+    description: 'Procédures d’octroi, délégations, notation, EBA LOM, provisionnement.',
+  },
+  RISQUE_OPERATIONNEL: {
+    label: 'Risque opérationnel & externalisation',
+    description: 'PCA/continuité, pertes opérationnelles, prestataires critiques (DORA art. 28, EBA).',
+  },
+  GOUVERNANCE_CONTROLE: {
+    label: 'Gouvernance & dispositif de contrôle interne',
+    description: 'Arrêté 3 nov. 2014, CRD/CRR, Solvabilité II — pilotage du contrôle interne.',
+  },
+  AUTRE: {
+    label: 'Autre / interne non classé',
+    description: 'Référentiels internes ne relevant pas des filières ci-dessus.',
+  },
+}
+
+/** Vrai si `v` est un code de domaine connu. */
+export function isDomaine(v: unknown): v is Domaine {
+  return typeof v === 'string' && (DOMAINES as readonly string[]).includes(v)
+}
+
+/** Borne une valeur au domaine : retombe sur le défaut si inconnue (rétrocompatible). */
+export function coerceDomaine(v: unknown): Domaine {
+  return isDomaine(v) ? v : DEFAULT_DOMAINE
+}
+
+/** Libellé lisible d'un domaine ; défaut si le code est inconnu. */
+export function domaineLabel(v: unknown): string {
+  return DOMAINE_META[coerceDomaine(v)].label
+}

--- a/src/lib/referentiel.server.ts
+++ b/src/lib/referentiel.server.ts
@@ -6,6 +6,7 @@
 
 import { prisma } from './prisma'
 import { FRAMEWORK_IDS, FRAMEWORK_META, getFrameworkControles, type FrameworkId } from './frameworks-data'
+import { coerceDomaine, type Domaine } from './referentiel-domaines'
 import type { Locale } from './i18n'
 import type { Exigence } from './referentiel'
 
@@ -16,6 +17,8 @@ export interface ReferentielSummary {
   nom: string
   source: ReferentielSource
   type: string
+  /** Filière de contrôle/audit (cf. referentiel-domaines.ts). */
+  domaine: Domaine
   version: string | null
   nbExigences: number
   actif: boolean
@@ -29,13 +32,19 @@ const BUILTIN_CODES = FRAMEWORK_IDS.filter(id => id !== 'CUSTOM')
 
 const isBuiltin = (code: string): code is FrameworkId => (BUILTIN_CODES as readonly string[]).includes(code)
 
-/** Résumés des référentiels visibles par l'organisation (livrés + custom). */
-export async function listReferentiels(orgId: string, locale: Locale): Promise<ReferentielSummary[]> {
+/**
+ * Résumés des référentiels visibles par l'organisation (livrés + custom).
+ * `domaine` (optionnel) filtre sur une filière de contrôle/audit (cyber, LCB-FT…).
+ */
+export async function listReferentiels(orgId: string, locale: Locale, domaine?: Domaine): Promise<ReferentielSummary[]> {
   const builtins: ReferentielSummary[] = BUILTIN_CODES.map(code => {
     const meta = FRAMEWORK_META[code]
     let nb = 0
     try { nb = getFrameworkControles(code, undefined, locale).length } catch { nb = 0 }
-    return { code, nom: meta.nom, source: 'BUILTIN', type: meta.cible, version: meta.version || null, nbExigences: nb, actif: true }
+    return {
+      code, nom: meta.nom, source: 'BUILTIN', type: meta.cible,
+      domaine: coerceDomaine(meta.domaine), version: meta.version || null, nbExigences: nb, actif: true,
+    }
   })
 
   const rows = await prisma.referentiel.findMany({ where: { organizationId: orgId }, orderBy: [{ createdAt: 'desc' }] })
@@ -45,12 +54,14 @@ export async function listReferentiels(orgId: string, locale: Locale): Promise<R
     nom: r.nom,
     source: 'CUSTOM',
     type: r.type,
+    domaine: coerceDomaine((r as { domaine?: unknown }).domaine),
     version: r.version,
     nbExigences: Array.isArray(r.exigences) ? (r.exigences as unknown[]).length : 0,
     actif: r.actif,
   }))
 
-  return [...customs, ...builtins]
+  const all = [...customs, ...builtins]
+  return domaine ? all.filter(r => r.domaine === domaine) : all
 }
 
 /** Exigences (points de contrôle) d'un référentiel, quelle que soit sa source. */

--- a/src/lib/referentiel.ts
+++ b/src/lib/referentiel.ts
@@ -9,6 +9,7 @@
 // Logique PURE et testée ; l'API/UI ne font qu'appliquer ce moteur.
 
 import type { FrameworkControl, ControlType } from './frameworks-data'
+import { coerceDomaine, type Domaine } from './referentiel-domaines'
 
 export type Exigence = FrameworkControl
 
@@ -29,6 +30,7 @@ export interface ReferentielInput {
   code?: unknown
   nom?: unknown
   type?: unknown
+  domaine?: unknown
   version?: unknown
   description?: unknown
   exigences?: unknown
@@ -39,6 +41,7 @@ export interface CleanReferentiel {
   code: string
   nom: string
   type: ReferentielType
+  domaine: Domaine
   version: string | null
   description: string | null
   exigences: Exigence[]
@@ -135,6 +138,7 @@ export function cleanReferentielInput(body: ReferentielInput): CleanReferentiel 
     code: slugifyCode(body.code),
     nom: txt(body.nom),
     type,
+    domaine: coerceDomaine(body.domaine),
     version: txtOrNull(body.version),
     description: txtOrNull(body.description),
     exigences,


### PR DESCRIPTION
## Contexte
Chantier **unification des référentiels** : un seul objet « référentiel » par organisation, partagé par **analyses de risques + contrôles + conformité + audit**, et ouvert **au-delà du cyber** (LCB-FT, gel des avoirs, déontologie, comptable, octroi de crédit…).

Étude complète et taxonomie : [`docs/referentiels-univers-grc.md`](docs/referentiels-univers-grc.md).

Livraison **phasée** (validée) — ceci est la **Phase 1 : socle non cassant**.

## Ce que fait cette PR
- **`lib/referentiel-domaines.ts`** (pur, testé) : enum `DOMAINES` — 11 filières de contrôle/audit (SECURITE_SI, PROTECTION_DONNEES, LCB_FT, SANCTIONS_GEL, PROTECTION_CLIENTELE, DEONTOLOGIE, COMPTABLE_FINANCIER, CREDIT_CONTREPARTIE, RISQUE_OPERATIONNEL, GOUVERNANCE_CONTROLE, AUTRE), alignées sur l'arrêté du 3 nov. 2014 **modifié** + assurance. Helpers `coerceDomaine`/`isDomaine`/`domaineLabel`. Défaut **SECURITE_SI** ⇒ rétrocompatible.
- **Migration** `Referentiel.domaine` (+ index `org/domaine`), défaut `SECURITE_SI` — aucune donnée à muter.
- **`FRAMEWORK_META.domaine`** optionnel (cadres livrés = SECURITE_SI).
- **`referentiel.server.listReferentiels`** expose `domaine` et **filtre par filière**.
- **`cleanReferentielInput`** borne le domaine ; API `POST`/`PATCH` le persistent ; **`ReferentielsManager`** : sélecteur de domaine + badge filière (affiché pour le non-cyber).
- **i18n ×5** : libellé « Domaine ».

## Non cassant
La dimension est **ajoutée** ; la sélection d'org et les catalogues contrôle/audit restent inchangés (rebranchés en **Phase 2** — unification RA↔GRC — et **Phase 3** — seeds non-cyber + UI filtrée).

## Vérification
- Migration appliquée en local (`localhost:5432`) : colonne + index OK ; `prisma migrate status` → **up to date** ; `migrate diff` schéma ↔ base **vide** (conforme).
- `tsc --noEmit` clean ; **1422 tests** verts (dont nouveaux tests domaines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)