### PR TITLE
feat(referentiels): Phase 2 — espace de codes unifié RA↔contrôles↔conformité

### DIFF
--- a/src/__tests__/unit/lib/referentiel-catalogue.test.ts
+++ b/src/__tests__/unit/lib/referentiel-catalogue.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  builtinCatalogue,
+  referentielCodeFromNom,
+  resolveReferentielCode,
+  NOM_ALIAS_CODE,
+} from '../../../lib/referentiel-catalogue'
+import { DEFAULT_REFERENTIELS } from '../../../lib/org-config-defaults'
+import { FRAMEWORK_META } from '../../../lib/frameworks-data'
+
+describe('builtinCatalogue', () => {
+  it('liste les cadres livrés (hors CUSTOM) avec code + nom + domaine', () => {
+    const cat = builtinCatalogue()
+    expect(cat.length).toBeGreaterThan(10)
+    expect(cat.find(c => c.code === 'CUSTOM')).toBeUndefined()
+    const iso = cat.find(c => c.code === 'ISO27001')
+    expect(iso).toMatchObject({ code: 'ISO27001', nom: FRAMEWORK_META.ISO27001.nom, domaine: 'SECURITE_SI' })
+  })
+})
+
+describe('referentielCodeFromNom — mapping nom → code canonique', () => {
+  it('mappe le nom exact d’un cadre livré', () => {
+    expect(referentielCodeFromNom('DORA')).toBe('DORA')
+    expect(referentielCodeFromNom('ISO/IEC 27001')).toBe('ISO27001')
+  })
+
+  it('tolère la version, la casse, les accents et la ponctuation', () => {
+    expect(referentielCodeFromNom('ISO/IEC 27001:2022')).toBe('ISO27001')
+    expect(referentielCodeFromNom('  dora  ')).toBe('DORA')
+    expect(referentielCodeFromNom('PCI-DSS')).toBe('PCI_DSS')
+  })
+
+  it('applique les alias métier (variantes)', () => {
+    expect(referentielCodeFromNom('CIS Controls v8')).toBe('CIS_V8')
+    expect(referentielCodeFromNom('NIST CSF 2.0')).toBe('NIST_CSF')
+    expect(referentielCodeFromNom('SOC 2')).toBe('SOC2')
+  })
+
+  it('tient ISO/IEC 27002 distinct de 27001 (→ null)', () => {
+    expect(referentielCodeFromNom('ISO/IEC 27002:2022')).toBeNull()
+    expect(referentielCodeFromNom('ISO 27002')).toBeNull()
+  })
+
+  it('retourne null pour un nom sans cadre livré correspondant (→ custom)', () => {
+    expect(referentielCodeFromNom('LPM')).toBeNull()
+    expect(referentielCodeFromNom('NIS2')).toBeNull()
+    expect(referentielCodeFromNom('RGPD')).toBeNull()
+    expect(referentielCodeFromNom('Politique interne maison')).toBeNull()
+    expect(referentielCodeFromNom('')).toBeNull()
+  })
+
+  it('couvre TOUS les référentiels par défaut connus (aucune perte silencieuse)', () => {
+    // Chaque DEFAULT_REFERENTIEL est soit mappé à un code livré, soit explicitement
+    // reconnu comme « custom » (null) — jamais une correspondance accidentelle.
+    const attendus: Record<string, string | null> = {
+      'ISO/IEC 27001:2022': 'ISO27001',
+      'ISO/IEC 27002:2022': null,
+      'RGPD': null,
+      'NIS2': null,
+      'RGS': 'RGS',
+      'HDS': 'HDS',
+      'PCI-DSS': 'PCI_DSS',
+      'SOC 2': 'SOC2',
+      'LPM': null,
+      'DORA': 'DORA',
+      'CIS Controls v8': 'CIS_V8',
+      'NIST CSF 2.0': 'NIST_CSF',
+    }
+    for (const r of DEFAULT_REFERENTIELS) {
+      expect(r.nom in attendus, `nom non couvert par le test : ${r.nom}`).toBe(true)
+      expect(referentielCodeFromNom(r.nom)).toBe(attendus[r.nom])
+    }
+  })
+})
+
+describe('resolveReferentielCode — point unique de résolution', () => {
+  it('privilégie le code explicite d’une nouvelle sélection', () => {
+    expect(resolveReferentielCode({ code: 'DORA', nom: 'peu importe' })).toBe('DORA')
+  })
+  it('rétro-résout par le nom quand le code est absent (données historiques)', () => {
+    expect(resolveReferentielCode({ nom: 'ISO/IEC 27001:2022' })).toBe('ISO27001')
+  })
+  it('retourne null pour un label sans cadre livré', () => {
+    expect(resolveReferentielCode({ nom: 'LPM' })).toBeNull()
+    expect(resolveReferentielCode({ code: null, nom: 'RGPD' })).toBeNull()
+    expect(resolveReferentielCode(null)).toBeNull()
+  })
+})
+
+describe('NOM_ALIAS_CODE', () => {
+  it('n’a que des codes de cadres livrés valides comme cibles', () => {
+    for (const code of Object.values(NOM_ALIAS_CODE)) {
+      expect(FRAMEWORK_META[code]).toBeDefined()
+    }
+  })
+})

--- a/src/__tests__/unit/lib/referentiels-precoche.test.ts
+++ b/src/__tests__/unit/lib/referentiels-precoche.test.ts
@@ -3,15 +3,22 @@ import { precheckReferentiels } from '@/lib/referentiels-precoche'
 
 describe('precheckReferentiels', () => {
   const org = [
-    { nom: 'ISO/IEC 27001:2022' },
-    { nom: 'CIS Controls v8' },
+    { nom: 'ISO/IEC 27001:2022', code: 'ISO27001' },
+    { nom: 'CIS Controls v8', code: 'CIS_V8' },
     { nom: 'Politique interne' },
-    { nom: 'DORA' },
+    { nom: 'DORA', code: 'DORA' },
   ]
   it('pré-coche les référentiels org correspondant aux cadres recommandés', () => {
     const r = precheckReferentiels(['ISO/IEC 27001', 'DORA'], org)
     expect(r.map(x => x.nom)).toEqual(['ISO/IEC 27001:2022', 'DORA'])
-    expect(r[0]).toEqual({ nom: 'ISO/IEC 27001:2022', applicable: true, ecarts: '', etatApplication: 'APPLIQUE' })
+    expect(r[0]).toEqual({ nom: 'ISO/IEC 27001:2022', code: 'ISO27001', applicable: true, ecarts: '', etatApplication: 'APPLIQUE' })
+  })
+
+  it('propage le code du référentiel org (unification RA↔GRC) ou null', () => {
+    const r = precheckReferentiels(['ISO/IEC 27001'], [{ nom: 'ISO/IEC 27001:2022', code: 'ISO27001' }])
+    expect(r[0].code).toBe('ISO27001')
+    const sansCode = precheckReferentiels(['ISO/IEC 27001'], [{ nom: 'ISO/IEC 27001:2022' }])
+    expect(sansCode[0].code).toBeNull()
   })
   it('tolère les suffixes de version (préfixe normalisé)', () => {
     expect(precheckReferentiels(['CIS Controls'], org).map(x => x.nom)).toEqual(['CIS Controls v8'])

--- a/src/app/api/admin/organization-config/route.ts
+++ b/src/app/api/admin/organization-config/route.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_TYPES_IMPACTS, DEFAULT_REFERENTIELS, DEFAULT_STRATEGIES,
   type TypeImpact, type ReferentielActif, type StrategieTraitement,
 } from '@/lib/org-config-defaults'
+import { resolveReferentielCode } from '@/lib/referentiel-catalogue'
 import { sanitizeExemples, getCategoryDef, type ExempleCategoryKey } from '@/lib/exemples-ateliers'
 import { sanitizeConformiteNiveau, sanitizeSnapshotMode } from '@/lib/conformite-config'
 import { sanitizeEchelles } from '@/lib/ecosystem-echelles'
@@ -142,7 +143,11 @@ export async function PUT(req: NextRequest) {
       .map((r: any) => {
         const nom = String(r?.nom ?? '').trim().slice(0, 100)
         if (!nom) return null
-        return { nom, description: String(r?.description ?? '').trim().slice(0, 200), actif: r?.actif !== false }
+        // `code` (unification référentiels) : conservé s'il est fourni, sinon résolu
+        // depuis le nom (rétro-compat des sélections historiques keyées par nom).
+        const codeRaw = typeof r?.code === 'string' ? r.code.trim().slice(0, 60) : ''
+        const code = codeRaw || resolveReferentielCode({ nom }) || null
+        return { nom, description: String(r?.description ?? '').trim().slice(0, 200), actif: r?.actif !== false, code }
       })
       .filter(Boolean)
       .slice(0, 50)

--- a/src/components/workshops/Atelier1.tsx
+++ b/src/components/workshops/Atelier1.tsx
@@ -47,6 +47,7 @@ import { showsHdsCaveat } from '@/lib/sous-secteurs'
 import { ETATS_SOCLE, etatSocleFromEntry, type EtatSocle } from '@/lib/socle-etat'
 import AutocompleteInput from '@/components/AutocompleteInput'
 import { precheckReferentiels } from '@/lib/referentiels-precoche'
+import { resolveReferentielCode } from '@/lib/referentiel-catalogue'
 
 // Styles statiques de l'indicateur d'état d'application du socle (EXI_M1_20).
 const ETAT_SOCLE_STYLE: Record<EtatSocle, { dot: string; active: string; idle: string }> = {
@@ -91,7 +92,7 @@ export default function Atelier1({ analyseId, initialData, analyse, flashMode, c
   // Translated arrays (derived from t so they re-render on locale change)
   // Config organisation (#8) — types d'impacts + référentiels actifs ; null tant que non chargé
   const [orgImpacts, setOrgImpacts] = useState<{ id: string; label: string; icon: string }[] | null>(null)
-  const [orgReferentiels, setOrgReferentiels] = useState<{ nom: string; description: string }[] | null>(null)
+  const [orgReferentiels, setOrgReferentiels] = useState<{ nom: string; description: string; code: string | null }[] | null>(null)
   // Exemples personnalisés par l'organisation (override par catégorie) ; vide = défauts
   const [exOverride, setExOverride] = useState<Record<string, any[]>>({})
   useEffect(() => {
@@ -101,7 +102,7 @@ export default function Atelier1({ analyseId, initialData, analyse, flashMode, c
         if (!d) return
         if (Array.isArray(d.typesImpacts)) setOrgImpacts(d.typesImpacts)
         if (Array.isArray(d.referentielsActifs)) {
-          setOrgReferentiels(d.referentielsActifs.filter((r: any) => r.actif !== false).map((r: any) => ({ nom: r.nom, description: r.description })))
+          setOrgReferentiels(d.referentielsActifs.filter((r: any) => r.actif !== false).map((r: any) => ({ nom: r.nom, description: r.description, code: resolveReferentielCode(r) })))
         }
         if (d.exemplesAteliers && typeof d.exemplesAteliers === 'object' && !Array.isArray(d.exemplesAteliers)) {
           setExOverride(d.exemplesAteliers)
@@ -364,11 +365,13 @@ export default function Atelier1({ analyseId, initialData, analyse, flashMode, c
   }
 
   // ── Socle de sécurité ─────────────────────────────────────────────────────
-  function toggleReferentiel(nom: string) {
+  function toggleReferentiel(nom: string, code?: string | null) {
     setReferentiels(prev => {
       const exists = prev.find(r => r.nom === nom)
       if (exists) return prev.filter(r => r.nom !== nom)
-      return [...prev, { nom, applicable: true, ecarts: '', etatApplication: 'APPLIQUE' }]
+      // `code` (unification) relie le référentiel appliqué au cadre unifié → même
+      // objet côté conformité/contrôles. Résolu depuis le nom si non fourni.
+      return [...prev, { nom, code: code ?? resolveReferentielCode({ nom }), applicable: true, ecarts: '', etatApplication: 'APPLIQUE' }]
     })
   }
 
@@ -1282,7 +1285,7 @@ export default function Atelier1({ analyseId, initialData, analyse, flashMode, c
                 return (
                   <button
                     key={r.nom}
-                    onClick={() => toggleReferentiel(r.nom)}
+                    onClick={() => toggleReferentiel(r.nom, (r as { code?: string | null }).code ?? null)}
                     className={`text-left p-3 border rounded-lg transition-colors ${
                       selected ? 'border-ebios-500 bg-ebios-50' : 'border-gray-200 hover:border-ebios-300 hover:bg-ebios-50'
                     }`}

--- a/src/lib/org-config-defaults.ts
+++ b/src/lib/org-config-defaults.ts
@@ -13,6 +13,13 @@ export interface ReferentielActif {
   nom: string
   description: string
   actif: boolean
+  /**
+   * Code canonique du référentiel unifié (cadre livré ou custom), reliant la
+   * sélection côté analyses aux exigences côté conformité/contrôles/audit.
+   * `null`/absent = référentiel « label » sans cadre livré (résolu à la lecture par
+   * referentielCodeFromNom, ou traité en custom). Cf. lib/referentiel-catalogue.ts.
+   */
+  code?: string | null
 }
 
 /** Types d'impacts par défaut (événements redoutés — Atelier 1). */
@@ -47,18 +54,23 @@ export const DEFAULT_STRATEGIES: StrategieTraitement[] = [
   { value: 'SURVEILLER', color: 'bg-purple-100 text-purple-700', label: 'Surveiller',       description: "Surveiller l'évolution du risque sans action immédiate",                        conseil: "Pour les risques émergents dont l'évolution est incertaine" },
 ]
 
-/** Référentiels de sécurité par défaut (tous actifs). */
+/**
+ * Référentiels de sécurité par défaut (tous actifs). `code` relie chaque entrée au
+ * catalogue canonique unifié — même objet côté analyses et côté conformité/contrôles.
+ * `null` = label sans cadre livré (RGPD → futur builtin P3 ; NIS2, LPM, ISO 27002
+ * tenus distincts / custom). Cf. lib/referentiel-catalogue.ts (table de correspondance).
+ */
 export const DEFAULT_REFERENTIELS: ReferentielActif[] = [
-  { nom: 'ISO/IEC 27001:2022', description: "Système de Management de la Sécurité de l'Information", actif: true },
-  { nom: 'ISO/IEC 27002:2022', description: "Mesures de sécurité de l'information", actif: true },
-  { nom: 'RGPD',  description: 'Règlement Général sur la Protection des Données', actif: true },
-  { nom: 'NIS2',  description: 'Directive européenne sécurité des réseaux et systèmes', actif: true },
-  { nom: 'RGS',   description: 'Référentiel Général de Sécurité (ANSSI)', actif: true },
-  { nom: 'HDS',   description: 'Hébergeur de Données de Santé', actif: true },
-  { nom: 'PCI-DSS', description: 'Payment Card Industry Data Security Standard', actif: true },
-  { nom: 'SOC 2', description: 'Service Organization Control 2', actif: true },
-  { nom: 'LPM',   description: 'Loi de Programmation Militaire (OIV)', actif: true },
-  { nom: 'DORA',  description: 'Digital Operational Resilience Act (secteur financier)', actif: true },
-  { nom: 'CIS Controls v8', description: 'Center for Internet Security Controls', actif: true },
-  { nom: 'NIST CSF 2.0', description: 'NIST Cybersecurity Framework', actif: true },
+  { nom: 'ISO/IEC 27001:2022', description: "Système de Management de la Sécurité de l'Information", actif: true, code: 'ISO27001' },
+  { nom: 'ISO/IEC 27002:2022', description: "Mesures de sécurité de l'information", actif: true, code: null },
+  { nom: 'RGPD',  description: 'Règlement Général sur la Protection des Données', actif: true, code: null },
+  { nom: 'NIS2',  description: 'Directive européenne sécurité des réseaux et systèmes', actif: true, code: null },
+  { nom: 'RGS',   description: 'Référentiel Général de Sécurité (ANSSI)', actif: true, code: 'RGS' },
+  { nom: 'HDS',   description: 'Hébergeur de Données de Santé', actif: true, code: 'HDS' },
+  { nom: 'PCI-DSS', description: 'Payment Card Industry Data Security Standard', actif: true, code: 'PCI_DSS' },
+  { nom: 'SOC 2', description: 'Service Organization Control 2', actif: true, code: 'SOC2' },
+  { nom: 'LPM',   description: 'Loi de Programmation Militaire (OIV)', actif: true, code: null },
+  { nom: 'DORA',  description: 'Digital Operational Resilience Act (secteur financier)', actif: true, code: 'DORA' },
+  { nom: 'CIS Controls v8', description: 'Center for Internet Security Controls', actif: true, code: 'CIS_V8' },
+  { nom: 'NIST CSF 2.0', description: 'NIST Cybersecurity Framework', actif: true, code: 'NIST_CSF' },
 ]

--- a/src/lib/referentiel-catalogue.ts
+++ b/src/lib/referentiel-catalogue.ts
@@ -1,0 +1,100 @@
+// ─── Catalogue canonique des cadres livrés + mapping nom → code ──────────────
+// Pont d'UNIFICATION entre le côté « analyses de risques » (historiquement keyé par
+// NOM : Cadrage.referentiels[].nom) et le côté « conformité / contrôles / audit »
+// (keyé par CODE : referentielCode). Ce module résout un nom d'affichage vers le
+// code canonique du cadre livré correspondant, pour que les deux mondes désignent
+// le MÊME référentiel. Logique PURE et testée.
+
+import { FRAMEWORK_IDS, FRAMEWORK_META, type FrameworkId } from './frameworks-data'
+import { coerceDomaine, type Domaine } from './referentiel-domaines'
+
+export interface CatalogueEntry {
+  code: FrameworkId
+  nom: string
+  domaine: Domaine
+  version: string
+}
+
+/** Cadres livrés proposables (on exclut CUSTOM, emplacement d'exigences ad hoc). */
+export function builtinCatalogue(): CatalogueEntry[] {
+  return FRAMEWORK_IDS.filter(id => id !== 'CUSTOM').map(code => {
+    const meta = FRAMEWORK_META[code]
+    return { code, nom: meta.nom, domaine: coerceDomaine(meta.domaine), version: meta.version }
+  })
+}
+
+// Normalise un nom pour comparaison : minuscules, sans accents, sans ponctuation ni
+// numéro de version (« ISO/IEC 27001:2022 » ≈ « iso iec 27001 »). Le millésime en
+// fin (":2022", " v8", " 2.0") est absorbé par la suppression de la ponctuation +
+// la comparaison par préfixe côté alias.
+function norm(v: unknown): string {
+  return String(v ?? '')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+// Alias métier explicites (nom d'affichage → code livré). Curatif plutôt que fuzzy :
+// on préfère une table lisible et testée à une heuristique qui « devine ».
+export const NOM_ALIAS_CODE: Record<string, FrameworkId> = {
+  'iso iec 27001': 'ISO27001',
+  'iso 27001': 'ISO27001',
+  // NB : ISO/IEC 27002 est tenu DISTINCT de 27001 (décision produit) → pas d'alias,
+  //      il résout à null (label/custom) tant qu'un cadre 27002 dédié n'est pas livré.
+  'dora': 'DORA',
+  'nist csf': 'NIST_CSF',
+  'nist cybersecurity framework': 'NIST_CSF',
+  'nist sp 800 53': 'NIST_800_53',
+  'nist 800 53': 'NIST_800_53',
+  'nist ssdf': 'NIST_SSDF',
+  'cis controls': 'CIS_V8',
+  'cis controls v8': 'CIS_V8',
+  'cis v8': 'CIS_V8',
+  'anssi guide d hygiene': 'ANSSI_HYG',
+  'guide d hygiene': 'ANSSI_HYG',
+  'hds': 'HDS',
+  'pci dss': 'PCI_DSS',
+  'soc 2': 'SOC2',
+  'soc 2 type ii': 'SOC2',
+  'rgs': 'RGS',
+  'recyf': 'RECYF',
+  'iec 62443': 'IEC_62443',
+  'tisax': 'TISAX',
+  'tisax vda isa': 'TISAX',
+}
+
+// Index normalisé des noms canoniques des cadres livrés (secours si absent des alias).
+const BUILTIN_NORM_INDEX: Record<string, FrameworkId> = Object.fromEntries(
+  FRAMEWORK_IDS.filter(id => id !== 'CUSTOM').map(id => [norm(FRAMEWORK_META[id].nom), id]),
+)
+
+/**
+ * Résout un nom d'affichage de référentiel vers le CODE d'un cadre livré, ou `null`
+ * si aucun ne correspond (le référentiel relève alors du custom / à seeder).
+ * Absorbe le millésime : « ISO/IEC 27001:2022 » → ISO27001.
+ */
+export function referentielCodeFromNom(nom: unknown): FrameworkId | null {
+  const n = norm(nom)
+  if (!n) return null
+  if (NOM_ALIAS_CODE[n]) return NOM_ALIAS_CODE[n]
+  if (BUILTIN_NORM_INDEX[n]) return BUILTIN_NORM_INDEX[n]
+  // Correspondance par préfixe : « iso iec 27001 2022 » commence par « iso iec 27001 ».
+  for (const [alias, code] of Object.entries(NOM_ALIAS_CODE)) {
+    if (n === alias || n.startsWith(alias + ' ')) return code
+  }
+  return null
+}
+
+/**
+ * Point UNIQUE de résolution du code d'un référentiel sélectionné (config org ou
+ * entrée d'analyse). Priorité au `code` explicite (nouvelles sélections) ; sinon
+ * rétro-résolution par le nom (données historiques keyées par nom). `null` = label
+ * sans cadre livré (custom / à seeder). Non destructif : aucune migration requise.
+ */
+export function resolveReferentielCode(entry: { code?: string | null; nom?: unknown } | null | undefined): string | null {
+  if (!entry) return null
+  const code = typeof entry.code === 'string' ? entry.code.trim() : ''
+  if (code) return code
+  return referentielCodeFromNom(entry.nom)
+}

--- a/src/lib/referentiels-precoche.ts
+++ b/src/lib/referentiels-precoche.ts
@@ -3,8 +3,8 @@
 // socle de l'organisation qui correspondent aux cadres RECOMMANDÉS pour le
 // secteur de l'analyse (ISO 27001, NIS2, DORA…). L'utilisateur peut décocher.
 
-export interface OrgReferentiel { nom: string; description?: string | null }
-export interface PrecheckedRef { nom: string; applicable: boolean; ecarts: string; etatApplication: string }
+export interface OrgReferentiel { nom: string; description?: string | null; code?: string | null }
+export interface PrecheckedRef { nom: string; code: string | null; applicable: boolean; ecarts: string; etatApplication: string }
 
 /** Normalise un nom de référentiel : minuscules, sans espaces ni ponctuation. */
 const norm = (s: string): string => (s ?? '').toLowerCase().replace(/[^a-z0-9]/g, '')
@@ -26,7 +26,7 @@ export function precheckReferentiels(recommendedNoms: string[], orgReferentiels:
     if (on.length < 3 || seen.has(on)) continue
     if (recs.some(rn => rn === on || rn.startsWith(on) || on.startsWith(rn))) {
       seen.add(on)
-      out.push({ nom: r.nom, applicable: true, ecarts: '', etatApplication: 'APPLIQUE' })
+      out.push({ nom: r.nom, code: r.code ?? null, applicable: true, ecarts: '', etatApplication: 'APPLIQUE' })
     }
   }
   return out


### PR DESCRIPTION
## Contexte
Chantier **unification des référentiels**, **Phase 2**. Objectif : que « la PSSI, DORA ou ISO 27001 n'existe que dans **une seule version par organisation**, où on fait les analyses de risques, les contrôles et la conformité sur la base des **mêmes référentiels** ».

> 🔗 **Stacked sur #85 (Phase 1)** — base = `feat/referentiels-domaines-p1`. À merger après #85 (ou retarget sur `main` une fois #85 mergée).

## Le problème résolu
Le côté **analyses** était keyé par **nom** (`Cadrage.referentiels[].nom`), le côté **conformité/contrôles/audit** par **code** (`referentielCode`). Résultat : « DORA » côté analyse ≠ « DORA » côté contrôle. Cette PR fait converger les deux sur **un même espace de codes**.

## Changements (non destructifs — aucune migration de données)
- **`referentiel-catalogue.ts`** (pur, testé) :
  - `builtinCatalogue()` — cadres livrés + domaine + version ;
  - `referentielCodeFromNom()` — nom d'affichage → code canonique (table d'alias **curative**, pas de fuzzy ; absorbe le millésime « ISO/IEC 27001:2022 » → `ISO27001`) ;
  - `resolveReferentielCode()` — **point unique** : code explicite prioritaire, sinon rétro-résolution par le nom (historique).
- **Décisions produit câblées** : ISO 27002 et NIS2 **distincts** (code `null`), RGPD → futur builtin (Phase 3), LPM → custom.
- **`ReferentielActif.code?`** + codes sur `DEFAULT_REFERENTIELS` (table de correspondance).
- **Config admin** : `code` **persisté** (résolu depuis le nom si absent) au lieu d'être supprimé au save.
- **Atelier 1** : les référentiels **appliqués** portent le code résolu → lien direct vers le cadre unifié ; `precheckReferentiels` propage le code. Stocké en JSON (Cadrage) → **zéro migration** ; les analyses historiques keyées par nom restent résolues à la lecture.

## Effet
Après cette PR, **analyses + contrôles + conformité parlent le même code**. Le reste (jointure visible dans un rapport de couverture, sélecteur de config depuis le catalogue unifié) = Phase 2b/3.

## Vérification
`tsc` clean · **1434 tests** verts (12 nouveaux : catalogue + résolveur + propagation de code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)