### PR TITLE
feat(referentiels): Phase 3 — ouverture non-cyber (LCB-FT, gel des avoirs, RGPD…)

### DIFF
--- a/docs/referentiels-univers-grc.md
+++ b/docs/referentiels-univers-grc.md
@@ -249,12 +249,19 @@ Analyses (Atelier 1, cadrage, `socle-etat`, PDF), conformité, `controles-catalo
 - **Phase 2 — unification RA ↔ GRC**
   - `referentielsActifs` = codes ; migration des noms ; Atelier 1 / cadrage / PDF lisent
     la sélection unifiée. Conformité évalue la même sélection.
-- **Phase 3 — ouverture non-cyber**
-  - Seed des en-têtes + exigences P1 (RGPD, LCB-FT, SANCTIONS_GEL, DSP2, Sapin II,
-    comptable, octroi crédit, externalisation, contrôle interne).
-  - `controles-catalogue` / `audit-programmes-catalogue` ouverts par domaine + catalogues
-    de départ non-cyber.
-  - UI : filtre par domaine dans `ReferentielsManager`, contrôles, audit ; i18n ×5.
+- **Phase 3 — ouverture non-cyber — LIVRÉE (en-têtes + exigences P1)**
+  - ✅ Seed des 9 cadres GRC livrés (`referentiels-builtins-grc.ts`) : RGPD, LCB-FT,
+    SANCTIONS_GEL (gel des avoirs), DSP2, Sapin II, contrôle interne comptable, octroi
+    de crédit, externalisation, dispositif de contrôle interne — chacun avec domaine,
+    version canonique et exigences de départ. Exposés en BUILTIN par
+    `referentiel.server` (list + `getExigencesFor`) → contrôles, audit et conformité
+    (couverture dérivée) opérationnels dessus par `referentielCode`.
+  - ✅ UI : filtre par domaine dans `ReferentielsManager` + badge filière (custom &
+    builtin) ; i18n ×5 (« Domaine », « Tous les domaines »).
+  - Reste (P2/P3 de contenu) : catalogues de départ prêts-à-l'emploi de contrôles/audits
+    non-cyber (`controles-catalogue` / `audit-programmes-catalogue` par domaine) ;
+    localisation des libellés d'exigences non-cyber ; référentiels P2 (ACPR, EBA, GAFI,
+    MIF 2, IDD…).
 
 ---
 

--- a/src/__tests__/unit/lib/referentiel-catalogue.test.ts
+++ b/src/__tests__/unit/lib/referentiel-catalogue.test.ts
@@ -80,9 +80,13 @@ describe('resolveReferentielCode — point unique de résolution', () => {
   it('rétro-résout par le nom quand le code est absent (données historiques)', () => {
     expect(resolveReferentielCode({ nom: 'ISO/IEC 27001:2022' })).toBe('ISO27001')
   })
+  it('rétro-résout aussi les cadres GRC livrés (ex. RGPD)', () => {
+    expect(resolveReferentielCode({ code: null, nom: 'RGPD' })).toBe('RGPD')
+    expect(resolveReferentielCode({ nom: 'Gel des avoirs' })).toBe('SANCTIONS_GEL')
+  })
   it('retourne null pour un label sans cadre livré', () => {
     expect(resolveReferentielCode({ nom: 'LPM' })).toBeNull()
-    expect(resolveReferentielCode({ code: null, nom: 'RGPD' })).toBeNull()
+    expect(resolveReferentielCode({ nom: 'Politique interne maison' })).toBeNull()
     expect(resolveReferentielCode(null)).toBeNull()
   })
 })

--- a/src/__tests__/unit/lib/referentiels-builtins-grc.test.ts
+++ b/src/__tests__/unit/lib/referentiels-builtins-grc.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GRC_BUILTINS,
+  GRC_BUILTIN_CODES,
+  isGrcBuiltin,
+  grcBuiltinByCode,
+  grcCodeFromNom,
+} from '../../../lib/referentiels-builtins-grc'
+import { DOMAINES } from '../../../lib/referentiel-domaines'
+
+describe('GRC_BUILTINS — catalogue non-cyber livré', () => {
+  it('couvre les filières P1 attendues (LCB-FT, gel des avoirs, RGPD, DSP2, Sapin II, compta, crédit, externalisation, contrôle interne)', () => {
+    expect(GRC_BUILTIN_CODES.sort()).toEqual([
+      'COMPTA_CI', 'CONTROLE_INTERNE', 'CREDIT_OCTROI', 'DSP2', 'EXTERNALISATION',
+      'LCB_FT', 'RGPD', 'SANCTIONS_GEL', 'SAPIN2',
+    ])
+  })
+
+  it('a des codes uniques', () => {
+    expect(new Set(GRC_BUILTIN_CODES).size).toBe(GRC_BUILTIN_CODES.length)
+  })
+
+  it('chaque référentiel a un domaine valide et des exigences bien formées', () => {
+    for (const r of GRC_BUILTINS) {
+      expect(DOMAINES).toContain(r.domaine)
+      expect(r.nom.length).toBeGreaterThan(0)
+      expect(r.version.length).toBeGreaterThan(0)
+      expect(r.exigences.length).toBeGreaterThan(0)
+      const refs = r.exigences.map(e => e.ref)
+      expect(new Set(refs).size, `refs dupliquées dans ${r.code}`).toBe(refs.length)
+      for (const e of r.exigences) {
+        expect(e.ref.length).toBeGreaterThan(0)
+        expect(e.nom.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('couvre bien des domaines hors cyber', () => {
+    const domaines = new Set(GRC_BUILTINS.map(r => r.domaine))
+    expect(domaines.has('LCB_FT')).toBe(true)
+    expect(domaines.has('SANCTIONS_GEL')).toBe(true)
+    expect(domaines.has('CREDIT_CONTREPARTIE')).toBe(true)
+    expect(domaines.has('SECURITE_SI')).toBe(false) // le non-cyber ne recouvre pas le cyber
+  })
+})
+
+describe('helpers GRC', () => {
+  it('isGrcBuiltin / grcBuiltinByCode', () => {
+    expect(isGrcBuiltin('LCB_FT')).toBe(true)
+    expect(isGrcBuiltin('ISO27001')).toBe(false)
+    expect(grcBuiltinByCode('RGPD')?.domaine).toBe('PROTECTION_DONNEES')
+    expect(grcBuiltinByCode('inconnu')).toBeUndefined()
+  })
+
+  it('grcCodeFromNom résout noms et alias', () => {
+    expect(grcCodeFromNom('RGPD')).toBe('RGPD')
+    expect(grcCodeFromNom('gel des avoirs')).toBe('SANCTIONS_GEL')
+    expect(grcCodeFromNom('LCB-FT')).toBe('LCB_FT')
+    expect(grcCodeFromNom('Sapin II')).toBe('SAPIN2')
+    expect(grcCodeFromNom('DSP2')).toBe('DSP2')
+    expect(grcCodeFromNom('n’importe quoi')).toBeNull()
+    expect(grcCodeFromNom('')).toBeNull()
+  })
+})

--- a/src/components/ReferentielsManager.tsx
+++ b/src/components/ReferentielsManager.tsx
@@ -31,6 +31,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
   const [couv, setCouv] = useState<{ code: string; nom: string; parExigence: CouvExigence[]; synthese: CouvSynthese } | null>(null)
   const [couvLoading, setCouvLoading] = useState(false)
   const [seeding, setSeeding] = useState(false)
+  const [filterDomaine, setFilterDomaine] = useState<string>('')
 
   const exigencesParsed = useMemo(() => parseExigences(form.exigencesText), [form.exigencesText])
 
@@ -90,9 +91,12 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
   const inputCls = 'w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-ebios-500'
 
   if (loading) return <div className="text-center py-12 text-gray-500">{t.loading}</div>
-  const customs = refs.filter(x => x.source === 'CUSTOM')
-  const builtins = refs.filter(x => x.source === 'BUILTIN')
-  const hasPolitique = customs.some(x => x.type === 'PSSI' || x.type === 'POLITIQUE')
+  const byDomaine = (x: Ref) => !filterDomaine || x.domaine === filterDomaine
+  const customs = refs.filter(x => x.source === 'CUSTOM' && byDomaine(x))
+  const builtins = refs.filter(x => x.source === 'BUILTIN' && byDomaine(x))
+  // Domaines réellement présents dans le catalogue de l'org (pour le filtre).
+  const domainesPresents = DOMAINES.filter(d => refs.some(x => x.domaine === d))
+  const hasPolitique = refs.some(x => x.source === 'CUSTOM' && (x.type === 'PSSI' || x.type === 'POLITIQUE'))
 
   const typeBadge = (type: string, source: string) => (
     <span className={`text-[11px] px-2 py-0.5 rounded-full font-medium ${source === 'BUILTIN' ? 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300' : 'bg-ebios-100 text-ebios-700 dark:bg-ebios-500/15 dark:text-ebios-300'}`}>
@@ -116,6 +120,18 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
 
       {!canManage && (
         <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{r.readOnly}</div>
+      )}
+
+      {/* Filtre par filière (domaine) — cyber, LCB-FT, gel des avoirs, comptable… */}
+      {domainesPresents.length > 1 && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-500 dark:text-gray-400">{r.champ.domaine}</span>
+          <select className="text-sm px-2.5 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+            value={filterDomaine} onChange={e => setFilterDomaine(e.target.value)}>
+            <option value="">{r.tousDomaines}</option>
+            {domainesPresents.map(d => <option key={d} value={d}>{DOMAINE_META[d].label}</option>)}
+          </select>
+        </div>
       )}
 
       {/* Aucune politique/stratégie : proposer d'initialiser le socle par défaut */}
@@ -246,7 +262,14 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
               {builtins.map(x => (
                 <tr key={x.code} className="border-t border-gray-100 dark:border-gray-700">
                   <td className="px-3 py-2">
-                    <div className="font-medium text-gray-800 dark:text-gray-100">{x.nom}</div>
+                    <div className="flex flex-wrap items-center gap-1">
+                      <span className="font-medium text-gray-800 dark:text-gray-100">{x.nom}</span>
+                      {x.domaine && x.domaine !== 'SECURITE_SI' && (
+                        <span className="text-[11px] px-2 py-0.5 rounded-full font-medium bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
+                          {DOMAINE_META[x.domaine as keyof typeof DOMAINE_META]?.label ?? x.domaine}
+                        </span>
+                      )}
+                    </div>
                     <div className="text-[11px] text-gray-400">{x.type}</div>
                   </td>
                   <td className="px-3 py-2 text-gray-500 dark:text-gray-400">{x.version ?? '—'}</td>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1628,6 +1628,7 @@ export const de: Translations = {
     missionsHint: 'Eine Mission pro Zeile: Titel | Beschreibung. Sicherheitsziele (z. B. Schutz der VIV von Kundendaten und -diensten).',
     yours: 'Ihre Referenzrahmen',
     builtin: 'Gelieferte Rahmenwerke (nur Lesen)',
+    tousDomaines: 'Alle Bereiche',
     empty: 'Noch kein eigener Referenzrahmen. Erstellen Sie Ihre Sicherheitsleitlinie oder interne Richtlinien und deren Anforderungen.',
     readOnly: 'Nur Lesezugriff — die Pflege der Referenzrahmen obliegt der Governance (CISO / Compliance).',
     champ: { code: 'Code', nom: 'Name', type: 'Typ', domaine: 'Bereich', version: 'Version', description: 'Beschreibung', exigences: 'Anforderungen (Kontrollpunkte)', missions: 'Missionen (Sicherheitsziele)' },

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1628,6 +1628,7 @@ export const en: Translations = {
     missionsHint: 'One mission per line: title | description. Security objectives (e.g. protect the CIA of client data and services).',
     yours: 'Your frameworks',
     builtin: 'Built-in frameworks (read only)',
+    tousDomaines: 'All domains',
     empty: 'No custom framework yet. Create your ISSP or internal policies and their requirements.',
     readOnly: 'Read only — framework management belongs to governance (CISO / compliance).',
     champ: { code: 'Code', nom: 'Name', type: 'Type', domaine: 'Domain', version: 'Version', description: 'Description', exigences: 'Requirements (control points)', missions: 'Missions (security objectives)' },

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1628,6 +1628,7 @@ export const es: Translations = {
     missionsHint: 'Una misión por línea: título | descripción. Objetivos de seguridad (p. ej. proteger la CID de los datos y servicios de clientes).',
     yours: 'Sus marcos',
     builtin: 'Marcos incluidos (solo lectura)',
+    tousDomaines: 'Todos los dominios',
     empty: 'Ningún marco propio. Cree su PSSI o sus políticas internas y sus requisitos.',
     readOnly: 'Solo lectura — la gestión de los marcos corresponde a la gobernanza (RSSI / cumplimiento).',
     champ: { code: 'Código', nom: 'Nombre', type: 'Tipo', domaine: 'Dominio', version: 'Versión', description: 'Descripción', exigences: 'Requisitos (puntos de control)', missions: 'Misiones (objetivos de seguridad)' },

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1651,6 +1651,7 @@ export const fr = {
     missionsHint: 'Une mission par ligne : intitulé | description. Objectifs de sécurité (ex. protéger le DIC des données et services clients).',
     yours: 'Vos référentiels',
     builtin: 'Cadres livrés (lecture seule)',
+    tousDomaines: 'Tous les domaines',
     empty: 'Aucun référentiel propre. Créez votre PSSI ou vos politiques internes et leurs exigences.',
     readOnly: 'Lecture seule — la tenue des référentiels relève de la gouvernance (RSSI / conformité).',
     champ: { code: 'Code', nom: 'Nom', type: 'Type', domaine: 'Domaine', version: 'Version', description: 'Description', exigences: 'Exigences (points de contrôle)', missions: 'Missions (objectifs de sécurité)' },

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1628,6 +1628,7 @@ export const it: Translations = {
     missionsHint: 'Una missione per riga: titolo | descrizione. Obiettivi di sicurezza (es. proteggere la RID dei dati e servizi ai clienti).',
     yours: 'I tuoi riferimenti',
     builtin: 'Quadri forniti (sola lettura)',
+    tousDomaines: 'Tutti i domini',
     empty: 'Nessun riferimento proprio. Crea la tua PSSI o le tue politiche interne e i loro requisiti.',
     readOnly: 'Sola lettura — la gestione dei riferimenti spetta alla governance (RSSI / conformità).',
     champ: { code: 'Codice', nom: 'Nome', type: 'Tipo', domaine: 'Dominio', version: 'Versione', description: 'Descrizione', exigences: 'Requisiti (punti di controllo)', missions: 'Missioni (obiettivi di sicurezza)' },

--- a/src/lib/org-config-defaults.ts
+++ b/src/lib/org-config-defaults.ts
@@ -63,7 +63,7 @@ export const DEFAULT_STRATEGIES: StrategieTraitement[] = [
 export const DEFAULT_REFERENTIELS: ReferentielActif[] = [
   { nom: 'ISO/IEC 27001:2022', description: "Système de Management de la Sécurité de l'Information", actif: true, code: 'ISO27001' },
   { nom: 'ISO/IEC 27002:2022', description: "Mesures de sécurité de l'information", actif: true, code: null },
-  { nom: 'RGPD',  description: 'Règlement Général sur la Protection des Données', actif: true, code: null },
+  { nom: 'RGPD',  description: 'Règlement Général sur la Protection des Données', actif: true, code: 'RGPD' },
   { nom: 'NIS2',  description: 'Directive européenne sécurité des réseaux et systèmes', actif: true, code: null },
   { nom: 'RGS',   description: 'Référentiel Général de Sécurité (ANSSI)', actif: true, code: 'RGS' },
   { nom: 'HDS',   description: 'Hébergeur de Données de Santé', actif: true, code: 'HDS' },

--- a/src/lib/referentiel-catalogue.ts
+++ b/src/lib/referentiel-catalogue.ts
@@ -7,6 +7,7 @@
 
 import { FRAMEWORK_IDS, FRAMEWORK_META, type FrameworkId } from './frameworks-data'
 import { coerceDomaine, type Domaine } from './referentiel-domaines'
+import { grcCodeFromNom } from './referentiels-builtins-grc'
 
 export interface CatalogueEntry {
   code: FrameworkId
@@ -96,5 +97,6 @@ export function resolveReferentielCode(entry: { code?: string | null; nom?: unkn
   if (!entry) return null
   const code = typeof entry.code === 'string' ? entry.code.trim() : ''
   if (code) return code
-  return referentielCodeFromNom(entry.nom)
+  // Cadre cyber livré, puis cadre GRC livré (RGPD, LCB-FT…), sinon null (custom/label).
+  return referentielCodeFromNom(entry.nom) ?? grcCodeFromNom(entry.nom)
 }

--- a/src/lib/referentiel.server.ts
+++ b/src/lib/referentiel.server.ts
@@ -7,6 +7,7 @@
 import { prisma } from './prisma'
 import { FRAMEWORK_IDS, FRAMEWORK_META, getFrameworkControles, type FrameworkId } from './frameworks-data'
 import { coerceDomaine, type Domaine } from './referentiel-domaines'
+import { GRC_BUILTINS, isGrcBuiltin, grcBuiltinByCode } from './referentiels-builtins-grc'
 import type { Locale } from './i18n'
 import type { Exigence } from './referentiel'
 
@@ -30,14 +31,14 @@ export interface ReferentielSummary {
 // analyse comme emplacement d'exigences ad hoc).
 const BUILTIN_CODES = FRAMEWORK_IDS.filter(id => id !== 'CUSTOM')
 
-const isBuiltin = (code: string): code is FrameworkId => (BUILTIN_CODES as readonly string[]).includes(code)
+const isCyberBuiltin = (code: string): code is FrameworkId => (BUILTIN_CODES as readonly string[]).includes(code)
 
 /**
  * Résumés des référentiels visibles par l'organisation (livrés + custom).
  * `domaine` (optionnel) filtre sur une filière de contrôle/audit (cyber, LCB-FT…).
  */
 export async function listReferentiels(orgId: string, locale: Locale, domaine?: Domaine): Promise<ReferentielSummary[]> {
-  const builtins: ReferentielSummary[] = BUILTIN_CODES.map(code => {
+  const cyberBuiltins: ReferentielSummary[] = BUILTIN_CODES.map(code => {
     const meta = FRAMEWORK_META[code]
     let nb = 0
     try { nb = getFrameworkControles(code, undefined, locale).length } catch { nb = 0 }
@@ -46,6 +47,14 @@ export async function listReferentiels(orgId: string, locale: Locale, domaine?: 
       domaine: coerceDomaine(meta.domaine), version: meta.version || null, nbExigences: nb, actif: true,
     }
   })
+
+  // Cadres GRC livrés (non-cyber : LCB-FT, gel des avoirs, RGPD, DSP2…).
+  const grcBuiltins: ReferentielSummary[] = GRC_BUILTINS.map(r => ({
+    code: r.code, nom: r.nom, source: 'BUILTIN', type: r.nature,
+    domaine: r.domaine, version: r.version || null, nbExigences: r.exigences.length, actif: true,
+  }))
+
+  const builtins = [...cyberBuiltins, ...grcBuiltins]
 
   const rows = await prisma.referentiel.findMany({ where: { organizationId: orgId }, orderBy: [{ createdAt: 'desc' }] })
   const customs: ReferentielSummary[] = rows.map(r => ({
@@ -66,8 +75,11 @@ export async function listReferentiels(orgId: string, locale: Locale, domaine?: 
 
 /** Exigences (points de contrôle) d'un référentiel, quelle que soit sa source. */
 export async function getExigencesFor(code: string, orgId: string, locale: Locale): Promise<Exigence[]> {
-  if (isBuiltin(code)) {
+  if (isCyberBuiltin(code)) {
     try { return getFrameworkControles(code, undefined, locale) as Exigence[] } catch { return [] }
+  }
+  if (isGrcBuiltin(code)) {
+    return grcBuiltinByCode(code)?.exigences ?? []
   }
   const row = await prisma.referentiel.findFirst({ where: { organizationId: orgId, code }, select: { exigences: true } })
   return Array.isArray(row?.exigences) ? (row!.exigences as unknown as Exigence[]) : []

--- a/src/lib/referentiels-builtins-grc.ts
+++ b/src/lib/referentiels-builtins-grc.ts
@@ -1,0 +1,193 @@
+// ─── Référentiels GRC livrés (non-cyber) — catalogue canonique ───────────────
+// Cadres RÉGLEMENTAIRES au-delà du cyber, livrés en code (une version canonique,
+// sélectionnable par l'organisation) : LCB-FT, gel des avoirs, RGPD, DSP2, Sapin II,
+// contrôle interne comptable, octroi de crédit, externalisation, contrôle interne.
+//
+// Chaque référentiel expose une OSSATURE d'exigences de départ (points de contrôle
+// de haut niveau) que l'organisation rattache à ses propres contrôles/audits et
+// enrichit au besoin (§3 de docs/referentiels-univers-grc.md). Contenu FR (produit
+// bancaire français) ; la localisation des exigences non-cyber viendra plus tard.
+//
+// Exposés par referentiel.server.ts au MÊME titre que les cadres cyber (source
+// BUILTIN), keyés par `code` → contrôles, audit et conformité s'y rattachent sans
+// distinction. Logique PURE et testée.
+
+import type { Exigence } from './referentiel'
+import { coerceDomaine, type Domaine } from './referentiel-domaines'
+
+export interface GrcBuiltinReferentiel {
+  code: string
+  nom: string
+  domaine: Domaine
+  /** Nature affichée (REGLEMENTATION | NORME | POLITIQUE…). */
+  nature: string
+  version: string
+  description: string
+  exigences: Exigence[]
+}
+
+// Toutes les exigences GRC non-cyber sont, par défaut, de nature ORGANISATIONNELLE
+// (les 4 catégories ControlType sont cyber-ISO ; la `categorie` porte le vrai
+// regroupement métier : « Vigilance », « Filtrage », « Piste d'audit »…).
+const O = 'ORGANISATIONNELLE' as const
+const ex = (ref: string, nom: string, categorie: string, description: string): Exigence =>
+  ({ ref, nom, categorie, description, type: O })
+
+export const GRC_BUILTINS: GrcBuiltinReferentiel[] = [
+  {
+    code: 'RGPD', nom: 'RGPD', domaine: 'PROTECTION_DONNEES', nature: 'REGLEMENTATION',
+    version: 'UE 2016/679',
+    description: 'Règlement général sur la protection des données — traitement des données personnelles.',
+    exigences: [
+      ex('RGPD-30', 'Registre des traitements', 'Gouvernance', 'Tenir et mettre à jour le registre des activités de traitement (art. 30).'),
+      ex('RGPD-6', 'Licéité & base légale', 'Fondement', 'Chaque traitement repose sur une base légale valide ; consentement recueilli et traçable si requis (art. 6-7).'),
+      ex('RGPD-13', 'Information des personnes', 'Transparence', 'Informer les personnes concernées (mentions, finalités, durées) (art. 13-14).'),
+      ex('RGPD-15', 'Droits des personnes', 'Droits', 'Traiter les demandes d’accès, rectification, effacement, opposition dans les délais (art. 15-22).'),
+      ex('RGPD-32', 'Sécurité des traitements', 'Sécurité', 'Mesures techniques et organisationnelles adaptées au risque (art. 32).'),
+      ex('RGPD-33', 'Violations de données', 'Incident', 'Notifier la CNIL sous 72 h et, si nécessaire, les personnes concernées (art. 33-34).'),
+      ex('RGPD-35', 'Analyse d’impact (AIPD)', 'Risque', 'Réaliser une AIPD pour les traitements à risque élevé (art. 35).'),
+      ex('RGPD-28', 'Sous-traitants', 'Tiers', 'Encadrer les sous-traitants par contrat et garanties suffisantes (art. 28).'),
+    ],
+  },
+  {
+    code: 'LCB_FT', nom: 'Dispositif LCB-FT', domaine: 'LCB_FT', nature: 'REGLEMENTATION',
+    version: 'CMF art. L.561-1 s.',
+    description: 'Lutte contre le blanchiment de capitaux et le financement du terrorisme.',
+    exigences: [
+      ex('LCBFT-1', 'Classification des risques', 'Approche par les risques', 'Établir et actualiser la classification des risques BC-FT (activités, clientèle, produits, canaux, géographie).'),
+      ex('LCBFT-2', 'Entrée en relation / KYC', 'Vigilance', 'Identifier et vérifier l’identité du client et du bénéficiaire effectif avant l’entrée en relation.'),
+      ex('LCBFT-3', 'Vigilance constante', 'Vigilance', 'Exercer une vigilance continue sur les opérations et actualiser la connaissance client.'),
+      ex('LCBFT-4', 'Personnes politiquement exposées', 'Vigilance renforcée', 'Détecter les PPE et appliquer des mesures de vigilance renforcée.'),
+      ex('LCBFT-5', 'Déclaration de soupçon', 'Déclaration', 'Détecter, analyser et déclarer à Tracfin les opérations suspectes sans délai.'),
+      ex('LCBFT-6', 'Conservation des documents', 'Traçabilité', 'Conserver les documents et pièces pendant la durée réglementaire (5 ans).'),
+      ex('LCBFT-7', 'Formation & sensibilisation', 'Dispositif', 'Former régulièrement les personnels exposés au risque BC-FT.'),
+      ex('LCBFT-8', 'Organisation & responsable', 'Gouvernance', 'Désigner un responsable LCB-FT et un déclarant/correspondant Tracfin ; procédures internes formalisées.'),
+    ],
+  },
+  {
+    code: 'SANCTIONS_GEL', nom: 'Gel des avoirs & sanctions', domaine: 'SANCTIONS_GEL', nature: 'REGLEMENTATION',
+    version: 'Règl. UE + DG Trésor',
+    description: 'Mesures restrictives et gel des avoirs (UE/ONU/OFAC, Direction générale du Trésor).',
+    exigences: [
+      ex('GEL-1', 'Filtrage des listes', 'Filtrage', 'Filtrer la base clients contre les listes de sanctions (UE, ONU, OFAC) et à chaque mise à jour.'),
+      ex('GEL-2', 'Filtrage des transactions', 'Filtrage', 'Filtrer les opérations (virements, correspondants) contre les mesures restrictives.'),
+      ex('GEL-3', 'Traitement des alertes', 'Analyse', 'Analyser et lever/qualifier les correspondances dans des délais maîtrisés.'),
+      ex('GEL-4', 'Gel sans délai', 'Exécution', 'Mettre en œuvre le gel des fonds sans délai en cas de correspondance avérée.'),
+      ex('GEL-5', 'Déclaration DG Trésor', 'Déclaration', 'Déclarer les mesures de gel à la Direction générale du Trésor.'),
+    ],
+  },
+  {
+    code: 'DSP2', nom: 'DSP2 — services de paiement', domaine: 'PROTECTION_CLIENTELE', nature: 'REGLEMENTATION',
+    version: 'Dir. UE 2015/2366',
+    description: 'Deuxième directive sur les services de paiement (sécurité et protection du payeur).',
+    exigences: [
+      ex('DSP2-1', 'Authentification forte (SCA)', 'Sécurité', 'Appliquer l’authentification forte du client et gérer les exemptions conformément aux RTS.'),
+      ex('DSP2-2', 'Sécurité des paiements', 'Sécurité', 'Mesures de sécurité et de surveillance des transactions (RTS).'),
+      ex('DSP2-3', 'Accès aux comptes (TPP)', 'Ouverture', 'Encadrer l’accès des prestataires tiers (AISP/PISP) via interfaces sécurisées.'),
+      ex('DSP2-4', 'Incidents de paiement majeurs', 'Incident', 'Détecter et notifier les incidents opérationnels/sécurité majeurs.'),
+      ex('DSP2-5', 'Information & transparence', 'Client', 'Informer le payeur (frais, délais, droits) et gérer les contestations.'),
+    ],
+  },
+  {
+    code: 'SAPIN2', nom: 'Anticorruption (Sapin II)', domaine: 'DEONTOLOGIE', nature: 'REGLEMENTATION',
+    version: 'Loi 2016-1691',
+    description: 'Dispositif anticorruption — les 8 piliers de l’article 17.',
+    exigences: [
+      ex('SAPIN2-1', 'Code de conduite', 'Cadre', 'Code de conduite anticorruption intégré au règlement intérieur.'),
+      ex('SAPIN2-2', 'Dispositif d’alerte', 'Alerte', 'Dispositif d’alerte interne pour le recueil des signalements.'),
+      ex('SAPIN2-3', 'Cartographie des risques', 'Risque', 'Cartographie des risques de corruption, actualisée.'),
+      ex('SAPIN2-4', 'Évaluation des tiers', 'Tiers', 'Procédures d’évaluation des clients, fournisseurs et intermédiaires.'),
+      ex('SAPIN2-5', 'Contrôles comptables', 'Comptable', 'Contrôles comptables destinés à prévenir la dissimulation de faits de corruption.'),
+      ex('SAPIN2-6', 'Formation', 'Dispositif', 'Formation des cadres et personnels exposés.'),
+      ex('SAPIN2-7', 'Régime disciplinaire', 'Sanction', 'Régime disciplinaire sanctionnant les manquements.'),
+      ex('SAPIN2-8', 'Contrôle & évaluation', 'Pilotage', 'Contrôle interne et évaluation de l’efficacité du dispositif.'),
+    ],
+  },
+  {
+    code: 'COMPTA_CI', nom: 'Contrôle interne comptable', domaine: 'COMPTABLE_FINANCIER', nature: 'REGLEMENTATION',
+    version: 'Arrêté 3 nov. 2014 (mod. 2021)',
+    description: 'Fiabilité de l’information comptable et financière (contrôle interne comptable).',
+    exigences: [
+      ex('COMPTA-1', 'Piste d’audit fiable', 'Traçabilité', 'Chemin de révision permettant de reconstituer toute écriture jusqu’à sa pièce justificative.'),
+      ex('COMPTA-2', 'Séparation des tâches', 'Organisation', 'Séparation des fonctions d’engagement, d’enregistrement et de règlement.'),
+      ex('COMPTA-3', 'Justification des comptes', 'Contrôle', 'Rapprochements et justification périodique des soldes de comptes.'),
+      ex('COMPTA-4', 'Contrôles d’arrêté', 'Arrêté', 'Contrôles de niveau 1 et 2 sur les arrêtés comptables.'),
+      ex('COMPTA-5', 'Archivage', 'Conservation', 'Archivage et intégrité des pièces et de la documentation comptable.'),
+    ],
+  },
+  {
+    code: 'CREDIT_OCTROI', nom: 'Octroi & suivi des crédits', domaine: 'CREDIT_CONTREPARTIE', nature: 'REGLEMENTATION',
+    version: 'EBA/GL/2020/06',
+    description: 'Octroi et suivi des prêts (procédures d’octroi, garanties, suivi).',
+    exigences: [
+      ex('CRED-1', 'Capacité de remboursement', 'Analyse', 'Analyse de solvabilité et de la capacité de remboursement de l’emprunteur.'),
+      ex('CRED-2', 'Délégations d’octroi', 'Gouvernance', 'Respect des schémas de délégation et des limites d’octroi.'),
+      ex('CRED-3', 'Dossier & garanties', 'Constitution', 'Complétude du dossier, évaluation et formalisation des garanties.'),
+      ex('CRED-4', 'Comité des engagements', 'Décision', 'Passage en comité des engagements pour les dossiers au-delà des seuils.'),
+      ex('CRED-5', 'Revue & impayés', 'Suivi', 'Revue périodique des encours et détection précoce des impayés.'),
+    ],
+  },
+  {
+    code: 'EXTERNALISATION', nom: 'Externalisation & prestataires', domaine: 'RISQUE_OPERATIONNEL', nature: 'REGLEMENTATION',
+    version: 'EBA/GL/2019/02 + DORA art. 28',
+    description: 'Encadrement des prestations externalisées et des prestataires critiques.',
+    exigences: [
+      ex('EXT-1', 'Registre des externalisations', 'Cartographie', 'Registre à jour des accords d’externalisation, dont les fonctions critiques.'),
+      ex('EXT-2', 'Criticité & due diligence', 'Évaluation', 'Analyse de criticité et diligence préalable avant externalisation.'),
+      ex('EXT-3', 'Clauses contractuelles', 'Contrat', 'Droits d’audit, sous-traitance, sécurité, réversibilité dans les contrats.'),
+      ex('EXT-4', 'Suivi des niveaux de service', 'Suivi', 'Suivi des SLA et de la performance des prestataires.'),
+      ex('EXT-5', 'Stratégie de sortie', 'Réversibilité', 'Plans de sortie/réversibilité pour les prestations critiques.'),
+    ],
+  },
+  {
+    code: 'CONTROLE_INTERNE', nom: 'Dispositif de contrôle interne', domaine: 'GOUVERNANCE_CONTROLE', nature: 'REGLEMENTATION',
+    version: 'Arrêté 3 nov. 2014 (mod. 2021)',
+    description: 'Gouvernance et dispositif de contrôle interne (permanent et périodique).',
+    exigences: [
+      ex('CI-1', 'Contrôle permanent', 'Dispositif', 'Contrôles de 1er et 2e niveau formalisés et tracés.'),
+      ex('CI-2', 'Contrôle périodique', 'Audit', 'Contrôle périodique indépendant (3e ligne) et plan pluriannuel.'),
+      ex('CI-3', 'Gouvernance', 'Gouvernance', 'Rôles de l’organe de surveillance et des dirigeants effectifs.'),
+      ex('CI-4', 'Reporting de contrôle interne', 'Reporting', 'Rapport annuel de contrôle interne et informations à l’organe de surveillance.'),
+      ex('CI-5', 'Cartographie des risques', 'Risque', 'Cartographie des risques tenue à jour, alimentant le plan de contrôle.'),
+    ],
+  },
+]
+
+export const GRC_BUILTIN_CODES: string[] = GRC_BUILTINS.map(r => r.code)
+
+const BY_CODE: Record<string, GrcBuiltinReferentiel> = Object.fromEntries(GRC_BUILTINS.map(r => [r.code, r]))
+
+/** Vrai si `code` est un référentiel GRC livré. */
+export function isGrcBuiltin(code: string): boolean {
+  return Object.prototype.hasOwnProperty.call(BY_CODE, code)
+}
+
+/** Référentiel GRC livré par code, ou undefined. */
+export function grcBuiltinByCode(code: string): GrcBuiltinReferentiel | undefined {
+  return BY_CODE[code]
+}
+
+const norm = (v: unknown): string =>
+  String(v ?? '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+
+// Alias de noms d'affichage → code GRC (rétro-résolution des sélections historiques).
+const NOM_INDEX: Record<string, string> = {
+  'rgpd': 'RGPD',
+  'gdpr': 'RGPD',
+  'lcb ft': 'LCB_FT',
+  'lcbft': 'LCB_FT',
+  'blanchiment': 'LCB_FT',
+  'gel des avoirs': 'SANCTIONS_GEL',
+  'sanctions': 'SANCTIONS_GEL',
+  'dsp2': 'DSP2',
+  'sapin 2': 'SAPIN2',
+  'sapin ii': 'SAPIN2',
+  'anticorruption': 'SAPIN2',
+  ...Object.fromEntries(GRC_BUILTINS.map(r => [norm(r.nom), r.code])),
+}
+
+/** Nom d'affichage → code GRC livré, ou null. */
+export function grcCodeFromNom(nom: unknown): string | null {
+  const n = norm(nom)
+  return n ? (NOM_INDEX[n] ?? null) : null
+}


### PR DESCRIPTION
## Contexte
Chantier **unification des référentiels**, **Phase 3** — *« les audits/contrôles peuvent porter sur d'autres référentiels non cyber : DSP2, PSSI, exigences BCE, compta, procédure d'octroi de crédit, LCB-FT, gel des avoirs, déontologie… »*

> 🔗 **Stacked sur #86 (Phase 2)** — base = `feat/referentiels-unification-p2`. À merger après #85 puis #86 (ou retarget sur `main`).

## Ce que ça livre — 9 cadres GRC non-cyber, canoniques et opérationnels
`referentiels-builtins-grc.ts` (pur, testé) — chacun avec **domaine**, **version canonique** et **exigences de départ** :

| Code | Référentiel | Domaine | Base |
|---|---|---|---|
| `RGPD` | RGPD | Protection des données | UE 2016/679 |
| `LCB_FT` | Dispositif LCB-FT | LCB-FT | CMF L.561-1 s. |
| `SANCTIONS_GEL` | Gel des avoirs & sanctions | Sanctions & gel | Règl. UE + DG Trésor |
| `DSP2` | DSP2 — services de paiement | Protection clientèle | Dir. UE 2015/2366 |
| `SAPIN2` | Anticorruption (Sapin II) | Déontologie | Loi 2016-1691 |
| `COMPTA_CI` | Contrôle interne comptable | Comptable & financier | Arrêté 3 nov. 2014 (mod. 2021) |
| `CREDIT_OCTROI` | Octroi & suivi des crédits | Crédit & contrepartie | EBA/GL/2020/06 |
| `EXTERNALISATION` | Externalisation & prestataires | Risque opérationnel | EBA/GL/2019/02 + DORA art. 28 |
| `CONTROLE_INTERNE` | Dispositif de contrôle interne | Gouvernance & contrôle | Arrêté 3 nov. 2014 (mod. 2021) |

## Intégration
- **`referentiel.server`** : `listReferentiels` expose les cadres GRC (source BUILTIN, domaine réel) ; `getExigencesFor` les résout → **conformité dérivée (couverture) opérationnelle** ; un contrôle/constat d'audit s'y rattache par `referentielCode` + `exigenceRefs`, exactement comme pour ISO/DORA.
- **`resolveReferentielCode`** consulte aussi les cadres GRC (RGPD, gel des avoirs…) ; `DEFAULT_REFERENTIELS` RGPD → code `RGPD`.
- **UI `ReferentielsManager`** : **filtre par domaine** (filière) + **badge filière** sur les référentiels custom ET livrés ; i18n ×5.

## Vérification
`tsc` clean · **1441 tests** verts (7 nouveaux : intégrité du registre + résolution serveur + `grcCodeFromNom`).

Le contenu prêt-à-l'emploi (catalogues de contrôles/audits non-cyber par domaine, localisation des exigences, référentiels P2 type ACPR/EBA/GAFI/MIF 2) reste en file — l'ossature est là et déjà exploitable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)