### PR TITLE
feat(controles/audit): catalogues non-cyber prêts-à-l'emploi (LCB-FT, crédit, gel, RGPD)

### DIFF
--- a/src/__tests__/unit/lib/audit-programmes-catalogue.test.ts
+++ b/src/__tests__/unit/lib/audit-programmes-catalogue.test.ts
@@ -3,8 +3,10 @@ import { PROGRAMMES_AUDIT, getProgrammeAudit } from '@/lib/audit-programmes-cata
 import { cleanChecklist } from '@/lib/controle'
 
 describe('audit-programmes-catalogue', () => {
-  it('expose ISO27001 et DORA', () => {
-    expect(PROGRAMMES_AUDIT.map(p => p.id).sort()).toEqual(['DORA', 'ISO27001'])
+  it('expose les programmes cyber et non-cyber', () => {
+    expect(PROGRAMMES_AUDIT.map(p => p.id).sort()).toEqual([
+      'CONTROLE_INTERNE', 'CREDIT_OCTROI', 'DORA', 'ISO27001', 'LCB_FT', 'RGPD', 'SANCTIONS_GEL',
+    ])
   })
   it('getProgrammeAudit retrouve / renvoie undefined', () => {
     expect(getProgrammeAudit('DORA')?.points.length).toBeGreaterThan(5)

--- a/src/__tests__/unit/lib/controles-catalogue.test.ts
+++ b/src/__tests__/unit/lib/controles-catalogue.test.ts
@@ -1,10 +1,26 @@
 import { describe, it, expect } from 'vitest'
 import { CATALOGUES_CONTROLES, getCatalogueControle } from '@/lib/controles-catalogue'
 import { CONTROLE_NIVEAUX, PERIODICITES, cleanControleInput, validateControleInput } from '@/lib/controle'
+import { grcBuiltinByCode } from '@/lib/referentiels-builtins-grc'
 
 describe('controles-catalogue', () => {
-  it('expose les socles ISO27001 et DORA', () => {
-    expect(CATALOGUES_CONTROLES.map(c => c.id).sort()).toEqual(['DORA', 'ISO27001'])
+  it('expose les socles cyber (ISO27001, DORA) et non-cyber (LCB-FT, gel des avoirs, crédit, RGPD)', () => {
+    expect(CATALOGUES_CONTROLES.map(c => c.id).sort()).toEqual([
+      'CREDIT_OCTROI', 'DORA', 'ISO27001', 'LCB_FT', 'RGPD', 'SANCTIONS_GEL',
+    ])
+  })
+
+  it('les socles non-cyber pointent des exigences RÉELLES de leur cadre GRC livré', () => {
+    for (const cat of CATALOGUES_CONTROLES) {
+      const grc = grcBuiltinByCode(cat.referentielCode)
+      if (!grc) continue // socle cyber (ISO/DORA) — hors de ce contrôle
+      const refs = new Set(grc.exigences.map(e => e.ref))
+      for (const t of cat.controles) {
+        for (const r of t.exigenceRefs) {
+          expect(refs.has(r), `exigence ${r} absente de ${cat.referentielCode}`).toBe(true)
+        }
+      }
+    }
   })
 
   it('getCatalogueControle retrouve un socle et renvoie undefined sinon', () => {

--- a/src/components/ControlesManager.tsx
+++ b/src/components/ControlesManager.tsx
@@ -4,6 +4,7 @@ import { FlaskConical, Paperclip } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
 import { CONTROLE_NIVEAUX, PERIODICITES, RESULTATS, deduireResultatChecklist, filtrerControles, type ControleFiltre } from '@/lib/controle'
+import { CATALOGUES_CONTROLES } from '@/lib/controles-catalogue'
 import { todayInputDate, suggestionsFromValues, defaultResponsable } from '@/lib/form-defaults'
 
 interface Efficacite {
@@ -230,8 +231,7 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
             <select value="" disabled={busy} onChange={e => { if (e.target.value) importerSocle(e.target.value); e.target.value = '' }}
               className={inp} aria-label={c.importLabel} title={c.importHint}>
               <option value="">{c.importLabel}</option>
-              <option value="ISO27001">ISO/IEC 27001:2022</option>
-              <option value="DORA">DORA</option>
+              {CATALOGUES_CONTROLES.map(cat => <option key={cat.id} value={cat.id}>{cat.nom}</option>)}
             </select>
             <button onClick={() => { setForm(emptyForm()); setEditId(null); setShowForm(true) }} className="btn-primary text-sm">{c.newBtn}</button>
           </div>

--- a/src/lib/audit-programmes-catalogue.ts
+++ b/src/lib/audit-programmes-catalogue.ts
@@ -44,7 +44,83 @@ const DORA: ProgrammeAuditType = {
   ],
 }
 
-export const PROGRAMMES_AUDIT: ProgrammeAuditType[] = [ISO27001, DORA]
+const LCB_FT: ProgrammeAuditType = {
+  id: 'LCB_FT', nom: 'Dispositif LCB-FT — programme type',
+  points: [
+    'Classification des risques BC-FT documentée, actualisée et approuvée',
+    'Procédures internes LCB-FT formalisées et à jour',
+    'Identification client et bénéficiaire effectif à l\'entrée en relation (KYC)',
+    'Mesures de vigilance adaptées au risque et vigilance constante sur les opérations',
+    'Détection et traitement des personnes politiquement exposées (PPE)',
+    'Détection, analyse et déclaration des soupçons à Tracfin (délais, traçabilité)',
+    'Dispositif de gel et filtrage des mesures restrictives articulé avec la LCB-FT',
+    'Conservation des documents pendant la durée réglementaire',
+    'Formation et sensibilisation des personnels exposés',
+    'Organisation : responsable LCB-FT, déclarant/correspondant Tracfin, moyens',
+    'Contrôle interne du dispositif et suivi des recommandations',
+  ],
+}
+
+const SANCTIONS_GEL: ProgrammeAuditType = {
+  id: 'SANCTIONS_GEL', nom: 'Gel des avoirs & sanctions — programme type',
+  points: [
+    'Listes de sanctions (UE/ONU/OFAC) intégrées et mises à jour sans délai',
+    'Filtrage de la base clients et rescreening après chaque mise à jour',
+    'Filtrage des transactions et des correspondants bancaires',
+    'Paramétrage de l\'outil de filtrage revu et documenté',
+    'Traitement des alertes : délais, analyse et qualification des correspondances',
+    'Procédure de gel des fonds exécutable sans délai (testée)',
+    'Déclaration des mesures de gel à la Direction générale du Trésor',
+    'Traçabilité des décisions et pistes d\'audit',
+  ],
+}
+
+const CREDIT_OCTROI: ProgrammeAuditType = {
+  id: 'CREDIT_OCTROI', nom: 'Octroi & suivi des crédits — programme type',
+  points: [
+    'Analyse de la capacité de remboursement au dossier (solvabilité)',
+    'Respect des schémas de délégation et des limites d\'octroi',
+    'Complétude du dossier de crédit et formalisation des garanties',
+    'Passage en comité des engagements au-delà des seuils',
+    'Dispositif de notation / cotation des contreparties',
+    'Revue périodique des encours et détection précoce des impayés',
+    'Provisionnement et classification des créances douteuses',
+    'Suivi des dépassements et des exceptions à la politique de crédit',
+  ],
+}
+
+const RGPD: ProgrammeAuditType = {
+  id: 'RGPD', nom: 'RGPD — programme type',
+  points: [
+    'Registre des activités de traitement exhaustif et à jour (art. 30)',
+    'Bases légales et recueil du consentement le cas échéant (art. 6-7)',
+    'Information des personnes concernées (art. 13-14)',
+    'Traitement des demandes d\'exercice des droits dans les délais (art. 15-22)',
+    'Sécurité des traitements adaptée au risque (art. 32)',
+    'Gestion et notification des violations de données (art. 33-34)',
+    'Analyses d\'impact (AIPD) pour les traitements à risque élevé (art. 35)',
+    'Encadrement contractuel des sous-traitants (art. 28)',
+    'Désignation et positionnement du DPO le cas échéant',
+  ],
+}
+
+const CONTROLE_INTERNE: ProgrammeAuditType = {
+  id: 'CONTROLE_INTERNE', nom: 'Dispositif de contrôle interne — programme type',
+  points: [
+    'Contrôles permanents de 1er et 2e niveau formalisés et tracés',
+    'Indépendance et moyens de la fonction de contrôle périodique (3e ligne)',
+    'Rôles de l\'organe de surveillance et des dirigeants effectifs',
+    'Cartographie des risques tenue à jour et alimentant le plan de contrôle',
+    'Plan de contrôle pluriannuel et couverture des activités/risques',
+    'Rapport annuel de contrôle interne et information de l\'organe de surveillance',
+    'Suivi des recommandations et des plans d\'action',
+    'Externalisation : registre, criticité et clauses de réversibilité',
+  ],
+}
+
+export const PROGRAMMES_AUDIT: ProgrammeAuditType[] = [
+  ISO27001, DORA, LCB_FT, SANCTIONS_GEL, CREDIT_OCTROI, RGPD, CONTROLE_INTERNE,
+]
 
 /** Retourne un programme type par identifiant, ou undefined. */
 export function getProgrammeAudit(id: string): ProgrammeAuditType | undefined {

--- a/src/lib/controles-catalogue.ts
+++ b/src/lib/controles-catalogue.ts
@@ -60,7 +60,58 @@ const DORA: CatalogueControle = {
   ],
 }
 
-export const CATALOGUES_CONTROLES: CatalogueControle[] = [ISO27001, DORA]
+// ── Socle LCB-FT (CMF art. L.561-1 s.) — non-cyber ───────────────────────────
+const LCB_FT: CatalogueControle = {
+  id: 'LCB_FT', nom: 'Dispositif LCB-FT — socle', referentielCode: 'LCB_FT',
+  controles: [
+    { intitule: 'Actualisation de la classification des risques BC-FT', description: 'Vérifier que la classification des risques (clientèle, produits, canaux, géographie) est à jour et approuvée.', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'LCB_FT', exigenceRefs: ['LCBFT-1'], checklist: ['Classification documentée', 'Revue < 12 mois', 'Validée par le responsable LCB-FT'] },
+    { intitule: 'Contrôle des dossiers d\'entrée en relation (KYC)', description: 'Contrôler par sondage la complétude de l\'identification client et bénéficiaire effectif à l\'entrée en relation.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'LCB_FT', exigenceRefs: ['LCBFT-2'], checklist: ['Identité vérifiée (pièces)', 'Bénéficiaire effectif identifié', 'Objet/nature de la relation renseignés'] },
+    { intitule: 'Vigilance constante sur les opérations', description: 'Vérifier le traitement des alertes de suivi des opérations et l\'actualisation de la connaissance client.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'LCB_FT', exigenceRefs: ['LCBFT-3'], checklist: ['Alertes traitées dans les délais', 'Dossiers KYC actualisés', 'Opérations atypiques justifiées'] },
+    { intitule: 'Détection et suivi des PPE', description: 'Contrôler l\'identification des personnes politiquement exposées et l\'application des mesures de vigilance renforcée.', niveau: 'N2', periodicite: 'TRIMESTRIEL', referentielCode: 'LCB_FT', exigenceRefs: ['LCBFT-4'], checklist: ['Screening PPE en place', 'Vigilance renforcée appliquée', 'Validation hiérarchique tracée'] },
+    { intitule: 'Qualité et délais des déclarations de soupçon', description: 'Contrôler la détection, l\'analyse et la transmission à Tracfin des opérations suspectes.', niveau: 'N2', periodicite: 'TRIMESTRIEL', referentielCode: 'LCB_FT', exigenceRefs: ['LCBFT-5'], checklist: ['Analyses formalisées', 'Déclarations transmises sans délai', 'Traçabilité des décisions de non-déclaration'] },
+    { intitule: 'Conservation des documents LCB-FT', description: 'Vérifier la conservation des pièces d\'identification et documents d\'opérations pendant la durée légale.', niveau: 'N1', periodicite: 'ANNUEL', referentielCode: 'LCB_FT', exigenceRefs: ['LCBFT-6'], checklist: ['Durée de conservation respectée (5 ans)', 'Pièces accessibles et intègres'] },
+    { intitule: 'Réalisation des formations LCB-FT', description: 'Contrôler la réalisation et la couverture des formations des personnels exposés.', niveau: 'N1', periodicite: 'ANNUEL', referentielCode: 'LCB_FT', exigenceRefs: ['LCBFT-7'], checklist: ['Formation réalisée sur la période', 'Taux de couverture suivi', 'Nouveaux arrivants formés'] },
+  ],
+}
+
+// ── Socle gel des avoirs & sanctions (Règl. UE + DG Trésor) — non-cyber ───────
+const SANCTIONS_GEL: CatalogueControle = {
+  id: 'SANCTIONS_GEL', nom: 'Gel des avoirs & sanctions — socle', referentielCode: 'SANCTIONS_GEL',
+  controles: [
+    { intitule: 'Filtrage de la base clients contre les listes', description: 'Vérifier le rescreening de la base clients à chaque mise à jour des listes de sanctions (UE/ONU/OFAC).', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'SANCTIONS_GEL', exigenceRefs: ['GEL-1'], checklist: ['Listes à jour', 'Rescreening réalisé après mise à jour', 'Correspondances tracées'] },
+    { intitule: 'Filtrage des transactions', description: 'Contrôler le filtrage des opérations (virements, correspondants) contre les mesures restrictives.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'SANCTIONS_GEL', exigenceRefs: ['GEL-2'], checklist: ['Filtrage actif sur les flux', 'Paramétrage revu', 'Alertes journalisées'] },
+    { intitule: 'Traitement des alertes de correspondance', description: 'Vérifier l\'analyse et la levée/qualification des correspondances dans des délais maîtrisés.', niveau: 'N2', periodicite: 'TRIMESTRIEL', referentielCode: 'SANCTIONS_GEL', exigenceRefs: ['GEL-3'], checklist: ['Délais de traitement respectés', 'Analyses formalisées', 'Escalade des vrais positifs'] },
+    { intitule: 'Mise en œuvre du gel sans délai', description: 'Contrôler la capacité à geler les fonds sans délai et à déclarer à la DG Trésor.', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'SANCTIONS_GEL', exigenceRefs: ['GEL-4', 'GEL-5'], checklist: ['Procédure de gel testée', 'Gel exécutable sans délai', 'Déclaration DG Trésor tracée'] },
+  ],
+}
+
+// ── Socle octroi & suivi des crédits (EBA/GL/2020/06) — non-cyber ─────────────
+const CREDIT_OCTROI: CatalogueControle = {
+  id: 'CREDIT_OCTROI', nom: 'Octroi & suivi des crédits — socle', referentielCode: 'CREDIT_OCTROI',
+  controles: [
+    { intitule: 'Analyse de la capacité de remboursement', description: 'Contrôler par sondage la réalisation et la qualité de l\'analyse de solvabilité au dossier.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'CREDIT_OCTROI', exigenceRefs: ['CRED-1'], checklist: ['Analyse de solvabilité présente', 'Revenus/charges vérifiés', 'Taux d\'endettement calculé'] },
+    { intitule: 'Respect des délégations d\'octroi', description: 'Vérifier que les décisions d\'octroi respectent les schémas de délégation et les limites.', niveau: 'N2', periodicite: 'TRIMESTRIEL', referentielCode: 'CREDIT_OCTROI', exigenceRefs: ['CRED-2'], checklist: ['Décision dans la limite de délégation', 'Dépassements escaladés', 'Traçabilité de la décision'] },
+    { intitule: 'Complétude du dossier et des garanties', description: 'Contrôler la complétude du dossier de crédit et la formalisation des garanties.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'CREDIT_OCTROI', exigenceRefs: ['CRED-3'], checklist: ['Pièces obligatoires présentes', 'Garanties évaluées et formalisées', 'Assurances vérifiées'] },
+    { intitule: 'Passage en comité des engagements', description: 'Vérifier le passage en comité des dossiers au-delà des seuils définis.', niveau: 'N2', periodicite: 'TRIMESTRIEL', referentielCode: 'CREDIT_OCTROI', exigenceRefs: ['CRED-4'], checklist: ['Seuils de passage respectés', 'Comptes rendus de comité', 'Avis motivés tracés'] },
+    { intitule: 'Revue des encours et détection des impayés', description: 'Contrôler la revue périodique des encours et la détection précoce des impayés.', niveau: 'N1', periodicite: 'MENSUEL', referentielCode: 'CREDIT_OCTROI', exigenceRefs: ['CRED-5'], checklist: ['Revue des encours réalisée', 'Impayés détectés et suivis', 'Provisions ajustées'] },
+  ],
+}
+
+// ── Socle RGPD (UE 2016/679) — non-cyber ─────────────────────────────────────
+const RGPD: CatalogueControle = {
+  id: 'RGPD', nom: 'RGPD — socle', referentielCode: 'RGPD',
+  controles: [
+    { intitule: 'Tenue du registre des traitements', description: 'Vérifier l\'exhaustivité et l\'actualisation du registre des activités de traitement (art. 30).', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'RGPD', exigenceRefs: ['RGPD-30'], checklist: ['Registre exhaustif', 'Finalités et durées renseignées', 'Revue < 12 mois'] },
+    { intitule: 'Traitement des demandes d\'exercice des droits', description: 'Contrôler le traitement des demandes (accès, effacement, opposition) dans les délais (art. 15-22).', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'RGPD', exigenceRefs: ['RGPD-15'], checklist: ['Demandes tracées', 'Délai d\'un mois respecté', 'Réponses formalisées'] },
+    { intitule: 'Gestion des violations de données', description: 'Vérifier la détection, la qualification et la notification des violations (art. 33-34).', niveau: 'N1', periodicite: 'TRIMESTRIEL', referentielCode: 'RGPD', exigenceRefs: ['RGPD-33'], checklist: ['Registre des violations tenu', 'Notification CNIL < 72 h', 'Information des personnes si requise'] },
+    { intitule: 'Encadrement des sous-traitants', description: 'Contrôler la présence de clauses et garanties suffisantes pour les sous-traitants (art. 28).', niveau: 'N2', periodicite: 'SEMESTRIEL', referentielCode: 'RGPD', exigenceRefs: ['RGPD-28'], checklist: ['Contrats art. 28 en place', 'Garanties évaluées', 'Sous-traitants ultérieurs encadrés'] },
+    { intitule: 'Réalisation des analyses d\'impact (AIPD)', description: 'Vérifier la réalisation d\'une AIPD pour les traitements à risque élevé (art. 35).', niveau: 'N2', periodicite: 'ANNUEL', referentielCode: 'RGPD', exigenceRefs: ['RGPD-35'], checklist: ['Traitements à risque identifiés', 'AIPD réalisées', 'Mesures d\'atténuation suivies'] },
+  ],
+}
+
+export const CATALOGUES_CONTROLES: CatalogueControle[] = [
+  ISO27001, DORA, LCB_FT, SANCTIONS_GEL, CREDIT_OCTROI, RGPD,
+]
 
 /** Retourne un socle par son identifiant, ou undefined. */
 export function getCatalogueControle(id: string): CatalogueControle | undefined {


### PR DESCRIPTION
## Contexte
Suite de l'unification des référentiels (Phases 1-3 mergées). La Phase 3 a livré les cadres GRC non-cyber avec leurs exigences ; cette PR les rend **immédiatement actionnables** — des socles de contrôles et programmes d'audit **prêts-à-l'emploi, importables en 1 clic**.

## Contrôles-types (`controles-catalogue`)
Nouveaux socles rattachés aux exigences **réelles** des cadres GRC → la conformité dérivée (couverture) se câble d'office :
- **LCB-FT** (7 contrôles) — classification des risques, KYC, vigilance constante, PPE, déclarations de soupçon, conservation, formation.
- **Gel des avoirs & sanctions** (4) — filtrage listes/transactions, traitement des alertes, gel sans délai + DG Trésor.
- **Octroi & suivi des crédits** (5) — capacité de remboursement, délégations, garanties, comité des engagements, impayés.
- **RGPD** (5) — registre, droits des personnes, violations, sous-traitants, AIPD.

Chaque contrôle a niveau (N1/N2), périodicité, checklist et `exigenceRefs`. **Nouveau test** : chaque `exigenceRef` existe *réellement* dans le cadre GRC (pas de référence morte).

## Programmes d'audit-types (`audit-programmes-catalogue`)
+ **LCB-FT · Gel des avoirs · Octroi de crédit · RGPD · Dispositif de contrôle interne** (programmes de points de revue).

## UI
- `ControlesManager` : liste des socles **dynamique** (fin du hardcode ISO/DORA) → les nouveaux apparaissent tout seuls.
- `AuditManager` : listait déjà dynamiquement.

## Vérification
`tsc` clean · **1442 tests** verts (dont l'invariant exigences réelles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)