### PR TITLE
feat(referentiels): jointure visible RA ↔ conformité dans la couverture

### DIFF
--- a/src/__tests__/unit/lib/couverture-referentiel.test.ts
+++ b/src/__tests__/unit/lib/couverture-referentiel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { synthetiserCouverture, type ControleCouvrant, type ConstatExigence } from '../../../lib/couverture-referentiel'
+import { synthetiserCouverture, croiserApplicationsAnalyses, type ControleCouvrant, type ConstatExigence } from '../../../lib/couverture-referentiel'
 
 const exigences = [{ ref: 'A1' }, { ref: 'A2' }, { ref: 'A3' }, { ref: 'A4' }]
 
@@ -59,5 +59,33 @@ describe('synthetiserCouverture', () => {
     expect(c.synthese.couverts).toBe(2)
     expect(c.synthese.tauxCouverture).toBe(50)
     expect(c.synthese.tauxConformite).toBe(50)
+  })
+})
+
+describe('croiserApplicationsAnalyses — jointure RA ↔ référentiel', () => {
+  const analyses = [
+    { id: 'a1', nom: 'Analyse SI', referentiels: [{ code: 'ISO27001', etatApplication: 'APPLIQUE' }, { nom: 'DORA', etatApplication: 'PARTIEL' }] },
+    { id: 'a2', nom: 'Analyse paiements', referentiels: [{ nom: 'DORA', code: 'DORA', applicable: false }] },
+    { id: 'a3', nom: 'Analyse RH', referentiels: [{ nom: 'ISO/IEC 27001:2022' }] }, // code résolu par le nom
+    { id: 'a4', nom: 'Analyse vide', referentiels: [] },
+  ]
+
+  it('compte les analyses appliquant un code + leur état (résolution nom→code incluse)', () => {
+    const r = croiserApplicationsAnalyses(analyses, 'ISO27001')
+    expect(r.total).toBe(2) // a1 (code) + a3 (résolu par le nom)
+    expect(r.appliques).toBe(2) // a1 APPLIQUE ; a3 défaut APPLIQUE
+    expect(r.analyses.map(a => a.analyseId).sort()).toEqual(['a1', 'a3'])
+  })
+
+  it('distingue appliqué / partiel / non appliqué', () => {
+    const r = croiserApplicationsAnalyses(analyses, 'DORA')
+    expect(r.total).toBe(2) // a1 (partiel) + a2 (non appliqué)
+    expect(r.partiels).toBe(1)
+    expect(r.nonAppliques).toBe(1)
+  })
+
+  it('retourne un total nul pour un code non appliqué', () => {
+    expect(croiserApplicationsAnalyses(analyses, 'LCB_FT').total).toBe(0)
+    expect(croiserApplicationsAnalyses([], 'ISO27001').total).toBe(0)
   })
 })

--- a/src/app/api/referentiels/couverture/route.ts
+++ b/src/app/api/referentiels/couverture/route.ts
@@ -8,7 +8,7 @@ import { getServerLocale } from '@/lib/i18n'
 import { type UserRole } from '@/lib/permissions'
 import { getExigencesFor } from '@/lib/referentiel.server'
 import { evaluerEfficacite } from '@/lib/controle'
-import { synthetiserCouverture, type ControleCouvrant, type ConstatExigence } from '@/lib/couverture-referentiel'
+import { synthetiserCouverture, croiserApplicationsAnalyses, type ControleCouvrant, type ConstatExigence } from '@/lib/couverture-referentiel'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
   if (!code) return NextResponse.json({ error: 'code_requis' }, { status: 400 })
   const locale = await getServerLocale()
 
-  const [exigences, controleRows, constatRows] = await Promise.all([
+  const [exigences, controleRows, constatRows, analyseRows] = await Promise.all([
     getExigencesFor(code, orgId, locale),
     prisma.controle.findMany({
       where: { organizationId: orgId, referentielCode: code },
@@ -38,6 +38,11 @@ export async function GET(req: NextRequest) {
     prisma.auditConstat.findMany({
       where: { organizationId: orgId, referentielCode: code },
       select: { exigenceRef: true, statut: true },
+    }),
+    // Jointure visible : analyses de risques appliquant ce référentiel (socle).
+    prisma.analyse.findMany({
+      where: { organizationId: orgId },
+      select: { id: true, nom: true, cadrage: { select: { referentiels: true } } },
     }),
   ])
 
@@ -52,5 +57,10 @@ export async function GET(req: NextRequest) {
   const nomByRef = new Map(exigences.map(e => [e.ref, e.nom]))
   const parExigence = cov.parExigence.map(e => ({ ...e, nom: nomByRef.get(e.ref) ?? e.ref }))
 
-  return NextResponse.json({ active: true, code, parExigence, synthese: cov.synthese })
+  const application = croiserApplicationsAnalyses(
+    analyseRows.map(a => ({ id: a.id, nom: a.nom, referentiels: a.cadrage?.referentiels ?? [] })),
+    code,
+  )
+
+  return NextResponse.json({ active: true, code, parExigence, synthese: cov.synthese, application })
 }

--- a/src/components/ReferentielsManager.tsx
+++ b/src/components/ReferentielsManager.tsx
@@ -9,6 +9,8 @@ import { DOMAINES, DOMAINE_META } from '@/lib/referentiel-domaines'
 
 interface CouvExigence { ref: string; nom: string; statut: string; nbControles: number; nbAnomaliesAudit: number }
 interface CouvSynthese { total: number; couverts: number; conformes: number; anomalies: number; nonCouverts: number; tauxCouverture: number; tauxConformite: number }
+interface AppAnalyse { analyseId: string; nom: string; etat: string }
+interface AppSynthese { total: number; appliques: number; partiels: number; nonAppliques: number; analyses: AppAnalyse[] }
 
 interface Ref {
   id?: string; code: string; nom: string; source: 'BUILTIN' | 'CUSTOM'
@@ -28,7 +30,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
   const [form, setForm] = useState({ ...emptyForm })
   const [err, setErr] = useState<string | null>(null)
   const [confirmDel, setConfirmDel] = useState<string | null>(null)
-  const [couv, setCouv] = useState<{ code: string; nom: string; parExigence: CouvExigence[]; synthese: CouvSynthese } | null>(null)
+  const [couv, setCouv] = useState<{ code: string; nom: string; parExigence: CouvExigence[]; synthese: CouvSynthese; application?: AppSynthese } | null>(null)
   const [couvLoading, setCouvLoading] = useState(false)
   const [seeding, setSeeding] = useState(false)
   const [filterDomaine, setFilterDomaine] = useState<string>('')
@@ -40,7 +42,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
     setCouvLoading(true)
     const d = await fetch(`/api/referentiels/couverture?code=${encodeURIComponent(code)}`).then(x => x.ok ? x.json() : null).catch(() => null)
     setCouvLoading(false)
-    if (d?.active) setCouv({ code, nom, parExigence: d.parExigence ?? [], synthese: d.synthese })
+    if (d?.active) setCouv({ code, nom, parExigence: d.parExigence ?? [], synthese: d.synthese, application: d.application })
   }
 
   async function reload() {
@@ -301,6 +303,31 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
                 <div className="card p-3"><div className={`text-xl font-bold tabular-nums ${couv.synthese.anomalies > 0 ? 'text-red-600 dark:text-red-400' : ''}`}>{couv.synthese.anomalies}</div><div className="text-[11px] text-gray-500">{r.covKpi.anomalies}</div></div>
                 <div className="card p-3"><div className="text-xl font-bold tabular-nums">{couv.synthese.tauxCouverture}%</div><div className="text-[11px] text-gray-500">{r.covKpi.taux}</div></div>
               </div>
+              {/* Jointure visible : application du référentiel dans les analyses de risques */}
+              {couv.application && !couvLoading && (
+                <div className="mb-4 border border-gray-100 dark:border-gray-700 rounded-lg p-3">
+                  <p className="text-xs font-semibold text-gray-600 dark:text-gray-300 mb-1.5">{r.covApp.title}</p>
+                  {couv.application.total === 0 ? (
+                    <p className="text-xs text-gray-400">{r.covApp.none}</p>
+                  ) : (
+                    <>
+                      <div className="flex flex-wrap gap-1.5 text-[11px] mb-2">
+                        <span className="px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-300">{r.covApp.applique} · {couv.application.appliques}</span>
+                        <span className="px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">{r.covApp.partiel} · {couv.application.partiels}</span>
+                        <span className="px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300">{r.covApp.nonApplique} · {couv.application.nonAppliques}</span>
+                      </div>
+                      <div className="space-y-1">
+                        {couv.application.analyses.map(a => (
+                          <div key={a.analyseId} className="flex items-center gap-2 text-sm">
+                            <span className={`w-2 h-2 rounded-full shrink-0 ${APP_DOT[a.etat] ?? 'bg-gray-300'}`} aria-hidden="true" />
+                            <span className="flex-1 truncate text-gray-700 dark:text-gray-200" title={a.nom}>{a.nom}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
               {couvLoading ? <div className="text-center py-6 text-gray-400 text-sm">{t.loading}</div>
                 : couv.parExigence.length === 0 ? <div className="text-center py-6 text-gray-400 text-sm">{r.covEmpty}</div>
                 : (
@@ -332,4 +359,11 @@ const COV_BADGE: Record<string, string> = {
   CONFORME: 'bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-300',
   PARTIEL: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300',
   ANOMALIE: 'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-300',
+}
+
+// Pastille d'état d'application d'un référentiel dans une analyse (socle).
+const APP_DOT: Record<string, string> = {
+  APPLIQUE: 'bg-green-500',
+  PARTIEL: 'bg-amber-500',
+  NON_APPLIQUE: 'bg-red-500',
 }

--- a/src/lib/couverture-referentiel.ts
+++ b/src/lib/couverture-referentiel.ts
@@ -4,6 +4,9 @@
 // visent — « conformité prouvée par les contrôles », pas seulement déclarée.
 // Logique PURE et testée.
 
+import { resolveReferentielCode } from './referentiel-catalogue'
+import { etatSocleFromEntry, type EtatSocle } from './socle-etat'
+
 export type CouvertureStatut = 'NON_COUVERT' | 'CONFORME' | 'PARTIEL' | 'ANOMALIE'
 
 export type Efficacite = 'FORTE' | 'MOYENNE' | 'FAIBLE' | null
@@ -95,5 +98,56 @@ export function synthetiserCouverture(
   return {
     parExigence,
     synthese: { total, couverts, conformes, anomalies, nonCouverts, tauxCouverture: pct(couverts), tauxConformite: pct(conformes) },
+  }
+}
+
+// ─── Jointure visible : application d'un référentiel dans les analyses de risques ─
+// Croise un référentiel (par CODE) avec les analyses qui le déclarent dans leur
+// socle (Cadrage.referentiels), et leur état d'application (vert/orange/rouge).
+// Rend visible « ce référentiel est-il appliqué en analyse ET couvert par les
+// contrôles ? » — les deux faces de la même unité. PURE et testée.
+
+export interface AnalyseApplication {
+  analyseId: string
+  nom: string
+  etat: EtatSocle
+}
+
+export interface ApplicationSynthese {
+  total: number // analyses appliquant ce référentiel
+  appliques: number
+  partiels: number
+  nonAppliques: number
+  analyses: AnalyseApplication[]
+}
+
+interface AnalyseAvecReferentiels {
+  id: string
+  nom: string
+  referentiels: unknown // Cadrage.referentiels : [{nom, code?, etatApplication?, applicable?, ecarts?}]
+}
+
+/**
+ * Analyses appliquant le référentiel `code` (résolution nom→code incluse pour les
+ * socles historiques), avec leur état d'application. Une analyse compte une seule
+ * fois (première entrée correspondante).
+ */
+export function croiserApplicationsAnalyses(
+  analyses: AnalyseAvecReferentiels[],
+  code: string,
+): ApplicationSynthese {
+  const out: AnalyseApplication[] = []
+  for (const a of analyses ?? []) {
+    const refs = Array.isArray(a.referentiels) ? (a.referentiels as Record<string, unknown>[]) : []
+    const entry = refs.find(r => r && typeof r === 'object' && resolveReferentielCode(r as { code?: string | null; nom?: unknown }) === code)
+    if (!entry) continue
+    out.push({ analyseId: a.id, nom: a.nom, etat: etatSocleFromEntry(entry) })
+  }
+  return {
+    total: out.length,
+    appliques: out.filter(a => a.etat === 'APPLIQUE').length,
+    partiels: out.filter(a => a.etat === 'PARTIEL').length,
+    nonAppliques: out.filter(a => a.etat === 'NON_APPLIQUE').length,
+    analyses: out,
   }
 }

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1643,6 +1643,7 @@ export const de: Translations = {
     couvertureTitle: 'Abgeleitete Konformität — Abdeckung durch reale Kontrollen',
     covKpi: { couverts: 'Abgedeckt', conformes: 'Konform', anomalies: 'Anomalien', taux: 'Abdeckungsgrad' },
     covStatut: { NON_COUVERT: 'Nicht abgedeckt', CONFORME: 'Konform', PARTIEL: 'Teilweise', ANOMALIE: 'Anomalie' },
+    covApp: { title: 'Anwendung in Risikoanalysen', none: 'Keine Analyse wendet dieses Rahmenwerk an', applique: 'Angewendet', partiel: 'Teilweise', nonApplique: 'Nicht angewendet' },
     covControles: '{n} Kontrolle(n)',
     covEmpty: 'Keine Anforderung in diesem Referenzrahmen.',
   },

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1643,6 +1643,7 @@ export const en: Translations = {
     couvertureTitle: 'Derived compliance — coverage by actual controls',
     covKpi: { couverts: 'Covered', conformes: 'Compliant', anomalies: 'Anomalies', taux: 'Coverage rate' },
     covStatut: { NON_COUVERT: 'Not covered', CONFORME: 'Compliant', PARTIEL: 'Partial', ANOMALIE: 'Anomaly' },
+    covApp: { title: 'Application in risk analyses', none: 'No analysis applies this framework', applique: 'Applied', partiel: 'Partial', nonApplique: 'Not applied' },
     covControles: '{n} control(s)',
     covEmpty: 'No requirement in this framework.',
   },

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1643,6 +1643,7 @@ export const es: Translations = {
     couvertureTitle: 'Conformidad derivada — cobertura por los controles reales',
     covKpi: { couverts: 'Cubiertas', conformes: 'Conformes', anomalies: 'Anomalías', taux: 'Tasa de cobertura' },
     covStatut: { NON_COUVERT: 'Sin cubrir', CONFORME: 'Conforme', PARTIEL: 'Parcial', ANOMALIE: 'Anomalía' },
+    covApp: { title: 'Aplicación en los análisis de riesgos', none: 'Ningún análisis aplica este marco', applique: 'Aplicado', partiel: 'Parcial', nonApplique: 'No aplicado' },
     covControles: '{n} control(es)',
     covEmpty: 'Ningún requisito en este marco.',
   },

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1666,6 +1666,7 @@ export const fr = {
     couvertureTitle: 'Conformité dérivée — couverture par les contrôles réels',
     covKpi: { couverts: 'Couvertes', conformes: 'Conformes', anomalies: 'Anomalies', taux: 'Taux de couverture' },
     covStatut: { NON_COUVERT: 'Non couvert', CONFORME: 'Conforme', PARTIEL: 'Partiel', ANOMALIE: 'Anomalie' },
+    covApp: { title: 'Application dans les analyses de risques', none: 'Aucune analyse n’applique ce référentiel', applique: 'Appliqué', partiel: 'Partiel', nonApplique: 'Non appliqué' },
     covControles: '{n} contrôle(s)',
     covEmpty: 'Aucune exigence dans ce référentiel.',
   },

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1643,6 +1643,7 @@ export const it: Translations = {
     couvertureTitle: 'Conformità derivata — copertura dai controlli reali',
     covKpi: { couverts: 'Coperte', conformes: 'Conformi', anomalies: 'Anomalie', taux: 'Tasso di copertura' },
     covStatut: { NON_COUVERT: 'Non coperto', CONFORME: 'Conforme', PARTIEL: 'Parziale', ANOMALIE: 'Anomalia' },
+    covApp: { title: 'Applicazione nelle analisi dei rischi', none: 'Nessuna analisi applica questo quadro', applique: 'Applicato', partiel: 'Parziale', nonApplique: 'Non applicato' },
     covControles: '{n} controlli',
     covEmpty: 'Nessun requisito in questo riferimento.',
   },


### PR DESCRIPTION
## Contexte
Axe **1/3** de la suite du chantier d'unification. Rendre **visible** que les analyses de risques, les contrôles et la conformité tournent sur les mêmes référentiels.

## Ce que ça montre
Le panneau de **couverture** d'un référentiel (`/referentiels` → icône jauge) affiche désormais, en plus de la conformité dérivée par exigence, une section **« Application dans les analyses de risques »** :
- combien d'analyses appliquent ce référentiel dans leur socle,
- réparties en **appliqué / partiel / non appliqué**,
- la liste des analyses avec une pastille d'état.

→ On lit d'un coup d'œil : *ce référentiel est-il appliqué en analyse **et** couvert par les contrôles ?* — les deux faces de la même unité, par **code**.

## Changements
- **`croiserApplicationsAnalyses`** (pur, testé) : résout le code de chaque socle d'analyse (nom→code inclus pour l'historique) et agrège l'état d'application.
- **Route couverture** : renvoie `application` (charge les analyses de l'org + `Cadrage.referentiels`).
- **UI** : nouvelle section dans la modale de couverture ; i18n ×5.

## Vérification
`tsc` clean · **1445 tests** verts (3 nouveaux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)