### PR TITLE
feat(referentiels): localisation i18n des libellés de domaine (5 langues)

### DIFF
--- a/src/components/ReferentielsManager.tsx
+++ b/src/components/ReferentielsManager.tsx
@@ -100,6 +100,10 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
   const domainesPresents = DOMAINES.filter(d => refs.some(x => x.domaine === d))
   const hasPolitique = refs.some(x => x.source === 'CUSTOM' && (x.type === 'PSSI' || x.type === 'POLITIQUE'))
 
+  // Libellé localisé d'un domaine (fallback sur le libellé canonique FR).
+  const dLabel = (d: string) => (r.domaines as Record<string, string> | undefined)?.[d]
+    ?? DOMAINE_META[d as keyof typeof DOMAINE_META]?.label ?? d
+
   const typeBadge = (type: string, source: string) => (
     <span className={`text-[11px] px-2 py-0.5 rounded-full font-medium ${source === 'BUILTIN' ? 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300' : 'bg-ebios-100 text-ebios-700 dark:bg-ebios-500/15 dark:text-ebios-300'}`}>
       {source === 'CUSTOM' ? (r.typeOpt[type as keyof typeof r.typeOpt] ?? type) : type}
@@ -131,7 +135,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
           <select className="text-sm px-2.5 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
             value={filterDomaine} onChange={e => setFilterDomaine(e.target.value)}>
             <option value="">{r.tousDomaines}</option>
-            {domainesPresents.map(d => <option key={d} value={d}>{DOMAINE_META[d].label}</option>)}
+            {domainesPresents.map(d => <option key={d} value={d}>{dLabel(d)}</option>)}
           </select>
         </div>
       )}
@@ -167,7 +171,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
               </select></label>
             <label className="block"><span className="text-sm text-gray-700 dark:text-gray-300">{r.champ.domaine}</span>
               <select className={`mt-1 ${inputCls}`} value={form.domaine} onChange={e => setForm({ ...form, domaine: e.target.value })}>
-                {DOMAINES.map(d => <option key={d} value={d}>{DOMAINE_META[d].label}</option>)}
+                {DOMAINES.map(d => <option key={d} value={d}>{dLabel(d)}</option>)}
               </select></label>
             <label className="block"><span className="text-sm text-gray-700 dark:text-gray-300">{r.champ.version}</span>
               <input className={`mt-1 ${inputCls}`} value={form.version} onChange={e => setForm({ ...form, version: e.target.value })} placeholder="v1.0" /></label>
@@ -225,7 +229,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
                         {typeBadge(x.type, x.source)}
                         {x.domaine && x.domaine !== 'SECURITE_SI' && (
                           <span className="text-[11px] px-2 py-0.5 rounded-full font-medium bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
-                            {DOMAINE_META[x.domaine as keyof typeof DOMAINE_META]?.label ?? x.domaine}
+                            {dLabel(x.domaine)}
                           </span>
                         )}
                       </div>
@@ -268,7 +272,7 @@ export default function ReferentielsManager({ canManage }: { canManage: boolean 
                       <span className="font-medium text-gray-800 dark:text-gray-100">{x.nom}</span>
                       {x.domaine && x.domaine !== 'SECURITE_SI' && (
                         <span className="text-[11px] px-2 py-0.5 rounded-full font-medium bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
-                          {DOMAINE_META[x.domaine as keyof typeof DOMAINE_META]?.label ?? x.domaine}
+                          {dLabel(x.domaine)}
                         </span>
                       )}
                     </div>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1629,6 +1629,7 @@ export const de: Translations = {
     yours: 'Ihre Referenzrahmen',
     builtin: 'Gelieferte Rahmenwerke (nur Lesen)',
     tousDomaines: 'Alle Bereiche',
+    domaines: { SECURITE_SI: 'IT-Sicherheit & digitale Resilienz', PROTECTION_DONNEES: 'Datenschutz', LCB_FT: 'Geldwäsche- & Terrorismusbekämpfung', SANCTIONS_GEL: 'Sanktionen & Vermögenseinfrierung', PROTECTION_CLIENTELE: 'Kundenschutz', DEONTOLOGIE: 'Ethik & Korruptionsbekämpfung', COMPTABLE_FINANCIER: 'Rechnungswesen & Finanzen', CREDIT_CONTREPARTIE: 'Kredit & Gegenpartei', RISQUE_OPERATIONNEL: 'Operationelles Risiko & Auslagerung', GOUVERNANCE_CONTROLE: 'Governance & interne Kontrolle', AUTRE: 'Sonstige / intern' },
     empty: 'Noch kein eigener Referenzrahmen. Erstellen Sie Ihre Sicherheitsleitlinie oder interne Richtlinien und deren Anforderungen.',
     readOnly: 'Nur Lesezugriff — die Pflege der Referenzrahmen obliegt der Governance (CISO / Compliance).',
     champ: { code: 'Code', nom: 'Name', type: 'Typ', domaine: 'Bereich', version: 'Version', description: 'Beschreibung', exigences: 'Anforderungen (Kontrollpunkte)', missions: 'Missionen (Sicherheitsziele)' },

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1629,6 +1629,7 @@ export const en: Translations = {
     yours: 'Your frameworks',
     builtin: 'Built-in frameworks (read only)',
     tousDomaines: 'All domains',
+    domaines: { SECURITE_SI: 'IT security & digital resilience', PROTECTION_DONNEES: 'Data protection', LCB_FT: 'Anti-money laundering & CFT', SANCTIONS_GEL: 'Sanctions & asset freezing', PROTECTION_CLIENTELE: 'Customer protection', DEONTOLOGIE: 'Ethics & anti-bribery', COMPTABLE_FINANCIER: 'Accounting & financial', CREDIT_CONTREPARTIE: 'Credit & counterparty', RISQUE_OPERATIONNEL: 'Operational risk & outsourcing', GOUVERNANCE_CONTROLE: 'Governance & internal control', AUTRE: 'Other / internal' },
     empty: 'No custom framework yet. Create your ISSP or internal policies and their requirements.',
     readOnly: 'Read only — framework management belongs to governance (CISO / compliance).',
     champ: { code: 'Code', nom: 'Name', type: 'Type', domaine: 'Domain', version: 'Version', description: 'Description', exigences: 'Requirements (control points)', missions: 'Missions (security objectives)' },

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1629,6 +1629,7 @@ export const es: Translations = {
     yours: 'Sus marcos',
     builtin: 'Marcos incluidos (solo lectura)',
     tousDomaines: 'Todos los dominios',
+    domaines: { SECURITE_SI: 'Seguridad TI y resiliencia digital', PROTECTION_DONNEES: 'Protección de datos', LCB_FT: 'Prevención de blanqueo y FT', SANCTIONS_GEL: 'Sanciones y congelación de activos', PROTECTION_CLIENTELE: 'Protección del cliente', DEONTOLOGIE: 'Deontología y anticorrupción', COMPTABLE_FINANCIER: 'Contable y financiero', CREDIT_CONTREPARTIE: 'Crédito y contraparte', RISQUE_OPERATIONNEL: 'Riesgo operacional y externalización', GOUVERNANCE_CONTROLE: 'Gobernanza y control interno', AUTRE: 'Otro / interno' },
     empty: 'Ningún marco propio. Cree su PSSI o sus políticas internas y sus requisitos.',
     readOnly: 'Solo lectura — la gestión de los marcos corresponde a la gobernanza (RSSI / cumplimiento).',
     champ: { code: 'Código', nom: 'Nombre', type: 'Tipo', domaine: 'Dominio', version: 'Versión', description: 'Descripción', exigences: 'Requisitos (puntos de control)', missions: 'Misiones (objetivos de seguridad)' },

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1652,6 +1652,7 @@ export const fr = {
     yours: 'Vos référentiels',
     builtin: 'Cadres livrés (lecture seule)',
     tousDomaines: 'Tous les domaines',
+    domaines: { SECURITE_SI: 'Sécurité SI & résilience numérique', PROTECTION_DONNEES: 'Protection des données', LCB_FT: 'Lutte anti-blanchiment & FT', SANCTIONS_GEL: 'Sanctions & gel des avoirs', PROTECTION_CLIENTELE: 'Protection de la clientèle', DEONTOLOGIE: 'Déontologie & anticorruption', COMPTABLE_FINANCIER: 'Comptable & financier', CREDIT_CONTREPARTIE: 'Crédit & contrepartie', RISQUE_OPERATIONNEL: 'Risque opérationnel & externalisation', GOUVERNANCE_CONTROLE: 'Gouvernance & contrôle interne', AUTRE: 'Autre / interne' },
     empty: 'Aucun référentiel propre. Créez votre PSSI ou vos politiques internes et leurs exigences.',
     readOnly: 'Lecture seule — la tenue des référentiels relève de la gouvernance (RSSI / conformité).',
     champ: { code: 'Code', nom: 'Nom', type: 'Type', domaine: 'Domaine', version: 'Version', description: 'Description', exigences: 'Exigences (points de contrôle)', missions: 'Missions (objectifs de sécurité)' },

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1629,6 +1629,7 @@ export const it: Translations = {
     yours: 'I tuoi riferimenti',
     builtin: 'Quadri forniti (sola lettura)',
     tousDomaines: 'Tutti i domini',
+    domaines: { SECURITE_SI: 'Sicurezza IT e resilienza digitale', PROTECTION_DONNEES: 'Protezione dei dati', LCB_FT: 'Antiriciclaggio e FT', SANCTIONS_GEL: 'Sanzioni e congelamento dei beni', PROTECTION_CLIENTELE: 'Protezione della clientela', DEONTOLOGIE: 'Deontologia e anticorruzione', COMPTABLE_FINANCIER: 'Contabile e finanziario', CREDIT_CONTREPARTIE: 'Credito e controparte', RISQUE_OPERATIONNEL: 'Rischio operativo ed esternalizzazione', GOUVERNANCE_CONTROLE: 'Governance e controllo interno', AUTRE: 'Altro / interno' },
     empty: 'Nessun riferimento proprio. Crea la tua PSSI o le tue politiche interne e i loro requisiti.',
     readOnly: 'Sola lettura — la gestione dei riferimenti spetta alla governance (RSSI / conformità).',
     champ: { code: 'Codice', nom: 'Nome', type: 'Tipo', domaine: 'Dominio', version: 'Versione', description: 'Descrizione', exigences: 'Requisiti (punti di controllo)', missions: 'Missioni (obiettivi di sicurezza)' },


### PR DESCRIPTION
## Contexte
Axe **3/3** de la suite d'unification. Les libellés des **11 domaines de filière** étaient affichés en FR uniquement (filtre, sélecteur, badges). Ils sont désormais **traduits fr/en/de/es/it**.

## Changements
- **i18n ×5** : nouveau bloc `referentiels.domaines` (11 clés — Sécurité SI, protection des données, LCB-FT, sanctions & gel, protection clientèle, déontologie, comptable, crédit, risque opérationnel, gouvernance, autre).
- **`ReferentielsManager`** : helper `dLabel` (i18n → fallback sur le libellé canonique `DOMAINE_META`) appliqué au filtre par domaine, au sélecteur du formulaire et aux badges de filière (custom + builtin).

`DOMAINE_META` reste la source canonique (fallback). Le **contenu des exigences** non-cyber reste FR (produit bancaire français) — hors scope de cet axe.

## Vérification
`tsc` clean · **1445 tests** verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)