### PR TITLE
fix(atelier2): cartographie SR/OV — pertinence source + clarté (couples numérotés)

### DIFF
--- a/src/__tests__/unit/lib/sr-ov-radar.test.ts
+++ b/src/__tests__/unit/lib/sr-ov-radar.test.ts
@@ -29,18 +29,23 @@ describe('sr-ov-radar (cartographie des couples SR/OV, EXI_M2_09)', () => {
       expect(couples.map(c => c.ovNom)).toEqual(['Rançon', 'Revente'])
     })
 
-    it('reporte la catégorie de la source et la pertinence du couple (pertinenceOV prioritaire)', () => {
+    it('reporte la catégorie de la source ; le RAYON = pertinence de la SOURCE', () => {
       const [c1] = srOvCouples(sources)
       expect(c1.categorie).toBe('CYBERCRIMINEL')
       expect(c1.sourceNom).toBe('Cybercriminel')
       expect(c1.priorite).toBe('P1')
-      expect(c1.pertinence).toBe(4) // pertinenceOV
+      expect(c1.pertinence).toBe(3) // pertinence de la source (pertinenceOV non saisissable)
     })
 
-    it('retombe sur la pertinence de la source si le couple n\'en a pas', () => {
-      const src = [{ nom: 'X', categorie: 'AMATEUR', retenu: true, pertinence: 3,
-        objectifsVises: [{ id: 'z', nom: 'OV', priorite: 'P2' }] }]
-      expect(srOvCouples(src)[0].pertinence).toBe(3)
+    it('les deux couples d\'une même source partagent la pertinence de la source', () => {
+      const couples = srOvCouples(sources)
+      expect(couples[0].pertinence).toBe(couples[1].pertinence) // même source → même niveau
+    })
+
+    it('retombe sur pertinenceOV si la source n\'a pas de pertinence', () => {
+      const src = [{ nom: 'X', categorie: 'AMATEUR', retenu: true,
+        objectifsVises: [{ id: 'z', nom: 'OV', priorite: 'P2', pertinenceOV: 2 }] }]
+      expect(srOvCouples(src)[0].pertinence).toBe(2)
     })
   })
 

--- a/src/components/SrOvRadar.tsx
+++ b/src/components/SrOvRadar.tsx
@@ -1,6 +1,6 @@
 import {
   srOvCouples, coupleRadiusFor, categoriesInOrder, couplePointSector,
-  sectorLabelPoint, sectorCenterAngle, type SrOvCouple,
+  sectorCenterAngle, type SrOvCouple,
 } from '@/lib/sr-ov-radar'
 
 // Couleurs (hex) par catégorie de source — cohérentes avec CATEGORY_COLORS d'Atelier2.
@@ -17,9 +17,10 @@ const CAT_HEX: Record<string, string> = {
 }
 const hexFor = (cat: string) => CAT_HEX[cat] ?? '#6b7280'
 
-// Repère plus grand + marge pour les libellés de catégorie en périphérie.
+// Marge modérée (les libellés de catégorie ne sont plus dans le SVG → pas de
+// débordement ; l'identification se fait par la liste numérotée à droite).
 const SIZE = 300
-const PAD = 58
+const PAD = 22
 const VB = SIZE + PAD * 2
 const CX = VB / 2
 const CY = VB / 2
@@ -36,7 +37,7 @@ const GEOM = { cx: CX, cy: CY, rMax: RMAX }
  */
 export default function SrOvRadar({ sources, labels, pertinenceLabel, categoryLabels }: {
   sources: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
-  labels: { empty: string; p1: string; pertinence1: string; pertinence4: string }
+  labels: { empty: string; p1: string; pertinence1: string; pertinence4: string; couplesTitle: string; hint: string }
   pertinenceLabel: string
   categoryLabels: Record<string, string>
 }) {
@@ -52,13 +53,22 @@ export default function SrOvRadar({ sources, labels, pertinenceLabel, categoryLa
   const localIndex = new Map<string, number>()
   const localCount = new Map<string, number>()
   for (const cat of cats) localCount.set(cat, couples.filter(c => c.categorie === cat).length)
+  // Ordre stable : par catégorie (regroupe les couples d'une même source), puis
+  // par pertinence décroissante. Ce rang donne le NUMÉRO affiché (point + liste).
+  const ordered = [...couples].sort((a, b) => {
+    const ca = cats.indexOf(a.categorie) - cats.indexOf(b.categorie)
+    return ca !== 0 ? ca : b.pertinence - a.pertinence
+  })
+  const numById = new Map<string, number>()
+  ordered.forEach((c, i) => numById.set(c.id, i + 1))
+
   const seen: Record<string, number> = {}
   const placed = couples.map(c => {
     const i = seen[c.categorie] ?? 0
     seen[c.categorie] = i + 1
     localIndex.set(c.id, i)
     const ci = cats.indexOf(c.categorie)
-    return { c, ...couplePointSector(ci, nCats, i, localCount.get(c.categorie) ?? 1, c.pertinence, GEOM) }
+    return { c, num: numById.get(c.id) ?? 0, ...couplePointSector(ci, nCats, i, localCount.get(c.categorie) ?? 1, c.pertinence, GEOM) }
   })
   // P1 dessinés en dernier (au-dessus).
   placed.sort((a, b) => (a.c.priorite === 'P1' ? 1 : 0) - (b.c.priorite === 'P1' ? 1 : 0))
@@ -85,64 +95,56 @@ export default function SrOvRadar({ sources, labels, pertinenceLabel, categoryLa
             )
           })}
 
-          {/* Libellés de catégorie en périphérie de chaque secteur */}
-          {cats.map((cat, ci) => {
-            const { x, y, anchor } = sectorLabelPoint(ci, nCats, GEOM, 20)
-            return (
-              <g key={cat}>
-                <circle cx={anchor === 'end' ? x + 6 : anchor === 'start' ? x - 6 : x} cy={y - 3} r={3} fill={hexFor(cat)} />
-                <text x={x} y={y} textAnchor={anchor} dominantBaseline="middle"
-                  className="fill-gray-600 dark:fill-gray-300" fontSize={11} fontWeight={600}>
-                  {categoryLabels[cat] ?? cat}
-                </text>
-              </g>
-            )
-          })}
-
           {/* Repère radial de pertinence, le long de l'axe vertical haut */}
           <text x={CX} y={CY - rInner + 12} textAnchor="middle" className="fill-ebios-600 dark:fill-ebios-300" fontSize={9} fontWeight={600}>
             {labels.pertinence4}
           </text>
-          <text x={CX} y={CY - RMAX + 12} textAnchor="middle" className="fill-gray-400 dark:fill-gray-500" fontSize={9}>
+          <text x={CX} y={CY - RMAX + 11} textAnchor="middle" className="fill-gray-400 dark:fill-gray-500" fontSize={9}>
             {labels.pertinence1}
           </text>
 
-          {/* Points : un par couple SR/OV */}
-          {placed.map(({ c, x, y }) => {
+          {/* Points : un par couple SR/OV, numéroté (renvoie à la liste à droite) */}
+          {placed.map(({ c, x, y, num }) => {
             const isP1 = c.priorite === 'P1'
             return (
               <g key={c.id}>
                 {isP1 && <circle cx={x} cy={y} r={10} fill={hexFor(c.categorie)} opacity={0.18} />}
-                <circle cx={x} cy={y} r={isP1 ? 6 : 4} fill={hexFor(c.categorie)}
+                <circle cx={x} cy={y} r={isP1 ? 6.5 : 5} fill={hexFor(c.categorie)}
                   stroke={isP1 ? '#111827' : '#ffffff'} strokeWidth={isP1 ? 1.5 : 1}
                   className={isP1 ? 'dark:[stroke:#f9fafb]' : ''}>
-                  <title>{`${c.sourceNom} → ${c.ovNom} — ${pertinenceLabel} ${c.pertinence}/4${isP1 ? ` (${labels.p1})` : ''}`}</title>
+                  <title>{`${num}. ${c.sourceNom} → ${c.ovNom} — ${pertinenceLabel} ${c.pertinence}/4${isP1 ? ` (${labels.p1})` : ''}`}</title>
                 </circle>
-                {isP1 && (
-                  <text x={x + 8} y={y + 3} className="fill-gray-700 dark:fill-gray-200" fontSize={9} fontWeight={600}>
-                    {c.ovNom.length > 22 ? c.ovNom.slice(0, 21) + '…' : c.ovNom}
-                  </text>
-                )}
+                <text x={x} y={y - (isP1 ? 9 : 8)} textAnchor="middle"
+                  className="fill-gray-600 dark:fill-gray-300" fontSize={9} fontWeight={700}>{num}</text>
               </g>
             )
           })}
         </svg>
       </div>
 
-      {/* Légende */}
-      <ul className="text-xs space-y-1">
-        {cats.map(cat => (
-          <li key={cat} className="flex items-center gap-2">
-            <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: hexFor(cat) }} aria-hidden />
-            <span className="text-gray-700 dark:text-gray-200">{categoryLabels[cat] ?? cat}</span>
-            <span className="text-gray-400 dark:text-gray-500">({couples.filter(c => c.categorie === cat).length})</span>
-          </li>
-        ))}
-        <li className="flex items-center gap-2 pt-1">
-          <span className="w-3.5 h-3.5 rounded-full flex-shrink-0 border-2 border-gray-900 dark:border-gray-100" aria-hidden />
-          <span className="text-gray-500 dark:text-gray-400">{labels.p1}</span>
-        </li>
-      </ul>
+      {/* Liste numérotée : chaque point = un couple source → objectif visé.
+          Lève l'ambiguïté entre deux couples d'une même catégorie (recette). */}
+      <div className="text-xs space-y-2 min-w-0">
+        <div>
+          <p className="font-semibold text-gray-700 dark:text-gray-200">{labels.couplesTitle} ({couples.length})</p>
+          <p className="text-gray-400 dark:text-gray-500">{labels.hint}</p>
+        </div>
+        <ol className="space-y-1">
+          {ordered.map(c => (
+            <li key={c.id} className="flex items-start gap-2">
+              <span className="w-4 text-right tabular-nums text-gray-400 dark:text-gray-500 flex-shrink-0">{numById.get(c.id)}</span>
+              <span className="w-2.5 h-2.5 rounded-full mt-0.5 flex-shrink-0" style={{ backgroundColor: hexFor(c.categorie) }} aria-hidden />
+              <span className="text-gray-700 dark:text-gray-200">
+                <span className="text-gray-500 dark:text-gray-400">{c.sourceNom || (categoryLabels[c.categorie] ?? c.categorie)}</span>
+                {' → '}{c.ovNom}
+                {c.priorite === 'P1' && (
+                  <span className="ml-1.5 text-[10px] px-1 py-0.5 rounded bg-ebios-100 text-ebios-700 dark:bg-ebios-500/20 dark:text-ebios-300 font-medium">{labels.p1}</span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ol>
+      </div>
     </div>
   )
 }

--- a/src/components/workshops/Atelier2.tsx
+++ b/src/components/workshops/Atelier2.tsx
@@ -561,6 +561,8 @@ export default function Atelier2({ analyseId, initialData, analyse, flashMode }:
                   p1: t.workshop.a2.radarP1,
                   pertinence1: t.workshop.a2.radarPert1,
                   pertinence4: t.workshop.a2.radarPert4,
+                  couplesTitle: t.workshop.a2.radarCouples,
+                  hint: t.workshop.a2.radarHint,
                 }}
               />
             </div>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -2509,6 +2509,8 @@ export const de: Translations = {
       radarP1:      'Prioritäres Paar (P1)',
       radarPert1:   'gering',
       radarPert4:   'hoch',
+      radarCouples: 'RQ/ZO-Paare',
+      radarHint:    'Jeder Punkt = 1 Risikoquelle × 1 angestrebtes Ziel. Abstand zur Mitte = Relevanz der Quelle.',
       synthEmpty:   'Keine Risikoquellen ausgewählt. Füllen Sie zuerst den Tab "Eingabe" aus.',
       thSR:         'Risikoquelle (RQ)',
       thCat:        'Kategorie',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2509,6 +2509,8 @@ export const en: Translations = {
       radarP1:      'Priority pair (P1)',
       radarPert1:   'low',
       radarPert4:   'high',
+      radarCouples: 'RS/TO pairs',
+      radarHint:    'Each dot = 1 risk source × 1 targeted objective. Distance to centre = source relevance.',
       synthEmpty:   'No risk sources retained. Complete the "Entry" tab first.',
       thSR:         'Risk source (RS)',
       thCat:        'Category',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -2509,6 +2509,8 @@ export const es: Translations = {
       radarP1:      'Par prioritario (P1)',
       radarPert1:   'baja',
       radarPert4:   'alta',
+      radarCouples: 'Pares FR/OB',
+      radarHint:    'Cada punto = 1 fuente de riesgo × 1 objetivo perseguido. Distancia al centro = pertinencia de la fuente.',
       synthEmpty:   'No hay fuentes de riesgo retenidas. Complete primero la pestaña "Entrada".',
       thSR:         'Fuente de riesgo (FR)',
       thCat:        'Categoría',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -2553,6 +2553,8 @@ export const fr = {
       radarP1:      'Couple prioritaire (P1)',
       radarPert1:   'faible',
       radarPert4:   'forte',
+      radarCouples: 'Couples SR/OV',
+      radarHint:    'Chaque point = 1 source de risque × 1 objectif visé. Distance au centre = pertinence de la source.',
       synthEmpty:   'Aucune source de risque retenue. Complétez l\'onglet "Saisie" d\'abord.',
       thSR:         'Source de risque (SR)',
       thCat:        'Catégorie',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -2509,6 +2509,8 @@ export const it: Translations = {
       radarP1:      'Coppia prioritaria (P1)',
       radarPert1:   'bassa',
       radarPert4:   'alta',
+      radarCouples: 'Coppie FR/OB',
+      radarHint:    'Ogni punto = 1 fonte di rischio × 1 obiettivo perseguito. Distanza dal centro = pertinenza della fonte.',
       synthEmpty:   'Nessuna fonte di rischio selezionata. Completare prima la scheda "Inserimento".',
       thSR:         'Fonte di rischio (FR)',
       thCat:        'Categoria',

--- a/src/lib/sr-ov-radar.ts
+++ b/src/lib/sr-ov-radar.ts
@@ -39,8 +39,12 @@ export function srOvCouples(sources: SourceLike[] | null | undefined): SrOvCoupl
         sourceNom: String(s.nom ?? ''),
         categorie: String(s.categorie ?? ''),
         ovNom: String(ov.nom ?? ''),
-        // pertinence du couple si présente, sinon celle de la source.
-        pertinence: clampPert(ov.pertinenceOV ?? s.pertinence ?? 2),
+        // Le RAYON = pertinence de la SOURCE (valeur réellement cotée en Atelier 2 :
+        // motivation/ressources/activité). La pertinence par objectif (pertinenceOV)
+        // n'est pas saisissable dans l'UI — on ne l'utilise donc pas ici (sinon tous
+        // les couples se retrouvent au même niveau, cf. recette). Les couples d'une
+        // même source partagent leur pertinence, ce qui est normal.
+        pertinence: clampPert(s.pertinence ?? ov.pertinenceOV ?? 2),
         priorite: ov.priorite === 'P1' ? 'P1' : 'P2',
       })
     }


### PR DESCRIPTION
Suite de la recette — la cartographie SR/OV.

## Réponses aux 3 questions
- **« Pourquoi 8 points pour 4 sources ? »** → chaque point est un **couple SR/OV** (1 source × 1 objectif visé). 4 sources × 2 objectifs = 8 couples. C'est l'unité formelle EBIOS RM. C'est désormais **rappelé explicitement** et chaque point renvoie à une **liste numérotée** « n. Source → Objectif ».
- **« Leur niveau est le même alors que leur pertinence est différente »** → 🔴 **vrai bug** : le rayon utilisait `pertinenceOV` (champ **non saisissable** dans l'UI, toujours à sa valeur par défaut 3) → tous les couples au même niveau. **Corrigé** : rayon = **pertinence de la SOURCE** (la valeur réellement cotée). Deux couples d'une même source partagent leur niveau (normal), mais des sources de pertinence différente sont bien à des niveaux différents.
- **Texte coupé à gauche** → suppression des libellés de catégorie en périphérie (source du débordement) ; l'identification passe par la **liste numérotée** à droite + l'infobulle au survol.

## Différenciation de deux couples d'une même catégorie
Chaque point est **numéroté** et listé « n. Source → Objectif visé (P1) » → deux « Prestataire » deviennent p. ex. « 5. Prestataire → Vol de données » et « 6. Prestataire → Rebond vers le SI ».

## Vérification
`tsc` clean · **1450 tests** verts (géométrie mise à jour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)