### PR TITLE
feat(ateliers 3 & 5): garde-fous ER + héritage ER risque + statut mesures depuis conformité

### DIFF
--- a/src/app/analyses/[id]/atelier/[num]/page.tsx
+++ b/src/app/analyses/[id]/atelier/[num]/page.tsx
@@ -133,6 +133,9 @@ export default async function AtelierPage({
     redirect(`/analyses/${id}?qualif=required`)
   }
   let nonConfItems: { ref: string; nom: string; statut: ConformiteStatut; commentaire?: string }[] = []
+  // Statut de conformité (Atelier 1) par référence de contrôle → réutilisé à l'Atelier 5
+  // pour préremplir le statut des mesures importées (conforme=réalisé, partiel=en cours…).
+  let conformiteByRef: Record<string, ConformiteStatut> = {}
   // Conformité EFFECTIVE : niveau ORGANISATION (entité), sinon propre à l'analyse
   // ou héritée du socle (Palier 1). Résolution centralisée (org-aware).
   const socleAnalyse = (analyse as any).socle as { id: string; nom: string; referentielMesures?: string; cadrage?: { socleSecurite?: unknown; customControles?: unknown } } | null
@@ -168,6 +171,7 @@ export default async function AtelierPage({
       statut: nc.statut,
       commentaire: nc.commentaire,
     }))
+    conformiteByRef = Object.fromEntries(confEntries.map(e => [e.ref, e.statut]))
   }
   const showCatalogue = conformiteActive && (atelierNum === 3 || atelierNum === 4)
 
@@ -309,6 +313,7 @@ export default async function AtelierPage({
                 flashMode={flashMode}
                 scaleConfig={await getEffectiveScaleConfig((analyse as any).organizationId)}
                 nonConformites={nonConfItems}
+                conformiteByRef={conformiteByRef}
               />
             )}
           </div>

--- a/src/components/workshops/Atelier3.tsx
+++ b/src/components/workshops/Atelier3.tsx
@@ -217,6 +217,19 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
     })
   })
   const [expanded, setExpanded] = useState<string | null>(null)
+  // Garde-fou : chaque scénario stratégique doit être rattaché à ≥1 événement redouté
+  // avant de passer aux mesures de l'écosystème (recette).
+  const [erGateWarning, setErGateWarning] = useState(false)
+  function goToMesures() {
+    const sansEr = scenarios.filter(s => erIdsOf(s).length === 0)
+    if (sansEr.length > 0) {
+      setErGateWarning(true)
+      window.scrollTo({ top: 0, behavior: 'auto' })
+      return
+    }
+    setErGateWarning(false)
+    setTab('mesures')
+  }
 
   // ── Auto-save ─────────────────────────────────────────────────────────────
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -692,6 +705,12 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
               {couplesDisponibles.length === 0 && <strong className="text-orange-700"> {t.workshop.a3.scenNoCouples}</strong>}
             </p>
           </div>
+          {erGateWarning && (
+            <div className="rounded-xl border border-amber-300 bg-amber-50 dark:border-amber-500/40 dark:bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200 flex items-start gap-2">
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+              <span>{t.workshop.a3.scenErRequired}</span>
+            </div>
+          )}
 
           {/* ── Propositions par critère DICT ─────────────────────────── */}
           <div className="card p-5">
@@ -778,7 +797,11 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
 
             <div className="space-y-3">
               {scenarios.map(s => (
-                <div key={s.id} className={`border rounded-xl overflow-hidden ${s.retenu ? 'border-gray-200' : 'border-gray-100 opacity-60'}`}>
+                <div key={s.id} className={`border rounded-xl overflow-hidden ${
+                  erGateWarning && erIdsOf(s).length === 0
+                    ? 'border-amber-400 ring-1 ring-amber-300 dark:border-amber-500/60 dark:ring-amber-500/40'
+                    : s.retenu ? 'border-gray-200' : 'border-gray-100 opacity-60'
+                }`}>
                   <div
                     role="button"
                     tabIndex={0}
@@ -1077,7 +1100,7 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
             </p>
           </div>
 
-          <button onClick={() => setTab('mesures')} className="btn-primary w-full text-base py-3">
+          <button onClick={goToMesures} className="btn-primary w-full text-base py-3">
             {t.workshop.a3.nextMesures}
           </button>
         </div>

--- a/src/components/workshops/Atelier5.tsx
+++ b/src/components/workshops/Atelier5.tsx
@@ -64,6 +64,8 @@ interface Props {
   scaleConfig?: ScaleConfig | null
   /** Écarts du socle (non-conformités) à traiter, importables comme mesures (issue #3). */
   nonConformites?: { ref: string; nom: string; statut: string; commentaire?: string }[]
+  /** Statut de conformité (Atelier 1) par réf. de contrôle → prérempli le statut des mesures importées. */
+  conformiteByRef?: Record<string, string>
 }
 
 // uid() centralisé dans @/lib/uid (audit R05)
@@ -83,7 +85,15 @@ const stratColors: Record<string, string> = {
   SURVEILLER: 'bg-purple-100 text-purple-700',
 }
 
-export default function Atelier5({ analyseId, initialData, analyse, initialTab, flashMode, scaleConfig, nonConformites = [] }: Props) {
+// Statut d'une mesure importée, déduit de la conformité cotée à l'Atelier 1 :
+// conforme → réalisé · partiel → en cours · sinon (non conforme / non évalué) → à faire.
+function statutMesureFromConf(confStatut: string | undefined): 'A_FAIRE' | 'EN_COURS' | 'REALISE' {
+  if (confStatut === 'conforme') return 'REALISE'
+  if (confStatut === 'partiel') return 'EN_COURS'
+  return 'A_FAIRE'
+}
+
+export default function Atelier5({ analyseId, initialData, analyse, initialTab, flashMode, scaleConfig, nonConformites = [], conformiteByRef = {} }: Props) {
   const router = useRouter()
   const { t } = useTranslation()
   const { STRATEGIES_TRAITEMENT, NIVEAUX_GRAVITE, NIVEAUX_VRAISEMBLANCE } = useEbiosData()
@@ -116,6 +126,18 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
     s === 'mesures' ? 'mesures' : s === 'synthese' ? 'synthese' : 'risques'
 
   const [tab, setTab] = useState<'risques' | 'mesures' | 'synthese'>(() => validTab(initialTab))
+  // Garde-fou : tout risque doit être rattaché à un événement redouté avant les mesures.
+  const [erRisqueWarning, setErRisqueWarning] = useState(false)
+  function goToMesures5() {
+    const sansEr = risques.filter(r => !r.evenementRedouteRef)
+    if (sansEr.length > 0) {
+      setErRisqueWarning(true)
+      window.scrollTo({ top: 0, behavior: 'auto' })
+      return
+    }
+    setErRisqueWarning(false)
+    setTab('mesures')
+  }
   // ID de la mesure à mettre en évidence après navigation depuis /actions
   const [highlightId, setHighlightId] = useState<string | null>(null)
 
@@ -193,6 +215,21 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
 
   // Scénarios opérationnels pour lien de traçabilité
   const scenariosOp: any[] = analyse?.scenariosOperationnels || []
+  const scenariosStrat: any[] = analyse?.scenariosStrategiques || []
+  // Événement redouté déjà configuré pour un scénario opérationnel : porté par le SO,
+  // sinon récupéré via son scénario stratégique (ER lié en Atelier 3). Évite de
+  // redemander l'ER pour chaque risque (recette).
+  function erRefForSO(so: any): string {
+    if (!so) return ''
+    if (so.evenementRedouteRef) return String(so.evenementRedouteRef)
+    const ss = scenariosStrat.find((x: any) => x.id === so.scenarioStrategiqueId)
+    if (ss) {
+      const ids = Array.isArray(ss.evenementsRedoutesIds) ? ss.evenementsRedoutesIds
+        : (ss.evenementRedouteRef ? [ss.evenementRedouteRef] : [])
+      return ids[0] ? String(ids[0]) : ''
+    }
+    return ''
+  }
   // Événements redoutés de l'atelier 1
   const evenementsRedoutes: any[] = analyse?.cadrage?.evenementsRedoutes || []
   // EBIOS RM peut valoir AIPD (RGPD art. 35) si données particulières (art. 9) en jeu
@@ -214,7 +251,7 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
       description: '',
       scenarioOpId: defaultSO?.id || '',
       scenarioOpNom: defaultSO?.nom || '',
-      evenementRedouteRef: defaultSO?.evenementRedouteRef || '',
+      evenementRedouteRef: erRefForSO(defaultSO),
       gravite: defaultSO?.gravite || 3,
       vraisemblance: defaultSO?.vraisemblance || 2,
       niveauRisque: (defaultSO?.gravite || 3) * (defaultSO?.vraisemblance || 2),
@@ -247,6 +284,9 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
           up.gravite = so.gravite
           up.vraisemblance = so.vraisemblance
           up.niveauRisque = so.gravite * so.vraisemblance
+          // Récupère l'ER déjà configuré pour ce scénario (sans écraser un choix manuel).
+          const er = erRefForSO(so)
+          if (er) up.evenementRedouteRef = er
         }
       }
       return up
@@ -301,7 +341,7 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
       type: 'ORGANISATIONNELLE',
       categorieEbios: 'GOUVERNANCE',
       priorite: nc.statut === 'non_conforme' ? 1 : 2,
-      statut: 'A_FAIRE',
+      statut: statutMesureFromConf(nc.statut),
       responsable: '',
       entite: '',
       echeance: defaultEcheance(),
@@ -321,7 +361,7 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
            : controle.type === 'PHYSIQUE'      ? 'ORGANISATIONNELLE'
            : controle.type,
       priorite: 2,
-      statut: 'A_FAIRE',
+      statut: statutMesureFromConf(conformiteByRef[controle.ref]),
       responsable: '',
       entite: '',
       echeance: defaultEcheance(),
@@ -380,6 +420,12 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
       {/* ── RISQUES ─────────────────────────────────────────────────────── */}
       {tab === 'risques' && (
         <div className="space-y-4">
+          {erRisqueWarning && (
+            <div className="rounded-xl border border-amber-300 bg-amber-50 dark:border-amber-500/40 dark:bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200 flex items-start gap-2">
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+              <span>{t.workshop.a5.erRisqueRequired}</span>
+            </div>
+          )}
           {/* Import depuis scénarios opérationnels (A4 réalisé, y compris en mode Flash) */}
           {scenariosOp.length > 0 && (
             <div className="card p-4">
@@ -427,7 +473,11 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
                 const reduction = r.niveauResiduel ? Math.round(((r.niveauRisque - r.niveauResiduel) / r.niveauRisque) * 100) : 0
 
                 return (
-                  <div key={r.id} className="border border-gray-200 rounded-xl overflow-hidden">
+                  <div key={r.id} className={`border rounded-xl overflow-hidden ${
+                    erRisqueWarning && !r.evenementRedouteRef
+                      ? 'border-amber-400 ring-1 ring-amber-300 dark:border-amber-500/60 dark:ring-amber-500/40'
+                      : 'border-gray-200'
+                  }`}>
                     <div
                       role="button"
                       tabIndex={0}
@@ -634,7 +684,7 @@ export default function Atelier5({ analyseId, initialData, analyse, initialTab, 
               })}
             </div>
           </div>
-          <button onClick={() => setTab('mesures')} className="btn-primary">{`${t.workshop.a5.mesuresTitle} →`}</button>
+          <button onClick={goToMesures5} className="btn-primary">{`${t.workshop.a5.mesuresTitle} →`}</button>
         </div>
       )}
 

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -2722,6 +2722,7 @@ export const de: Translations = {
       scenSummaryRetenu: 'Szenario(en) ausgewählt von',
       scenSummaryTotal:  'identifiziert.',
       nextMesures:       'Zu den Ökosystem-Maßnahmen →',
+      scenErRequired:    'Jedes strategische Szenario muss mit mindestens einem befürchteten Ereignis verknüpft sein. Vervollständigen Sie die hervorgehobenen Szenarien, bevor Sie fortfahren.',
     },
     a4: {
       title:        'Workshop 4 — Operative Szenarien',
@@ -2785,6 +2786,7 @@ export const de: Translations = {
       desc:         'Verknüpfen Sie jedes Risiko mit einem operativen Szenario und einem befürchteten Ereignis, wählen Sie eine Behandlungsstrategie, dokumentieren Sie Restrisiken und Erschwerungsfaktoren, und bewerten Sie das Restrisiko.',
       risquesTitle: 'Risikoprofile',
       mesuresTitle: 'Sicherheitsmaßnahmen',
+      erRisqueRequired: 'Jedes Risiko muss mit einem befürchteten Ereignis verknüpft sein. Vervollständigen Sie die hervorgehobenen Risiken, bevor Sie zu den Maßnahmen übergehen.',
       planTitle:    'Zusammenfassung des Risikobehandlungsplans',
       stratLabel:   'Behandlungsstrategie',
       residualLabel:'Restrisiko',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2722,6 +2722,7 @@ export const en: Translations = {
       scenSummaryRetenu: 'scenario(s) retained out of',
       scenSummaryTotal:  'identified.',
       nextMesures:       'Go to ecosystem measures →',
+      scenErRequired:    'Each strategic scenario must be linked to at least one feared event. Complete the highlighted scenarios before continuing.',
     },
     a4: {
       title:        'Workshop 4 — Operational scenarios',
@@ -2785,6 +2786,7 @@ export const en: Translations = {
       desc:         'Link each risk to an operational scenario and a feared event, choose a treatment strategy, document residual vulnerabilities and aggravating factors, then assess the residual risk.',
       risquesTitle: 'Risk profiles',
       mesuresTitle: 'Security measures',
+      erRisqueRequired: 'Each risk must be linked to a feared event. Complete the highlighted risks before moving to measures.',
       planTitle:    'Risk treatment plan summary',
       stratLabel:   'Treatment strategy',
       residualLabel:'Residual level',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -2722,6 +2722,7 @@ export const es: Translations = {
       scenSummaryRetenu: 'escenario(s) retenido(s) de',
       scenSummaryTotal:  'identificado(s).',
       nextMesures:       'Ir a las medidas del ecosistema →',
+      scenErRequired:    'Cada escenario estratégico debe estar vinculado a al menos un evento temido. Complete los escenarios resaltados antes de continuar.',
     },
     a4: {
       title:        'Taller 4 — Escenarios operativos',
@@ -2785,6 +2786,7 @@ export const es: Translations = {
       desc:         'Vincula cada riesgo a un escenario operativo y un evento temido, elige una estrategia de tratamiento, documenta las vulnerabilidades residuales y factores agravantes, luego evalúa el riesgo residual.',
       risquesTitle: 'Perfiles de riesgo',
       mesuresTitle: 'Medidas de seguridad',
+      erRisqueRequired: 'Cada riesgo debe estar vinculado a un evento temido. Complete los riesgos resaltados antes de pasar a las medidas.',
       planTitle:    'Resumen del plan de tratamiento del riesgo',
       stratLabel:   'Estrategia de tratamiento',
       residualLabel:'Nivel residual',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -2767,6 +2767,7 @@ export const fr = {
       scenSummaryRetenu: 'scénario(s) retenu(s) sur',
       scenSummaryTotal:  'identifié(s).',
       nextMesures:       'Passer aux mesures de l\'écosystème →',
+      scenErRequired:    'Chaque scénario stratégique doit être rattaché à au moins un événement redouté. Complétez les scénarios en surbrillance avant de continuer.',
     },
     // Atelier 4
     a4: {
@@ -2832,6 +2833,7 @@ export const fr = {
       desc:         "Liez chaque risque à un scénario opérationnel et un événement redouté, choisissez une stratégie de traitement, documentez les vulnérabilités résiduelles et facteurs aggravants, puis évaluez le risque résiduel.",
       risquesTitle: 'Fiches de risque',
       mesuresTitle: 'Mesures de sécurité',
+      erRisqueRequired: 'Chaque risque doit être rattaché à un événement redouté. Complétez les risques en surbrillance avant de passer aux mesures.',
       planTitle:    "Synthèse du plan de traitement du risque",
       stratLabel:   'Stratégie de traitement',
       residualLabel:'Niveau résiduel',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -2722,6 +2722,7 @@ export const it: Translations = {
       scenSummaryRetenu: 'scenario/i mantenuto/i su',
       scenSummaryTotal:  'identificato/i.',
       nextMesures:       'Vai alle misure dell\'ecosistema →',
+      scenErRequired:    'Ogni scenario strategico deve essere collegato ad almeno un evento temuto. Completa gli scenari evidenziati prima di continuare.',
     },
     a4: {
       title:        'Workshop 4 — Scenari operativi',
@@ -2785,6 +2786,7 @@ export const it: Translations = {
       desc:         "Collega ogni rischio a uno scenario operativo e un evento temuto, scegli una strategia di trattamento, documenta le vulnerabilità residue e i fattori aggravanti, quindi valuta il rischio residuo.",
       risquesTitle: 'Profili di rischio',
       mesuresTitle: 'Misure di sicurezza',
+      erRisqueRequired: 'Ogni rischio deve essere collegato a un evento temuto. Completa i rischi evidenziati prima di passare alle misure.',
       planTitle:    'Sintesi del piano di trattamento del rischio',
       stratLabel:   'Strategia di trattamento',
       residualLabel:'Livello residuo',


### PR DESCRIPTION
Recette comité (lot 3) — Ateliers 3 et 5.

## Atelier 3
- **Garde-fou ER** : on ne peut passer aux **mesures de l'écosystème** que si **chaque scénario stratégique est rattaché à ≥ 1 événement redouté** (message + surbrillance ambre des scénarios à compléter).
- *(Rappel : la **priorité (P1–P4)** et le **statut (à faire/en cours/réalisé)** des mesures de l'écosystème étaient déjà éditables sur chaque mesure.)*

## Atelier 5
- **Héritage de l'ER** : un risque **récupère automatiquement l'événement redouté déjà configuré** via son scénario (opérationnel → stratégique → ER lié), à la **création** et au **changement de scénario** — plus besoin de le ressaisir pour chaque risque.
- **Garde-fou ER** : on ne peut passer aux **mesures de sécurité** que si **tous les risques** ont un événement redouté (message + surbrillance).
- **Statut des mesures importées = conformité de l'Atelier 1** : à l'import d'une mesure depuis le socle/conformité, le statut est prérempli selon la conformité cotée en A1 — **conforme → réalisé**, **partiel → en cours**, sinon **à faire** (nouveau prop `conformiteByRef` alimenté par la page atelier depuis `socleSecurite`).

## Vérification
`tsc` clean · **1450 tests** verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)