### PR TITLE
feat(config/admin): réglages d'instance → admin, délais → matrice, A3 mesures éditables

### DIFF
--- a/src/app/admin/instance/page.tsx
+++ b/src/app/admin/instance/page.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import Link from 'next/link'
+import { Home, Server } from 'lucide-react'
+import Navbar from '@/components/Navbar'
+import { useTranslation } from '@/lib/i18n/context'
+import { isAdminRole } from '@/lib/permissions'
+import ApiKeysManager from '@/components/ApiKeysManager'
+import WebhooksManager from '@/components/WebhooksManager'
+
+/**
+ * Administration — Paramètres d'instance (identité, politique de modules, API,
+ * webhooks). Regroupés dans l'espace ADMIN, distinct de la /configuration métier
+ * (échelles, matrice, exemples…) — cf. recette.
+ */
+export default function AdminInstancePage() {
+  const router = useRouter()
+  const { data: session, status } = useSession()
+  const { t } = useTranslation()
+  const role = (session?.user as { role?: string } | undefined)?.role
+  const isAdmin = isAdminRole(role as never)
+  const isSuperAdmin = role === 'SUPER_ADMIN'
+
+  const [brandName, setBrandName] = useState('')
+  const [brandBaseline, setBrandBaseline] = useState('')
+  const [brandSaved, setBrandSaved] = useState(false)
+  const [modulesPolicy, setModulesPolicy] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    if (status === 'authenticated' && !isAdmin) router.replace('/dashboard')
+  }, [status, isAdmin, router])
+
+  useEffect(() => {
+    if (!isSuperAdmin) return
+    fetch('/api/admin/branding').then(r => r.ok ? r.json() : null)
+      .then(d => { if (d) { setBrandName(d.appName ?? ''); setBrandBaseline(d.appBaseline ?? '') } }).catch(() => {})
+    fetch('/api/admin/organization-config').then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.modulesPolicy && typeof d.modulesPolicy === 'object') setModulesPolicy(d.modulesPolicy) }).catch(() => {})
+  }, [isSuperAdmin])
+
+  async function saveBranding() {
+    setBrandSaved(false)
+    const res = await fetch('/api/admin/branding', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appName: brandName, appBaseline: brandBaseline }),
+    })
+    if (res.ok) { setBrandSaved(true); setTimeout(() => setBrandSaved(false), 2500) }
+  }
+
+  async function saveModulesPolicy(moduleKey: string, etat: string) {
+    const prev = modulesPolicy
+    const next = { ...modulesPolicy, [moduleKey]: etat }
+    setModulesPolicy(next)
+    const res = await fetch('/api/admin/modules-policy', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modulesPolicy: next }),
+    })
+    if (!res.ok) setModulesPolicy(prev)
+  }
+
+  const modules = [
+    { key: 'registreRisques', label: t.features.registreRisquesTitle },
+    { key: 'incidents', label: t.features.incidentsTitle },
+    { key: 'controlePermanent', label: t.features.controlePermanentTitle },
+    { key: 'auditInterne', label: t.features.auditInterneTitle },
+    { key: 'kri', label: t.features.kriTitle },
+    { key: 'reglementaire', label: t.features.reglementaireTitle },
+    { key: 'secondeLigne', label: t.features.secondeLigneTitle },
+  ]
+
+  if (status === 'loading' || !isAdmin) {
+    return <div className="min-h-screen bg-gray-50 dark:bg-gray-900"><Navbar /><div className="flex items-center justify-center h-64 text-gray-500">{t.loading}</div></div>
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <Navbar />
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <Link href="/admin" className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400"><Home size={14} className="inline align-[-0.15em] mr-1" aria-hidden="true" /> {t.instanceAdmin.back}</Link>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mt-2"><Server size={22} className="inline align-[-0.15em] mr-2" aria-hidden="true" /> {t.instanceAdmin.title}</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t.instanceAdmin.subtitle}</p>
+        </div>
+
+        {isSuperAdmin && (
+          <section className="card p-6">
+            <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-1">{t.branding.sectionTitle}</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{t.branding.sectionDesc}</p>
+            <div className="flex flex-wrap gap-4 items-end">
+              <label className="text-sm text-gray-700 dark:text-gray-300 flex-1 min-w-[180px]">
+                <span className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{t.branding.nameLabel}</span>
+                <input value={brandName} onChange={e => setBrandName(e.target.value)} placeholder={t.auth.appName} maxLength={120}
+                  className="w-full px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+              </label>
+              <label className="text-sm text-gray-700 dark:text-gray-300 flex-1 min-w-[220px]">
+                <span className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{t.branding.baselineLabel}</span>
+                <input value={brandBaseline} onChange={e => setBrandBaseline(e.target.value)} placeholder={t.auth.appSubtitle} maxLength={120}
+                  className="w-full px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+              </label>
+              <button onClick={saveBranding} className="btn-primary text-sm">{brandSaved ? t.config.savedLabel : t.config.saveShort}</button>
+            </div>
+            <p className="text-xs text-gray-400 mt-2">{t.branding.hint}</p>
+          </section>
+        )}
+
+        {isSuperAdmin && (
+          <section className="card p-6">
+            <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-1">{t.modulesPolicy.sectionTitle}</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{t.modulesPolicy.sectionDesc}</p>
+            <div className="space-y-3">
+              {modules.map(m => (
+                <div key={m.key} className="flex flex-wrap items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+                  <span className="text-sm font-medium text-gray-800 dark:text-gray-100">{m.label}</span>
+                  <select value={modulesPolicy[m.key] ?? 'PER_ORG'} onChange={e => saveModulesPolicy(m.key, e.target.value)}
+                    className="px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm">
+                    <option value="PER_ORG">{t.modulesPolicy.perOrg}</option>
+                    <option value="FORCE_ON">{t.modulesPolicy.forceOn}</option>
+                    <option value="FORCE_OFF">{t.modulesPolicy.forceOff}</option>
+                  </select>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-gray-400 mt-2">{t.modulesPolicy.hint}</p>
+          </section>
+        )}
+
+        {isAdmin && <ApiKeysManager />}
+        {isAdmin && <WebhooksManager />}
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AlertTriangle, CheckCircle2, ClipboardList, Download, FileText, Home, KeyRound, Lock, LockOpen, Pin, ShieldCheck, Trash2, UserPlus, Users, XCircle, type LucideIcon } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, ClipboardList, Download, FileText, Home, KeyRound, Lock, LockOpen, Pin, Server, ShieldCheck, Trash2, UserPlus, Users, XCircle, type LucideIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
@@ -205,6 +205,13 @@ export default function AdminDashboardPage() {
             <div>
               <div className="font-semibold text-gray-800 text-sm">Journal d&apos;audit</div>
               <div className="text-xs text-gray-500">Tous les événements + export CSV</div>
+            </div>
+          </Link>
+          <Link href="/admin/instance" className="card p-4 hover:shadow-md transition-shadow flex items-center gap-3">
+            <span className="text-2xl"><Server size={24} aria-hidden="true" /></span>
+            <div>
+              <div className="font-semibold text-gray-800 text-sm">Paramètres d&apos;instance</div>
+              <div className="text-xs text-gray-500">Identité, modules, clés d&apos;API, webhooks</div>
             </div>
           </Link>
         </div>

--- a/src/app/configuration/page.tsx
+++ b/src/app/configuration/page.tsx
@@ -22,8 +22,7 @@ import { defaultExemplesFor, type ExemplesTranslations } from '@/lib/exemples-de
 import { useEbiosData } from '@/lib/i18n/use-ebios-data'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import EchellesEcosystemeEditor from '@/components/config/EchellesEcosystemeEditor'
-import ApiKeysManager from '@/components/ApiKeysManager'
-import WebhooksManager from '@/components/WebhooksManager'
+import Link from 'next/link'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -708,80 +707,14 @@ export default function ConfigurationPage() {
           )}
         </div>
 
-        {/* Identité de l'application (instance) — SUPER_ADMIN uniquement */}
-        {isSuperAdmin && (
-          <section className="mb-6 card p-6">
-            <h2 className="text-base font-semibold text-gray-800 mb-1">{t.branding.sectionTitle}</h2>
-            <p className="text-sm text-gray-500 mb-4">{t.branding.sectionDesc}</p>
-            <div className="flex flex-wrap gap-4 items-end">
-              <label className="text-sm text-gray-700 flex-1 min-w-[180px]">
-                <span className="block text-xs font-medium text-gray-600 mb-1">{t.branding.nameLabel}</span>
-                <input value={brandName} onChange={e => setBrandName(e.target.value)}
-                  placeholder={t.auth.appName} maxLength={120}
-                  className="w-full px-2 py-1.5 rounded border border-gray-300 text-sm" />
-              </label>
-              <label className="text-sm text-gray-700 flex-1 min-w-[220px]">
-                <span className="block text-xs font-medium text-gray-600 mb-1">{t.branding.baselineLabel}</span>
-                <input value={brandBaseline} onChange={e => setBrandBaseline(e.target.value)}
-                  placeholder={t.auth.appSubtitle} maxLength={120}
-                  className="w-full px-2 py-1.5 rounded border border-gray-300 text-sm" />
-              </label>
-              <button onClick={saveBranding} className="btn-primary text-sm">
-                {brandSaved ? t.config.savedLabel : t.config.saveShort}
-              </button>
-            </div>
-            <p className="text-xs text-gray-400 mt-2">{t.branding.hint}</p>
-          </section>
-        )}
-
-        {/* Politique d'activation des modules (instance) — SUPER_ADMIN */}
-        {isSuperAdmin && (
-          <section className="mb-6 card p-6">
-            <h2 className="text-base font-semibold text-gray-800 mb-1">{t.modulesPolicy.sectionTitle}</h2>
-            <p className="text-sm text-gray-500 mb-4">{t.modulesPolicy.sectionDesc}</p>
-            <div className="space-y-3">
-              {([{ key: 'registreRisques', label: t.features.registreRisquesTitle }, { key: 'incidents', label: t.features.incidentsTitle }, { key: 'controlePermanent', label: t.features.controlePermanentTitle }, { key: 'auditInterne', label: t.features.auditInterneTitle }, { key: 'kri', label: t.features.kriTitle }, { key: 'reglementaire', label: t.features.reglementaireTitle }, { key: 'secondeLigne', label: t.features.secondeLigneTitle }]).map(m => (
-                <div key={m.key} className="flex flex-wrap items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 bg-gray-50">
-                  <span className="text-sm font-medium text-gray-800">{m.label}</span>
-                  <select
-                    value={modulesPolicy[m.key] ?? 'PER_ORG'}
-                    onChange={e => saveModulesPolicy(m.key, e.target.value)}
-                    className="px-2 py-1.5 rounded border border-gray-300 text-sm"
-                  >
-                    <option value="PER_ORG">{t.modulesPolicy.perOrg}</option>
-                    <option value="FORCE_ON">{t.modulesPolicy.forceOn}</option>
-                    <option value="FORCE_OFF">{t.modulesPolicy.forceOff}</option>
-                  </select>
-                </div>
-              ))}
-            </div>
-            <p className="text-xs text-gray-400 mt-2">{t.modulesPolicy.hint}</p>
-          </section>
-        )}
-
-        {/* Clés d'API (accès machine à l'API publique v1) — ADMIN */}
-        {isAdmin && <ApiKeysManager />}
-        {isAdmin && <WebhooksManager />}
-
-        {/* Délais d'échéance par défaut d'une action selon sa priorité — ADMIN */}
+        {/* Identité de l'application, politique de modules, clés d'API et webhooks
+            ont été déplacés dans l'espace Administration (/admin/instance) — la
+            configuration ne concerne plus que le métier (échelles, exemples…). */}
         {isAdmin && (
-          <section className="mb-6 card p-6">
-            <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-1">{t.actionDelais.title}</h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{t.actionDelais.subtitle}</p>
-            <div className="flex flex-wrap gap-4">
-              {(['CRITIQUE', 'MAJEUR', 'MODERE'] as const).map(k => (
-                <label key={k} className="text-xs text-gray-500 dark:text-gray-400">
-                  {(t.riskActions.priorites as Record<string, string>)[k]}
-                  <span className="flex items-center gap-1.5 mt-1">
-                    <input type="number" min={1} max={600} defaultValue={actionDelais[k]}
-                      onBlur={e => saveActionDelai(k, Math.max(1, Math.min(600, Number(e.target.value) || actionDelais[k])))}
-                      className="px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm w-20" />
-                    <span className="text-xs text-gray-400">{t.actionDelais.monthsUnit}</span>
-                  </span>
-                </label>
-              ))}
-            </div>
-          </section>
+          <div className="mb-6 flex items-center justify-between gap-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-3">
+            <p className="text-sm text-gray-600 dark:text-gray-300">{t.config.instanceMoved}</p>
+            <Link href="/admin/instance" className="text-sm font-medium text-ebios-600 hover:text-ebios-700 whitespace-nowrap">{t.config.instanceMovedLink} →</Link>
+          </div>
         )}
 
         {/* Bannière lecture seule pour non-ADMIN */}
@@ -1152,6 +1085,27 @@ export default function ConfigurationPage() {
                 <strong>{t.config.maxScoreLabel}</strong> {config.nbNiveaux} × {config.nbNiveaux} = <strong>{config.nbNiveaux * config.nbNiveaux}</strong>
                 <br />
                 <strong>{t.config.coveredLabel}</strong> {config.seuilsMatrice[0]?.scoreMin || '?'} → {config.seuilsMatrice[config.seuilsMatrice.length - 1]?.scoreMax || '?'}
+              </div>
+            )}
+
+            {/* Délais d'échéance par défaut d'une action selon sa priorité — ADMIN (en dernier) */}
+            {isAdmin && (
+              <div className="pt-6 mt-2 border-t border-gray-200 dark:border-gray-700">
+                <h3 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-1">{t.actionDelais.title}</h3>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{t.actionDelais.subtitle}</p>
+                <div className="flex flex-wrap gap-4">
+                  {(['CRITIQUE', 'MAJEUR', 'MODERE'] as const).map(k => (
+                    <label key={k} className="text-xs text-gray-500 dark:text-gray-400">
+                      {(t.riskActions.priorites as Record<string, string>)[k]}
+                      <span className="flex items-center gap-1.5 mt-1">
+                        <input type="number" min={1} max={600} defaultValue={actionDelais[k]}
+                          onBlur={e => saveActionDelai(k, Math.max(1, Math.min(600, Number(e.target.value) || actionDelais[k])))}
+                          className="px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm w-20" />
+                        <span className="text-xs text-gray-400">{t.actionDelais.monthsUnit}</span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
               </div>
             )}
           </div>
@@ -1749,19 +1703,14 @@ export default function ConfigurationPage() {
         </div>
 
         {/* Bouton sauvegarde bas de page (échelles) */}
-        <div className="flex items-center justify-between mt-8 pt-6 border-t border-gray-200">
-          <button onClick={() => router.push('/dashboard')} className="btn-secondary">
-            {t.config.backDash}
-          </button>
-          {isAdmin && section === 'echelles' && (
-            <div className="flex items-center gap-3">
-              {saved && <span className="text-sm text-green-600 font-medium">{t.config.savedFull}</span>}
-              <button onClick={save} disabled={saving} className="btn-primary">
-                {saving ? t.config.savingLabel : t.config.saveLong}
-              </button>
-            </div>
-          )}
-        </div>{/* ═══ fin Section 3 — Exemples des ateliers ═══ */}
+        {isAdmin && section === 'echelles' && (
+          <div className="flex items-center justify-end gap-3 mt-8 pt-6 border-t border-gray-200">
+            {saved && <span className="text-sm text-green-600 font-medium">{t.config.savedFull}</span>}
+            <button onClick={save} disabled={saving} className="btn-primary">
+              {saving ? t.config.savingLabel : t.config.saveLong}
+            </button>
+          </div>
+        )}{/* ═══ fin Section 3 — Exemples des ateliers ═══ */}
 
         {/* ═══ Section 4 — Écosystème (échelles de dangerosité des PP) ═════════ */}
         <div className={section === 'ecosysteme' ? '' : 'hidden'}>

--- a/src/components/workshops/Atelier3.tsx
+++ b/src/components/workshops/Atelier3.tsx
@@ -459,6 +459,15 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
     }))
   }
 
+  // Met à jour une mesure d'écosystème PARTOUT où elle vit (vue consolidée : on ne
+  // connaît pas le scénario propriétaire, la mesure peut être mutualisée).
+  function updateMesureEcoAny(mesureId: string, field: string, value: string) {
+    setScenarios(prev => prev.map(s => ({
+      ...s,
+      mesuresEcosysteme: (s.mesuresEcosysteme || []).map((m: any) => m.id === mesureId ? { ...m, [field]: value } : m),
+    })))
+  }
+
   /** Mutualise/retire une mesure vers un autre scénario stratégique (issue #2). */
   function toggleMesureScenario(scenarioId: string, mesureId: string, targetScenarioId: string) {
     setScenarios(prev => prev.map(s => {
@@ -1288,7 +1297,16 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
                       <span className="ml-1 text-xs text-gray-400">· {m._ownerNom}</span>
                       {m.description ? <span className="block text-xs text-gray-400">{m.description}</span> : null}
                     </span>
-                    <span className="text-xs text-gray-500 whitespace-nowrap">{m.priorite ? t.workshop.a3.measPriorites[m.priorite as 'P1'] : '—'}</span>
+                    <select value={m.priorite || 'P2'} onChange={e => updateMesureEcoAny(m.id, 'priorite', e.target.value)}
+                      className="input text-xs py-1 w-28 flex-shrink-0" title={t.workshop.a3.measPrioriteLabel}>
+                      {PRIORITES_MESURE.map(pr => <option key={pr} value={pr}>{t.workshop.a3.measPriorites[pr]}</option>)}
+                    </select>
+                    <select value={m.statut || 'A_FAIRE'} onChange={e => updateMesureEcoAny(m.id, 'statut', e.target.value)}
+                      className="input text-xs py-1 w-24 flex-shrink-0">
+                      <option value="A_FAIRE">{t.workshop.a3.statutFaire}</option>
+                      <option value="EN_COURS">{t.workshop.a3.statutEnCours}</option>
+                      <option value="REALISE">{t.workshop.a3.statutRealise}</option>
+                    </select>
                   </li>
                 ))}
               </ul>
@@ -1317,16 +1335,20 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
                         {m._mutualisee ? <span className="ml-1 text-[10px] px-1 py-0.5 rounded bg-ebios-100 text-ebios-700 align-middle">{t.workshop.a3.measMutualisee}</span> : null}
                         {m.description ? <span className="block text-xs text-gray-400">{m.description}</span> : null}
                       </td>
-                      <td className="p-2 text-gray-600">{m.priorite ? t.workshop.a3.measPriorites[m.priorite as 'P1'] : '—'}</td>
+                      <td className="p-2">
+                        <select value={m.priorite || 'P2'} onChange={e => updateMesureEcoAny(m.id, 'priorite', e.target.value)}
+                          className="input text-xs py-1" title={t.workshop.a3.measPrioriteLabel}>
+                          {PRIORITES_MESURE.map(pr => <option key={pr} value={pr}>{t.workshop.a3.measPriorites[pr]}</option>)}
+                        </select>
+                      </td>
                       <td className="p-2 text-gray-600">{m.partiePrenante || '—'}</td>
                       <td className="p-2">
-                        <span className={`text-xs px-2 py-0.5 rounded font-medium ${
-                          m.statut === 'REALISE' ? 'bg-green-100 text-green-700' :
-                          m.statut === 'EN_COURS' ? 'bg-yellow-100 text-yellow-700' :
-                          'bg-gray-100 text-gray-600'
-                        }`}>
-                          {m.statut === 'REALISE' ? `✓ ${t.workshop.a3.statutRealise}` : m.statut === 'EN_COURS' ? `⏳ ${t.workshop.a3.statutEnCours}` : t.workshop.a3.statutFaire}
-                        </span>
+                        <select value={m.statut || 'A_FAIRE'} onChange={e => updateMesureEcoAny(m.id, 'statut', e.target.value)}
+                          className="input text-xs py-1">
+                          <option value="A_FAIRE">{t.workshop.a3.statutFaire}</option>
+                          <option value="EN_COURS">{t.workshop.a3.statutEnCours}</option>
+                          <option value="REALISE">{t.workshop.a3.statutRealise}</option>
+                        </select>
                       </td>
                     </tr>
                   ))}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1818,6 +1818,11 @@ export const de: Translations = {
       serviceCritique: 'Kritische Dienste betroffen',
     },
   },
+  instanceAdmin: {
+    title: 'Instanzeinstellungen',
+    subtitle: 'App-Identität, Modulaktivierung, API-Schlüssel und Webhooks — nur für die Administration.',
+    back: 'Administration',
+  },
   branding: {
     sectionTitle: 'Anwendungsidentität',
     sectionDesc: 'Name und Untertitel, die in der App angezeigt werden (Navigationsleiste, Anmeldeseite). Leer lassen, um den Standardnamen beizubehalten.',
@@ -1927,6 +1932,8 @@ export const de: Translations = {
     saveLong:          '💾 Konfiguration speichern',
     savedFull:         '✅ Konfiguration gespeichert',
     backDash:          '← Zurück zum Dashboard',
+    instanceMoved:     'App-Identität, Modulaktivierung, API-Schlüssel und Webhooks befinden sich jetzt im Administrationsbereich.',
+    instanceMovedLink: 'Instanzeinstellungen öffnen',
     levelsSectionTitle:'Anzahl der Stufen in den Skalen',
     levelWarning:      '⚠️ Das Ändern der Stufenanzahl setzt die Skalen auf die entsprechenden Standardwerte zurück.',
     level4label:       '4 Stufen',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1818,6 +1818,11 @@ export const en: Translations = {
       serviceCritique: 'Critical services affected',
     },
   },
+  instanceAdmin: {
+    title: 'Instance settings',
+    subtitle: 'App identity, module activation, API keys and webhooks — administration only.',
+    back: 'Administration',
+  },
   branding: {
     sectionTitle: 'Application identity',
     sectionDesc: 'Name and subtitle shown across the app (navigation bar, sign-in page). Leave blank to keep the default name.',
@@ -1927,6 +1932,8 @@ export const en: Translations = {
     saveLong:          '💾 Save configuration',
     savedFull:         '✅ Configuration saved',
     backDash:          '← Back to dashboard',
+    instanceMoved:     'App identity, module activation, API keys and webhooks now live in the Administration area.',
+    instanceMovedLink: 'Open instance settings',
     levelsSectionTitle:'Number of levels in the scales',
     levelWarning:      '⚠️ Changing the number of levels resets the scales to the corresponding default values.',
     level4label:       '4 levels',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1818,6 +1818,11 @@ export const es: Translations = {
       serviceCritique: 'Servicios críticos afectados',
     },
   },
+  instanceAdmin: {
+    title: 'Ajustes de instancia',
+    subtitle: 'Identidad de la aplicación, activación de módulos, claves de API y webhooks — solo administración.',
+    back: 'Administración',
+  },
   branding: {
     sectionTitle: 'Identidad de la aplicación',
     sectionDesc: 'Nombre y subtítulo mostrados en la aplicación (barra de navegación, página de inicio de sesión). Deja en blanco para conservar el nombre predeterminado.',
@@ -1927,6 +1932,8 @@ export const es: Translations = {
     saveLong:          '💾 Guardar configuración',
     savedFull:         '✅ Configuración guardada',
     backDash:          '← Volver al panel',
+    instanceMoved:     'Identidad, activación de módulos, claves de API y webhooks ahora están en el área de Administración.',
+    instanceMovedLink: 'Abrir ajustes de instancia',
     levelsSectionTitle:'Número de niveles en las escalas',
     levelWarning:      '⚠️ Cambiar el número de niveles restablece las escalas a los valores predeterminados correspondientes.',
     level4label:       '4 niveles',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1856,6 +1856,11 @@ export const fr = {
       serviceCritique: 'Services critiques touchés',
     },
   },
+  instanceAdmin: {
+    title: 'Paramètres d’instance',
+    subtitle: 'Identité de l’application, activation des modules, clés d’API et webhooks — réservé à l’administration.',
+    back: 'Administration',
+  },
   branding: {
     sectionTitle: 'Identité de l\'application',
     sectionDesc: 'Nom et sous-titre affichés dans l\'application (barre de navigation, page de connexion). Laissez vide pour conserver le nom par défaut.',
@@ -1965,6 +1970,8 @@ export const fr = {
     saveLong:          '💾 Sauvegarder la configuration',
     savedFull:         '✅ Configuration sauvegardée',
     backDash:          '← Retour au tableau de bord',
+    instanceMoved:     'Identité, activation des modules, clés d’API et webhooks sont désormais dans l’espace Administration.',
+    instanceMovedLink: 'Ouvrir les paramètres d’instance',
     levelsSectionTitle:'Nombre de niveaux dans les échelles',
     levelWarning:      '⚠️ Changer le nombre de niveaux réinitialise les échelles aux valeurs par défaut correspondantes.',
     level4label:       '4 niveaux',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1818,6 +1818,11 @@ export const it: Translations = {
       serviceCritique: 'Servizi critici colpiti',
     },
   },
+  instanceAdmin: {
+    title: 'Impostazioni di istanza',
+    subtitle: 'Identità dell’applicazione, attivazione dei moduli, chiavi API e webhook — solo amministrazione.',
+    back: 'Amministrazione',
+  },
   branding: {
     sectionTitle: 'Identità dell\'applicazione',
     sectionDesc: 'Nome e sottotitolo mostrati nell\'app (barra di navigazione, pagina di accesso). Lascia vuoto per mantenere il nome predefinito.',
@@ -1927,6 +1932,8 @@ export const it: Translations = {
     saveLong:          '💾 Salva configurazione',
     savedFull:         '✅ Configurazione salvata',
     backDash:          '← Torna alla dashboard',
+    instanceMoved:     'Identità, attivazione dei moduli, chiavi API e webhook ora si trovano nell’area Amministrazione.',
+    instanceMovedLink: 'Apri le impostazioni di istanza',
     levelsSectionTitle:'Numero di livelli nelle scale',
     levelWarning:      '⚠️ Modificare il numero di livelli reimposta le scale ai valori predefiniti corrispondenti.',
     level4label:       '4 livelli',


### PR DESCRIPTION
Recette comité — réorganisation configuration/admin + un correctif Atelier 3.

## Atelier 3 (correctif)
Le **statut** et la **priorité** des mesures de l'écosystème sont maintenant **éditables dans la vue consolidée** (onglet « mesures »), pas seulement dans le scénario déplié. `updateMesureEcoAny` met à jour la mesure où qu'elle vive (y compris mutualisée sur plusieurs scénarios).

## Réglages d'instance → espace Admin (#2)
Nouvelle page **/admin/instance** regroupant :
- **Identité de l'application**
- **Activation des modules (instance)**
- **Clés d'API**
- **Webhooks**

…retirés de **/configuration** (qui ne concerne plus que le **métier** : échelles, matrice, exemples, écosystème). Accès depuis la page **/admin** (nouvelle carte « Paramètres d'instance ») + un pointeur depuis la configuration.

## Délais d'échéance → onglet Échelles/Matrice (#3)
« Délais d'échéance des actions » déplacé **dans l'onglet Échelles → Matrice, en dernier**.

## Bouton « Retour au tableau de bord » retiré (#4)
Supprimé de la configuration (navigation déjà assurée par la barre).

## Vérification
`tsc` clean · **1450 tests** verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)