### PR TITLE
feat(nav): barre de navigation adaptative au nombre d'items (mode cyber)

### DIFF
--- a/src/__tests__/unit/lib/navigation.test.ts
+++ b/src/__tests__/unit/lib/navigation.test.ts
@@ -50,10 +50,22 @@ describe('buildNav — mode cyber (aucun module 2ᵉ/3ᵉ ligne)', () => {
     expect(groupIds(buildNav('LECTEUR', ALL_OFF))).toEqual([])
   })
 
-  it('incidents SEULS ne basculent pas en mode GRC (restent dans le menu « GRC »)', () => {
+  it('incidents SEULS ne basculent pas en mode GRC ; peu d’items → lien direct (pas de menu)', () => {
     const m = buildNav('ANALYSTE', { ...ALL_OFF, incidents: true })
     expect(m.mode).toBe('cyber')
     expect(allKeys(m)).toContain('incidents')
+    // 1 seul item secondaire → étalé en lien direct, aucun menu « GRC ».
+    expect(groupIds(m)).toEqual([])
+    expect(m.entries).toContainEqual({ kind: 'link', key: 'incidents' })
+  })
+
+  it('la barre s’adapte : ≤2 items secondaires étalés, ≥3 regroupés dans « GRC »', () => {
+    // DIRECTION_METIER : gouvernance = [derogations] (1) → étalé, pas de menu.
+    const dm = buildNav('DIRECTION_METIER', ALL_OFF)
+    expect(groupIds(dm)).toEqual([])
+    expect(dm.entries).toContainEqual({ kind: 'link', key: 'derogations' })
+    // RISK_MANAGER : 4 items de gouvernance → regroupés dans un menu « GRC ».
+    expect(groupIds(buildNav('RISK_MANAGER', ALL_OFF))).toEqual(['grc'])
   })
 })
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -51,6 +51,9 @@ export interface NavModel {
 /** Parcours EBIOS de base (cyber). */
 const CORE: NavKey[] = ['analyses', 'risques', 'tiers', 'actions']
 
+/** Nb max d'items secondaires (gouvernance/incidents) étalés inline avant regroupement. */
+export const SECONDARY_INLINE_MAX = 2
+
 const link = (key: NavKey): NavEntry => ({ kind: 'link', key })
 
 /** 1 item → lien direct ; 2+ → groupe déroulant. */
@@ -83,11 +86,18 @@ export function buildNav(role: UserRole, modules: NavModules): NavModel {
   const grcMode = modules.registre || modules.controles || modules.audit || modules.kri || modules.reglementaire
 
   // ─── MODE CYBER ────────────────────────────────────────────────────────────
+  // La barre s'ADAPTE au nombre d'items : dashboard + le cœur EBIOS restent étalés ;
+  // les items secondaires (gouvernance, incidents) sont ÉTALÉS tant qu'ils sont peu
+  // nombreux (≤ SECONDARY_INLINE_MAX), sinon REGROUPÉS dans le menu « GRC ». Un seul
+  // item ne fait donc jamais un menu déroulant pour rien.
   if (!grcMode) {
-    const grc: NavKey[] = [...gouvernance]
-    if (modules.incidents) grc.push('incidents')
+    const secondary: NavKey[] = [...gouvernance]
+    if (modules.incidents) secondary.push('incidents')
     const entries: NavEntry[] = [link('dashboard'), ...CORE.map(link)]
-    if (grc.length) entries.push({ kind: 'group', id: 'grc', items: grc })
+    if (secondary.length > 0) {
+      if (secondary.length <= SECONDARY_INLINE_MAX) entries.push(...secondary.map(link))
+      else entries.push({ kind: 'group', id: 'grc', items: secondary })
+    }
     return { mode: 'cyber', entries }
   }
 


### PR DESCRIPTION
Réponse à la recette : « quand on désactive tous les modules GRC, la navbar doit s'adapter au nombre d'items ».

## Comportement
En **mode cyber** (tous modules GRC OFF) : le cœur EBIOS reste étalé (Tableau de bord · Analyses · Risques · Tiers · Actions), et les items **secondaires** (gouvernance, incidents) **s'adaptent** :
- **≤ 2 items** → **étalés** en liens directs (fini le menu déroulant pour 1 seul lien) ;
- **≥ 3 items** → **regroupés** dans le menu « GRC ».

Seuil unique et **tunable** (`SECONDARY_INLINE_MAX = 2`). Le mode GRC utilisait déjà `groupOrLink` (1 item = lien direct) — inchangé.

Exemples : un ANALYSTE avec incidents seuls a un lien direct **Incidents** ; un RISK_MANAGER (4 items de gouvernance) garde le menu **« GRC »**.

`tsc` clean · **1450 tests** verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)