### PR TITLE
fix(atelier3): selects priorité/statut tronqués dans les mesures éco

### DIFF
--- a/src/components/workshops/Atelier3.tsx
+++ b/src/components/workshops/Atelier3.tsx
@@ -1298,11 +1298,11 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
                       {m.description ? <span className="block text-xs text-gray-400">{m.description}</span> : null}
                     </span>
                     <select value={m.priorite || 'P2'} onChange={e => updateMesureEcoAny(m.id, 'priorite', e.target.value)}
-                      className="input text-xs py-1 w-28 flex-shrink-0" title={t.workshop.a3.measPrioriteLabel}>
+                      className="input text-xs py-1 w-auto min-w-[9.5rem] flex-shrink-0" title={t.workshop.a3.measPrioriteLabel}>
                       {PRIORITES_MESURE.map(pr => <option key={pr} value={pr}>{t.workshop.a3.measPriorites[pr]}</option>)}
                     </select>
                     <select value={m.statut || 'A_FAIRE'} onChange={e => updateMesureEcoAny(m.id, 'statut', e.target.value)}
-                      className="input text-xs py-1 w-24 flex-shrink-0">
+                      className="input text-xs py-1 w-auto min-w-[6.5rem] flex-shrink-0">
                       <option value="A_FAIRE">{t.workshop.a3.statutFaire}</option>
                       <option value="EN_COURS">{t.workshop.a3.statutEnCours}</option>
                       <option value="REALISE">{t.workshop.a3.statutRealise}</option>
@@ -1335,16 +1335,16 @@ export default function Atelier3({ analyseId, initialData, analyse, flashMode }:
                         {m._mutualisee ? <span className="ml-1 text-[10px] px-1 py-0.5 rounded bg-ebios-100 text-ebios-700 align-middle">{t.workshop.a3.measMutualisee}</span> : null}
                         {m.description ? <span className="block text-xs text-gray-400">{m.description}</span> : null}
                       </td>
-                      <td className="p-2">
+                      <td className="p-2 whitespace-nowrap">
                         <select value={m.priorite || 'P2'} onChange={e => updateMesureEcoAny(m.id, 'priorite', e.target.value)}
-                          className="input text-xs py-1" title={t.workshop.a3.measPrioriteLabel}>
+                          className="input text-xs py-1 w-auto min-w-[9.5rem]" title={t.workshop.a3.measPrioriteLabel}>
                           {PRIORITES_MESURE.map(pr => <option key={pr} value={pr}>{t.workshop.a3.measPriorites[pr]}</option>)}
                         </select>
                       </td>
                       <td className="p-2 text-gray-600">{m.partiePrenante || '—'}</td>
-                      <td className="p-2">
+                      <td className="p-2 whitespace-nowrap">
                         <select value={m.statut || 'A_FAIRE'} onChange={e => updateMesureEcoAny(m.id, 'statut', e.target.value)}
-                          className="input text-xs py-1">
+                          className="input text-xs py-1 w-auto min-w-[6.5rem]">
                           <option value="A_FAIRE">{t.workshop.a3.statutFaire}</option>
                           <option value="EN_COURS">{t.workshop.a3.statutEnCours}</option>
                           <option value="REALISE">{t.workshop.a3.statutRealise}</option>


### PR DESCRIPTION
Dans les vues consolidées des mesures de l'écosystème (**« par scénario »** et **« par partie prenante »**), les `select` priorité/statut héritaient de `.input` (`w-full`) et étaient **écrasés** quand une mesure avait une longue description (colonne 1 élargie) → libellés coupés (« À fai », « P2 — Cour », cf. capture).

Correctif CSS : `w-auto` + largeur minimale contenant « P2 — Court terme » (`min-w-[9.5rem]` priorité, `min-w-[6.5rem]` statut) + `whitespace-nowrap` sur les cellules du tableau.

Aucun changement de logique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)