### PR TITLE
feat(gouvernance): gel de l'analyse après acceptation des risques résiduels

### DIFF
--- a/prisma/migrations/20260907140000_gel_apres_acceptation/migration.sql
+++ b/prisma/migrations/20260907140000_gel_apres_acceptation/migration.sql
@@ -1,0 +1,2 @@
+-- Gel de l'analyse après acceptation des risques résiduels (lecture seule + nouvelle version requise)
+ALTER TABLE "OrganizationConfig" ADD COLUMN "gelApresAcceptationActive" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1428,6 +1428,9 @@ model OrganizationConfig {
   // Fonctionnalité optionnelle : acceptation des risques résiduels par la Direction métier
   // (rôle DIRECTION_METIER), distincte de la validation de l'analyse.
   acceptationRisquesActive   Boolean       @default(false)
+  // Gel de l'analyse après acceptation des risques résiduels : une fois acceptés,
+  // l'analyse est figée (lecture seule) et toute modification exige une nouvelle version.
+  gelApresAcceptationActive  Boolean       @default(false)
   // Fonctionnalité optionnelle : dérogations (acceptation temporaire d'une non-conformité
   // au socle, avec échéance + suivi). Voir docs/derogations-spec.md.
   derogationsActive          Boolean       @default(false)

--- a/src/__tests__/unit/lib/gel-analyse.test.ts
+++ b/src/__tests__/unit/lib/gel-analyse.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { analyseGelee, STATUT_GEL } from '@/lib/gel-analyse'
+
+describe('analyseGelee', () => {
+  it('gèle uniquement si le gel est actif ET les risques acceptés', () => {
+    expect(analyseGelee('ACCEPTES', true)).toBe(true)
+    expect(STATUT_GEL).toBe('ACCEPTES')
+  })
+
+  it('ne gèle pas si la fonctionnalité est désactivée', () => {
+    expect(analyseGelee('ACCEPTES', false)).toBe(false)
+  })
+
+  it('ne gèle pas les autres statuts (attente, refus)', () => {
+    expect(analyseGelee('EN_ATTENTE', true)).toBe(false)
+    expect(analyseGelee('REFUSES', true)).toBe(false)
+    expect(analyseGelee(null, true)).toBe(false)
+    expect(analyseGelee(undefined, true)).toBe(false)
+  })
+})

--- a/src/__tests__/unit/lib/org-config.test.ts
+++ b/src/__tests__/unit/lib/org-config.test.ts
@@ -21,6 +21,7 @@ function row(partial: Partial<RawOrgConfig>): RawOrgConfig {
     conformiteSnapshotMode: 'MANUEL',
     conseilsAteliersActive: true,
     acceptationRisquesActive: false,
+    gelApresAcceptationActive: false,
     derogationsActive: false,
     derogationDureeDefautJours: 180,
     derogationAlerteJours: 30,

--- a/src/app/analyses/[id]/page.tsx
+++ b/src/app/analyses/[id]/page.tsx
@@ -16,6 +16,7 @@ import RiskMatrixTabs from '@/components/RiskMatrixTabs'
 import EcosystemRadar from '@/components/EcosystemRadar'
 import { getEffectiveScaleConfig } from '@/lib/configuration-server'
 import { getOrgConfig } from '@/lib/org-config.server'
+import { analyseGelee } from '@/lib/gel-analyse'
 import AccessPanel from '@/components/AccessPanel'
 import PDFExportButton from '@/components/PDFExportButton'
 import PptxExportButton from '@/components/PptxExportButton'
@@ -135,8 +136,9 @@ export default async function AnalyseDetailPage({ params }: { params: Promise<{ 
   const qualificationObligatoire = orgConfig.qualificationObligatoire
   const qualificationComplete = isQualificationComplete(sanitizeQualification((analyse as any).qualification))
 
-  // Verrouillage si analyse approuvée (sauf ADMIN)
-  const locked = analyse.statut === 'APPROUVE' && userRole !== 'ADMIN'
+  // Verrouillage si analyse approuvée (sauf ADMIN) OU gelée (risques résiduels acceptés)
+  const gelee = analyseGelee((analyse as any).risquesResiduelsStatut, orgConfig.gelApresAcceptationActive)
+  const locked = (analyse.statut === 'APPROUVE' && userRole !== 'ADMIN') || gelee
   const isOwner = analyse.userId === userId
 
   // Mettre la qualification en avant (avant les ateliers) tant qu'elle est incomplète.
@@ -499,6 +501,8 @@ export default async function AnalyseDetailPage({ params }: { params: Promise<{ 
                 le={(analyse as any).risquesResiduelsLe ? (analyse as any).risquesResiduelsLe.toISOString() : null}
                 commentaire={(analyse as any).risquesResiduelsCommentaire ?? null}
                 canAct={canAcceptResidualRisks(sessionUser, orgConfig.acceptationRisquesActive)}
+                gelActive={orgConfig.gelApresAcceptationActive}
+                canReopen={editable}
                 locale={locale}
               />
             )}

--- a/src/app/api/admin/organization-config/route.ts
+++ b/src/app/api/admin/organization-config/route.ts
@@ -73,6 +73,7 @@ export async function GET(_req: NextRequest) {
     conformiteSnapshotMode: cfg.conformiteSnapshotMode,
     conseilsAteliersActive: cfg.conseilsAteliersActive,
     acceptationRisquesActive: cfg.acceptationRisquesActive,
+    gelApresAcceptationActive: cfg.gelApresAcceptationActive,
     derogationsActive: cfg.derogationsActive,
     derogationDureeDefautJours: cfg.derogationDureeDefautJours,
     derogationAlerteJours: cfg.derogationAlerteJours,
@@ -189,6 +190,7 @@ export async function PUT(req: NextRequest) {
   if (typeof body.conformiteSnapshotMode === 'string') data.conformiteSnapshotMode = sanitizeSnapshotMode(body.conformiteSnapshotMode)
   if (typeof body.conseilsAteliersActive === 'boolean') data.conseilsAteliersActive = body.conseilsAteliersActive
   if (typeof body.acceptationRisquesActive === 'boolean') data.acceptationRisquesActive = body.acceptationRisquesActive
+  if (typeof body.gelApresAcceptationActive === 'boolean') data.gelApresAcceptationActive = body.gelApresAcceptationActive
   if (typeof body.derogationsActive === 'boolean') data.derogationsActive = body.derogationsActive
   // Durée par défaut (1 jour à 10 ans) et fenêtre d'alerte (1 à 365 jours), bornées.
   if (typeof body.derogationDureeDefautJours === 'number' && Number.isFinite(body.derogationDureeDefautJours)) {

--- a/src/app/api/analyses/[id]/revisions/route.ts
+++ b/src/app/api/analyses/[id]/revisions/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { canViewAnalyse, canEditAnalyse, type UserRole } from '@/lib/permissions'
 import { analyseAccessWhere } from '@/lib/org-context.server'
+import { getOrgConfig } from '@/lib/org-config.server'
+import { analyseGelee } from '@/lib/gel-analyse'
 import { auditLog, getClientIp } from '@/lib/logger'
 import { normalizeCycle, nextVersion, formatVersion } from '@/lib/version-analyse'
 
@@ -70,10 +72,18 @@ export async function POST(req: NextRequest, { params }: Params) {
   const { maj, min } = nextVersion(analyse.versionMajeure, analyse.versionMineure, cycle)
   const version = formatVersion(maj, min)
 
+  // Réouverture d'une analyse gelée : une nouvelle version invalide l'acceptation
+  // des risques résiduels et rend l'analyse de nouveau modifiable → statut « en attente ».
+  const orgConfig = await getOrgConfig(analyse.organizationId).catch(() => null)
+  const rouvreGel = analyseGelee(analyse.risquesResiduelsStatut, orgConfig?.gelApresAcceptationActive ?? false)
+  const resetAcceptation = rouvreGel
+    ? { risquesResiduelsStatut: 'EN_ATTENTE', risquesResiduelsPar: null, risquesResiduelsLe: null, risquesResiduelsCommentaire: null }
+    : {}
+
   const [, revision] = await prisma.$transaction([
     prisma.analyse.update({
       where: { id },
-      data: { versionMajeure: maj, versionMineure: min, updatedAt: new Date() },
+      data: { versionMajeure: maj, versionMineure: min, updatedAt: new Date(), ...resetAcceptation },
     }),
     prisma.revisionAnalyse.create({
       data: { analyseId: id, version, cycle, note, ateliers, createdById: userId },

--- a/src/app/api/analyses/[id]/workshop/[num]/route.ts
+++ b/src/app/api/analyses/[id]/workshop/[num]/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { analyseAccessWhere } from '@/lib/org-context.server'
+import { getOrgConfig } from '@/lib/org-config.server'
+import { analyseGelee } from '@/lib/gel-analyse'
 import { canEditAnalyse } from '@/lib/permissions'
 import {
   cleanSourceRisque,
@@ -67,6 +69,15 @@ export async function PUT(
   // Bloquer les modifications si l'analyse est approuvée
   if (analyse.statut === 'APPROUVE' && userRole !== 'ADMIN') {
     return NextResponse.json({ error: 'L\'analyse est approuvée et ne peut plus être modifiée' }, { status: 403 })
+  }
+
+  // Gel après acceptation des risques résiduels : l'analyse est figée tant que la
+  // fonctionnalité est active pour l'org. Réouverture = nouvelle version (révision).
+  if (analyse.risquesResiduelsStatut === 'ACCEPTES') {
+    const orgConfig = await getOrgConfig(analyse.organizationId).catch(() => null)
+    if (analyseGelee(analyse.risquesResiduelsStatut, orgConfig?.gelApresAcceptationActive ?? false)) {
+      return NextResponse.json({ error: 'Analyse gelée : les risques résiduels ont été acceptés. Ouvrez une nouvelle version pour la modifier.' }, { status: 403 })
+    }
   }
 
   const body = await req.json()

--- a/src/app/configuration/page.tsx
+++ b/src/app/configuration/page.tsx
@@ -151,6 +151,7 @@ export default function ConfigurationPage() {
   const [savingConfOpt, setSavingConfOpt] = useState(false)
   const [conseilsAteliersActive, setConseilsAteliersActive] = useState(true)
   const [acceptationRisquesActive, setAcceptationRisquesActive] = useState(false)
+  const [gelApresAcceptationActive, setGelApresAcceptationActive] = useState(false)
   const [derogationsActive, setDerogationsActive] = useState(false)
   const [derogationDuree, setDerogationDuree] = useState(180)
   const [derogationAlerte, setDerogationAlerte] = useState(30)
@@ -208,6 +209,7 @@ export default function ConfigurationPage() {
         setConformiteSnapshotMode(['MANUEL', 'AUTO', 'CHANGEMENT'].includes(data.conformiteSnapshotMode) ? data.conformiteSnapshotMode : 'MANUEL')
         setConseilsAteliersActive(data.conseilsAteliersActive !== false)
         setAcceptationRisquesActive(Boolean(data.acceptationRisquesActive))
+        setGelApresAcceptationActive(Boolean(data.gelApresAcceptationActive))
         setDerogationsActive(Boolean(data.derogationsActive))
         if (data.actionDelaisMois && typeof data.actionDelaisMois === 'object') setActionDelais({ CRITIQUE: 6, MAJEUR: 12, MODERE: 24, ...data.actionDelaisMois })
         if (typeof data.derogationDureeDefautJours === 'number') setDerogationDuree(data.derogationDureeDefautJours)
@@ -258,6 +260,7 @@ export default function ConfigurationPage() {
     conformiteActive: setConformiteActive,
     conseilsAteliersActive: setConseilsAteliersActive,
     acceptationRisquesActive: setAcceptationRisquesActive,
+    gelApresAcceptationActive: setGelApresAcceptationActive,
     derogationsActive: setDerogationsActive,
     derogationDoubleRegard: setDerogationDoubleRegard,
     derogationSortCatalogue: setDerogationSortCatalogue,
@@ -269,7 +272,7 @@ export default function ConfigurationPage() {
     reglementaireActive: setReglementaireActive,
     secondeLigneActive: setSecondeLigneActive,
   }
-  async function saveFeature(field: 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive', value: boolean) {
+  async function saveFeature(field: 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'gelApresAcceptationActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive', value: boolean) {
     FEATURE_SETTERS[field]?.(value) // mise à jour optimiste
     setSavingFeatures(true)
     const res = await fetch('/api/admin/organization-config', {
@@ -1251,6 +1254,7 @@ export default function ConfigurationPage() {
                 { field: 'conformiteActive' as const, value: conformiteActive, title: t.features.conformiteTitle, desc: t.features.conformiteDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
                 { field: 'conseilsAteliersActive' as const, value: conseilsAteliersActive, title: t.features.conseilsTitle, desc: t.features.conseilsDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
                 { field: 'acceptationRisquesActive' as const, value: acceptationRisquesActive, title: t.features.acceptationRisquesTitle, desc: t.features.acceptationRisquesDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
+                { field: 'gelApresAcceptationActive' as const, value: gelApresAcceptationActive, title: t.features.gelApresAcceptationTitle, desc: t.features.gelApresAcceptationDesc, href: 'https://club-ebios.org/site/', disabled: !acceptationRisquesActive, indent: true },
                 { field: 'derogationsActive' as const, value: derogationsActive, title: t.features.derogationsTitle, desc: t.features.derogationsDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
                 { field: 'registreRisquesActive' as const, value: registreRisquesActive, title: t.features.registreRisquesTitle, desc: t.features.registreRisquesDesc, href: 'https://www.acpr.banque-france.fr/', disabled: modulesPolicy.registreRisques === 'FORCE_ON' || modulesPolicy.registreRisques === 'FORCE_OFF', indent: false, forced: modulesPolicy.registreRisques },
                 { field: 'incidentsActive' as const, value: incidentsActive, title: t.features.incidentsTitle, desc: t.features.incidentsDesc, href: 'https://www.acpr.banque-france.fr/', disabled: modulesPolicy.incidents === 'FORCE_ON' || modulesPolicy.incidents === 'FORCE_OFF', indent: false, forced: modulesPolicy.incidents },

--- a/src/components/ResidualRisksPanel.tsx
+++ b/src/components/ResidualRisksPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Lock } from 'lucide-react'
 import { useTranslation } from '@/lib/i18n/context'
 
 type Statut = 'EN_ATTENTE' | 'ACCEPTES' | 'REFUSES' | string
@@ -12,13 +13,15 @@ type Statut = 'EN_ATTENTE' | 'ACCEPTES' | 'REFUSES' | string
  * Direction métier (ou un admin) peut agir (`canAct`).
  */
 export default function ResidualRisksPanel({
-  analyseId, statut: statut0, le: le0, commentaire: commentaire0, canAct, locale,
+  analyseId, statut: statut0, le: le0, commentaire: commentaire0, canAct, gelActive = false, canReopen = false, locale,
 }: {
   analyseId: string
   statut: Statut
   le: string | null
   commentaire: string | null
   canAct: boolean
+  gelActive?: boolean
+  canReopen?: boolean
   locale: string
 }) {
   const { t } = useTranslation()
@@ -29,6 +32,24 @@ export default function ResidualRisksPanel({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Analyse gelée : risques acceptés ET gel activé pour l'org → lecture seule,
+  // réouverture uniquement via une nouvelle version.
+  const frozen = statut === 'ACCEPTES' && gelActive
+
+  async function reopen() {
+    setBusy(true); setError(null)
+    try {
+      const res = await fetch(`/api/analyses/${analyseId}/revisions`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cycle: 'STRATEGIQUE', note: r.reopenNote, ateliers: [] }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) { setError(data.error || 'Erreur'); return }
+      // La nouvelle version a remis le statut à « en attente » et déverrouillé l'analyse.
+      if (typeof window !== 'undefined') window.location.reload()
+    } finally { setBusy(false) }
+  }
+
   async function decide(action: 'ACCEPTER' | 'REFUSER' | 'REINITIALISER') {
     setBusy(true); setError(null)
     try {
@@ -38,6 +59,11 @@ export default function ResidualRisksPanel({
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) { setError(data.error || 'Erreur'); return }
+      // Si le gel est actif, l'acceptation fige toute l'analyse (ateliers en lecture
+      // seule) : on recharge pour refléter l'état gelé partout, pas seulement ici.
+      if (action === 'ACCEPTER' && gelActive && data.risquesResiduelsStatut === 'ACCEPTES') {
+        if (typeof window !== 'undefined') { window.location.reload(); return }
+      }
       setStatut(data.risquesResiduelsStatut)
       setLe(data.risquesResiduelsLe ?? null)
       setCommentaire(data.risquesResiduelsCommentaire ?? '')
@@ -68,7 +94,20 @@ export default function ResidualRisksPanel({
 
       {error && <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-3 py-2 text-sm mb-3">{error}</div>}
 
-      {canAct ? (
+      {frozen ? (
+        <div className="space-y-3">
+          <div className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2">
+            <Lock size={15} className="mt-0.5 flex-shrink-0 text-gray-400" aria-hidden="true" />
+            <span>{r.frozenNotice}</span>
+          </div>
+          {canReopen && (
+            <button onClick={reopen} disabled={busy}
+              className="px-4 py-2 rounded-lg border border-ebios-300 dark:border-ebios-500/40 text-ebios-700 dark:text-ebios-300 text-sm font-medium hover:bg-ebios-50 dark:hover:bg-ebios-500/10 disabled:opacity-60">
+              {busy ? r.reopenBusy : r.reopen}
+            </button>
+          )}
+        </div>
+      ) : canAct ? (
         <div className="space-y-3">
           <textarea
             value={commentaire}

--- a/src/lib/gel-analyse.ts
+++ b/src/lib/gel-analyse.ts
@@ -1,0 +1,20 @@
+// ─── Gel d'une analyse après acceptation des risques résiduels ──────────────
+// Gouvernance : une fois que la Direction métier a ACCEPTÉ les risques résiduels,
+// l'analyse est figée (lecture seule) tant que la fonctionnalité est active pour
+// l'organisation (OrganizationConfig.gelApresAcceptationActive). Toute modification
+// exige d'ouvrir une NOUVELLE VERSION (révision), ce qui remet la décision
+// d'acceptation à « en attente ».
+//
+// Règle PURE et testée — l'API (garde de sauvegarde), la page (lecture seule) et
+// le panneau d'acceptation la lisent, sans la redériver.
+
+/** Statut d'acceptation des risques résiduels qui déclenche le gel. */
+export const STATUT_GEL = 'ACCEPTES'
+
+/**
+ * Une analyse est-elle gelée ? Vrai uniquement si le gel est activé pour l'org
+ * ET que les risques résiduels ont été acceptés.
+ */
+export function analyseGelee(risquesResiduelsStatut: string | null | undefined, gelActive: boolean): boolean {
+  return gelActive === true && risquesResiduelsStatut === STATUT_GEL
+}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -825,6 +825,10 @@ export const de: Translations = {
     reset: 'Zurücksetzen',
     commentPlaceholder: 'Kommentar (bei Ablehnung erforderlich)…',
     readOnlyHint: 'Nur die Fachbereichsleitung kann Restrisiken akzeptieren oder ablehnen.',
+    frozenNotice: 'Die Restrisiken wurden akzeptiert: Die Analyse ist eingefroren (schreibgeschützt). Öffnen Sie eine neue Version, um sie zu ändern — die Akzeptanzentscheidung muss dann erneut getroffen werden.',
+    reopen: 'Als neue Version öffnen',
+    reopenBusy: 'Wird geöffnet…',
+    reopenNote: 'Wiedereröffnung nach Akzeptanz der Restrisiken',
   },
 
   derogations: {
@@ -3058,6 +3062,8 @@ export const de: Translations = {
     conseilsDesc:       'Zeigt neben jedem Workshop die empfohlenen Teilnehmer (Fachbereich, IT, CISO…) und wesentliche Tipps (EBIOS RM / Club EBIOS). Von jedem Benutzer ausblendbar.',
     acceptationRisquesTitle: 'Akzeptanz von Restrisiken (Fachbereichsleitung)',
     acceptationRisquesDesc:  'Ermöglicht der Rolle „Fachbereichsleitung“, die Restrisiken einer Analyse zu akzeptieren (oder abzulehnen) — Risikoakzeptanz, getrennt von der Validierung der Analyse.',
+    gelApresAcceptationTitle: 'Analyse nach Risikoakzeptanz einfrieren',
+    gelApresAcceptationDesc:  'Sobald die Restrisiken akzeptiert sind, wird die Analyse eingefroren (schreibgeschützt); jede Änderung erfordert eine neue Version. In der Produktion empfohlen; für Testumgebungen deaktivierbar.',
     derogationsTitle:   'Ausnahmegenehmigungen (vorübergehende Akzeptanz von Nichtkonformität)',
     derogationsDesc:    'Ermöglicht die vorübergehende Akzeptanz einer Nichtkonformität der Sicherheitsbasis: Antrag des Verantwortlichen, CISO-Stellungnahme, Freigabe durch die Fachbereichsleitung, Ablaufdatum und Warnungen vor dem Ablauf.',
     derogationDureeLabel: 'Standarddauer einer Ausnahmegenehmigung (Tage)',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -825,6 +825,10 @@ export const en: Translations = {
     reset: 'Reset',
     commentPlaceholder: 'Comment (required when refusing)…',
     readOnlyHint: 'Only Business management can accept or refuse residual risks.',
+    frozenNotice: 'Residual risks have been accepted: the analysis is frozen (read-only). To modify it, open a new version — the acceptance decision will then need to be made again.',
+    reopen: 'Reopen as a new version',
+    reopenBusy: 'Reopening…',
+    reopenNote: 'Reopened after residual risk acceptance',
   },
 
   derogations: {
@@ -3058,6 +3062,8 @@ export const en: Translations = {
     conseilsDesc:       'Shows, next to each workshop, the recommended participants (Business, IT dept, CISO…) and essential tips (EBIOS RM / Club EBIOS). Can be hidden by each user.',
     acceptationRisquesTitle: 'Residual risk acceptance (Business management)',
     acceptationRisquesDesc:  'Lets the “Business management” role accept (or refuse) an analysis\'s residual risks — risk acceptance, distinct from analysis validation.',
+    gelApresAcceptationTitle: 'Freeze the analysis after risk acceptance',
+    gelApresAcceptationDesc:  'Once residual risks are accepted, the analysis is frozen (read-only); any change requires opening a new version. Recommended in production; can be turned off for test environments.',
     derogationsTitle:   'Waivers (temporary acceptance of non-conformity)',
     derogationsDesc:    'Allows temporary acceptance of a baseline non-conformity: request by the owner, CISO opinion, validation by Business management, expiry date and alerts before expiration.',
     derogationDureeLabel: 'Default waiver duration (days)',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -825,6 +825,10 @@ export const es: Translations = {
     reset: 'Restablecer',
     commentPlaceholder: 'Comentario (obligatorio en caso de rechazo)…',
     readOnlyHint: 'Solo la Dirección de negocio puede aceptar o rechazar los riesgos residuales.',
+    frozenNotice: 'Los riesgos residuales han sido aceptados: el análisis está congelado (solo lectura). Para modificarlo, abra una nueva versión — la decisión de aceptación deberá tomarse de nuevo.',
+    reopen: 'Reabrir en una nueva versión',
+    reopenBusy: 'Reabriendo…',
+    reopenNote: 'Reapertura tras la aceptación de los riesgos residuales',
   },
 
   derogations: {
@@ -3058,6 +3062,8 @@ export const es: Translations = {
     conseilsDesc:       'Muestra, junto a cada taller, los participantes recomendados (Negocio, TI, CISO…) y consejos esenciales (EBIOS RM / Club EBIOS). Cada usuario puede ocultarlo.',
     acceptationRisquesTitle: 'Aceptación de riesgos residuales (Dirección de negocio)',
     acceptationRisquesDesc:  'Permite al rol «Dirección de negocio» aceptar (o rechazar) los riesgos residuales de un análisis — aceptación del riesgo, distinta de la validación del análisis.',
+    gelApresAcceptationTitle: 'Congelar el análisis tras la aceptación de riesgos',
+    gelApresAcceptationDesc:  'Una vez aceptados los riesgos residuales, el análisis se congela (solo lectura); cualquier cambio requiere abrir una nueva versión. Recomendado en producción; se puede desactivar en entornos de prueba.',
     derogationsTitle:   'Exenciones (aceptación temporal de no conformidad)',
     derogationsDesc:    'Permite aceptar temporalmente una no conformidad de la base de seguridad: solicitud del responsable, dictamen del CISO, validación por la Dirección de negocio, fecha de vencimiento y alertas antes de la expiración.',
     derogationDureeLabel: 'Duración por defecto de una exención (días)',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -842,6 +842,10 @@ export const fr = {
     reset: 'Réinitialiser',
     commentPlaceholder: 'Commentaire (obligatoire en cas de refus)…',
     readOnlyHint: 'Seule la Direction métier peut accepter ou refuser les risques résiduels.',
+    frozenNotice: 'Les risques résiduels ont été acceptés : l\'analyse est gelée (lecture seule). Pour la modifier, ouvrez une nouvelle version — la décision d\'acceptation devra alors être reprise.',
+    reopen: 'Rouvrir en nouvelle version',
+    reopenBusy: 'Réouverture…',
+    reopenNote: 'Réouverture après acceptation des risques résiduels',
   },
 
   derogations: {
@@ -3106,6 +3110,8 @@ export const fr = {
     conseilsDesc:       "Affiche, à côté de chaque atelier, les participants recommandés (Métier, DSI, RSSI…) et des conseils essentiels (EBIOS RM / Club EBIOS). Masquable par chaque utilisateur.",
     acceptationRisquesTitle: 'Acceptation des risques résiduels (Direction métier)',
     acceptationRisquesDesc:  "Permet au rôle « Direction métier » d'accepter (ou refuser) les risques résiduels d'une analyse — acceptation du risque, distincte de la validation de l'analyse.",
+    gelApresAcceptationTitle: 'Gel de l\'analyse après acceptation des risques',
+    gelApresAcceptationDesc:  'Une fois les risques résiduels acceptés, l\'analyse est figée (lecture seule) ; toute modification exige d\'ouvrir une nouvelle version. Recommandé en production ; désactivable pour les environnements de test.',
     derogationsTitle:   'Dérogations (acceptation temporaire de non-conformité)',
     derogationsDesc:    "Permet d'accepter temporairement une non-conformité au socle : demande du porteur, avis RSSI, validation par la Direction métier, échéance et alertes avant expiration.",
     derogationDureeLabel: 'Durée par défaut d\'une dérogation (jours)',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -825,6 +825,10 @@ export const it: Translations = {
     reset: 'Reimposta',
     commentPlaceholder: 'Commento (obbligatorio in caso di rifiuto)…',
     readOnlyHint: 'Solo la Direzione aziendale può accettare o rifiutare i rischi residui.',
+    frozenNotice: 'I rischi residui sono stati accettati: l\'analisi è congelata (sola lettura). Per modificarla, apri una nuova versione — la decisione di accettazione dovrà essere ripresa.',
+    reopen: 'Riapri in una nuova versione',
+    reopenBusy: 'Riapertura…',
+    reopenNote: 'Riapertura dopo l\'accettazione dei rischi residui',
   },
 
   derogations: {
@@ -3058,6 +3062,8 @@ export const it: Translations = {
     conseilsDesc:       'Mostra, accanto a ogni workshop, i partecipanti consigliati (Business, IT, CISO…) e consigli essenziali (EBIOS RM / Club EBIOS). Ogni utente può nasconderlo.',
     acceptationRisquesTitle: 'Accettazione dei rischi residui (Direzione aziendale)',
     acceptationRisquesDesc:  'Consente al ruolo «Direzione aziendale» di accettare (o rifiutare) i rischi residui di un\'analisi — accettazione del rischio, distinta dalla validazione dell\'analisi.',
+    gelApresAcceptationTitle: 'Congela l\'analisi dopo l\'accettazione dei rischi',
+    gelApresAcceptationDesc:  'Una volta accettati i rischi residui, l\'analisi è congelata (sola lettura); qualsiasi modifica richiede l\'apertura di una nuova versione. Consigliato in produzione; disattivabile per gli ambienti di test.',
     derogationsTitle:   'Deroghe (accettazione temporanea di non conformità)',
     derogationsDesc:    'Consente di accettare temporaneamente una non conformità della base di sicurezza: richiesta del responsabile, parere del CISO, validazione della Direzione aziendale, data di scadenza e avvisi prima della scadenza.',
     derogationDureeLabel: 'Durata predefinita di una deroga (giorni)',

--- a/src/lib/org-config.server.ts
+++ b/src/lib/org-config.server.ts
@@ -25,6 +25,7 @@ const CONFIG_SELECT = {
   conformiteSnapshotMode: true,
   conseilsAteliersActive: true,
   acceptationRisquesActive: true,
+  gelApresAcceptationActive: true,
   derogationsActive: true,
   derogationDureeDefautJours: true,
   derogationAlerteJours: true,

--- a/src/lib/org-config.ts
+++ b/src/lib/org-config.ts
@@ -40,6 +40,7 @@ export interface RawOrgConfig {
   conformiteSnapshotMode: string
   conseilsAteliersActive: boolean
   acceptationRisquesActive: boolean
+  gelApresAcceptationActive: boolean
   derogationsActive: boolean
   derogationDureeDefautJours: number
   derogationAlerteJours: number
@@ -73,6 +74,7 @@ export interface OrgConfigResolved {
   conformiteSnapshotMode: string
   conseilsAteliersActive: boolean
   acceptationRisquesActive: boolean
+  gelApresAcceptationActive: boolean
   derogationsActive: boolean
   derogationDureeDefautJours: number
   derogationAlerteJours: number
@@ -108,6 +110,7 @@ export const DEFAULT_ORG_CONFIG: OrgConfigResolved = {
   conformiteSnapshotMode: 'MANUEL',
   conseilsAteliersActive: true,
   acceptationRisquesActive: false,
+  gelApresAcceptationActive: false,
   derogationsActive: false,
   derogationDureeDefautJours: 180,
   derogationAlerteJours: 30,
@@ -135,7 +138,7 @@ function isEmptyJson(v: unknown): boolean {
 }
 
 type JsonKey = 'entitesMesures' | 'typesImpacts' | 'referentielsActifs' | 'strategiesTraitement' | 'exemplesAteliers' | 'echellesEcosysteme' | 'taxonomieRisques' | 'appetitRisque' | 'actionDelaisMois'
-type BoolKey = 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive'
+type BoolKey = 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'gelApresAcceptationActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive'
 type StrKey = 'conformiteNiveau' | 'conformiteSnapshotMode' | 'derogationWorkflow'
 type IntKey = 'derogationDureeDefautJours' | 'derogationAlerteJours'
 
@@ -184,6 +187,7 @@ export function resolveOrgConfig(chainSelfFirst: (RawOrgConfig | null)[], defaul
     conformiteSnapshotMode: pickStr('conformiteSnapshotMode', defaults.conformiteSnapshotMode),
     conseilsAteliersActive: pickBool('conseilsAteliersActive', defaults.conseilsAteliersActive),
     acceptationRisquesActive: pickBool('acceptationRisquesActive', defaults.acceptationRisquesActive),
+    gelApresAcceptationActive: pickBool('gelApresAcceptationActive', defaults.gelApresAcceptationActive),
     derogationsActive: pickBool('derogationsActive', defaults.derogationsActive),
     derogationDureeDefautJours: pickInt('derogationDureeDefautJours', defaults.derogationDureeDefautJours),
     derogationAlerteJours: pickInt('derogationAlerteJours', defaults.derogationAlerteJours),


### PR DESCRIPTION
Corrige le défaut signalé (les boutons **Accepter/Refuser restaient actifs après acceptation**) et met en place le **gel de gouvernance** demandé : une fois les risques résiduels **acceptés** par la Direction métier, l'analyse est **figée** ; pour la modifier il faut **ouvrir une nouvelle version**.

## Réglage (modèle de config, ADMIN)
- `OrganizationConfig.gelApresAcceptationActive` — **défaut `false`** (rétrocompatible : aucune analyse déjà acceptée n'est gelée sans action de l'admin ; on l'active en prod, on le laisse off en test/dev). Réglable dans **/configuration**, imbriqué sous « Acceptation des risques » (désactivé si l'acceptation n'est pas active). Hérité dans l'arbre multi-org via `resolveOrgConfig`.

## Verrouillage en un seul point
- **Garde serveur** dans `workshop/[num]` PUT → `403 « Analyse gelée… »` (précédent : blocage si `APPROUVE`).
- **Page analyse** : `locked` étendu → ateliers en lecture seule + bannière existante.
- **Panneau d'acceptation** : masque Accepter/Refuser une fois gelé, affiche l'état verrouillé + **« Rouvrir en nouvelle version »**.

## Réouverture = nouvelle version
`revisions POST` remet le statut d'acceptation à `EN_ATTENTE` et déverrouille (une nouvelle version invalide l'acceptation précédente — traçable via la révision).

## Tests / QA
- Règle pure `analyseGelee()` testée (actif+accepté uniquement).
- `tsc` propre · **1461/1461** Vitest.
- **Runtime vérifié** sur localhost:3000 : migration appliquée (migrator exit 0), colonne `gelApresAcceptationActive boolean default false` présente, app 200.

Défaut = **désactivé** (réponse Q2 + règle projet). Si tu préfères **activé par défaut**, c'est une seule valeur à changer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)