### PR TITLE
feat(gouvernance): gel après acceptation activé par défaut

### DIFF
--- a/prisma/migrations/20260907160000_gel_defaut_actif/migration.sql
+++ b/prisma/migrations/20260907160000_gel_defaut_actif/migration.sql
@@ -1,0 +1,3 @@
+-- Gel après acceptation : activé par défaut (gouvernance)
+ALTER TABLE "OrganizationConfig" ALTER COLUMN "gelApresAcceptationActive" SET DEFAULT true;
+UPDATE "OrganizationConfig" SET "gelApresAcceptationActive" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1430,7 +1430,8 @@ model OrganizationConfig {
   acceptationRisquesActive   Boolean       @default(false)
   // Gel de l'analyse après acceptation des risques résiduels : une fois acceptés,
   // l'analyse est figée (lecture seule) et toute modification exige une nouvelle version.
-  gelApresAcceptationActive  Boolean       @default(false)
+  // Activé par défaut (gouvernance) ; désactivable par l'ADMIN (ex. test/dev).
+  gelApresAcceptationActive  Boolean       @default(true)
   // Fonctionnalité optionnelle : dérogations (acceptation temporaire d'une non-conformité
   // au socle, avec échéance + suivi). Voir docs/derogations-spec.md.
   derogationsActive          Boolean       @default(false)

--- a/src/lib/org-config.ts
+++ b/src/lib/org-config.ts
@@ -110,7 +110,7 @@ export const DEFAULT_ORG_CONFIG: OrgConfigResolved = {
   conformiteSnapshotMode: 'MANUEL',
   conseilsAteliersActive: true,
   acceptationRisquesActive: false,
-  gelApresAcceptationActive: false,
+  gelApresAcceptationActive: true,
   derogationsActive: false,
   derogationDureeDefautJours: 180,
   derogationAlerteJours: 30,


### PR DESCRIPTION
Bascule `gelApresAcceptationActive` à **true par défaut** (demande utilisateur). Une analyse dont les risques résiduels sont acceptés est **figée par défaut** ; l'ADMIN peut désactiver le gel (test/dev).

- `schema.prisma` : `@default(true)` · `DEFAULT_ORG_CONFIG` : true · migration (SET DEFAULT true + UPDATE des lignes existantes).
- Note : sur base déjà migrée, migrate-recover réconcilie sans rejouer le SQL → appliqué manuellement (instance locale OK) ; sur base neuve, appliqué normalement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)