### PR TITLE
fix(tiers): message clair quand la fusion ne renomme rien

### DIFF
--- a/src/components/TiersClient.tsx
+++ b/src/components/TiersClient.tsx
@@ -88,7 +88,13 @@ export default function TiersClient({ tiers, canMerge = false }: { tiers: Consol
       })
       if (res.ok) {
         const d = await res.json() as { renamed: number; blocked: number }
-        setMergeMsg(t.tiers.mergeDone.replace('{n}', String(d.renamed)).replace('{b}', String(d.blocked)))
+        // Aucun renommage possible : les doublons sont dans des analyses finalisées
+        // (soumises/approuvées/terminées), non modifiables → message explicite.
+        setMergeMsg(
+          d.renamed === 0 && d.blocked > 0
+            ? t.tiers.mergeBlocked.replace('{b}', String(d.blocked))
+            : t.tiers.mergeDone.replace('{n}', String(d.renamed)).replace('{b}', String(d.blocked))
+        )
         router.refresh()
       } else {
         setMergeMsg(t.tiers.mergeError)

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -126,6 +126,7 @@ export const de: Translations = {
     mergeConfirmTitle: 'Diese Dritten zusammenführen?',
     mergeConfirmMsg: 'Alle Vorkommen werden in den von Ihnen bearbeitbaren Analysen in „{cible}“ umbenannt (eingereichte oder genehmigte Analysen bleiben unberührt). Dies kann nicht rückgängig gemacht werden.',
     mergeDone: '{n} Vorkommen umbenannt, {b} übersprungen (außerhalb Ihres Bearbeitungsbereichs).',
+    mergeBlocked: 'Keine Zusammenführung möglich: Die {b} Vorkommen liegen in abgeschlossenen Analysen (eingereicht, genehmigt oder abgeschlossen), die nicht änderbar sind. Öffnen Sie eine neue Version der Analyse, um den Namen zu vereinheitlichen.',
     mergeError: 'Zusammenführung fehlgeschlagen. Bitte erneut versuchen.',
   },
 

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -126,6 +126,7 @@ export const en: Translations = {
     mergeConfirmTitle: 'Merge these third parties?',
     mergeConfirmMsg: 'All occurrences will be renamed “{cible}” in the analyses you can edit (submitted or approved analyses are left untouched). This cannot be undone.',
     mergeDone: '{n} occurrence(s) renamed, {b} skipped (outside your edit scope).',
+    mergeBlocked: 'No merge possible: the {b} occurrence(s) are in finalized analyses (submitted, approved or completed), which cannot be modified. Reopen a new version of the analysis to harmonize the name.',
     mergeError: 'Merge failed. Please try again.',
   },
 

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -126,6 +126,7 @@ export const es: Translations = {
     mergeConfirmTitle: '¿Fusionar estos terceros?',
     mergeConfirmMsg: 'Todas las apariciones se renombrarán «{cible}» en los análisis que puedes editar (los análisis enviados o aprobados no se modifican). Acción irreversible.',
     mergeDone: '{n} aparición(es) renombrada(s), {b} omitida(s) (fuera de tu ámbito de edición).',
+    mergeBlocked: 'Ninguna fusión posible: las {b} apariciones están en análisis finalizados (enviados, aprobados o terminados), no modificables. Reabra una nueva versión del análisis para armonizar el nombre.',
     mergeError: 'La fusión falló. Inténtalo de nuevo.',
   },
 

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -127,6 +127,7 @@ export const fr = {
     mergeConfirmTitle: 'Fusionner ces tiers ?',
     mergeConfirmMsg: 'Toutes les occurrences seront renommées « {cible} » dans les analyses que vous pouvez modifier (les analyses soumises ou approuvées ne sont pas touchées). Action irréversible.',
     mergeDone: "{n} occurrence(s) renommée(s), {b} ignorée(s) (hors de votre périmètre d'édition).",
+    mergeBlocked: 'Aucune fusion possible : les {b} occurrence(s) sont dans des analyses finalisées (soumises, approuvées ou terminées), non modifiables. Rouvrez une nouvelle version de l’analyse concernée pour harmoniser le nom.',
     mergeError: 'La fusion a échoué. Réessayez.',
   },
 

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -126,6 +126,7 @@ export const it: Translations = {
     mergeConfirmTitle: 'Unire queste terze parti?',
     mergeConfirmMsg: 'Tutte le occorrenze saranno rinominate «{cible}» nelle analisi che puoi modificare (le analisi inviate o approvate non vengono toccate). Azione irreversibile.',
     mergeDone: '{n} occorrenza/e rinominata/e, {b} ignorata/e (fuori dal tuo ambito di modifica).',
+    mergeBlocked: 'Nessuna fusione possibile: le {b} occorrenze sono in analisi finalizzate (inviate, approvate o completate), non modificabili. Riapri una nuova versione dell’analisi per armonizzare il nome.',
     mergeError: 'Unione non riuscita. Riprova.',
   },
 


### PR DESCRIPTION
**Cause du « il ne se passe rien »** (reproduite sur tes données) : les doublons flaggés — ex. « Éditeur du SIH » (SOUMIS) vs « Éditeur SIH (MediSoft) » (TERMINE) — sont dans des **analyses finalisées**, que la fusion ne modifie jamais (immuabilité volontaire). Résultat : `renamed=0`, le compte ne bouge pas, sans explication.

Ajoute un message explicite **mergeBlocked** quand rien n'a pu être renommé : « Aucune fusion possible : les N occurrences sont dans des analyses finalisées, non modifiables. Rouvrez une nouvelle version pour harmoniser le nom. » (fr/en/de/es/it).

**Question de politique** (à trancher séparément) : veux-tu autoriser l'harmonisation d'un nom de tiers même dans une analyse finalisée (renommage cosmétique, ne change aucune cotation) ? Aujourd'hui c'est interdit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)