### PR TITLE
feat(export): export Word (.docx) + cohérence CSV/XLSX + menu complet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-pdf/renderer": "^4.5.1",
         "@types/nodemailer": "^8.0.1",
         "bcryptjs": "^2.4.3",
+        "docx": "^9.7.1",
         "exceljs": "^4.4.0",
         "lucide-react": "^1.17.0",
         "next": "^16.2.11",
@@ -5349,6 +5350,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/docx": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
+      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/docx/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -6786,6 +6819,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -8132,6 +8175,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -9550,6 +9599,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -11204,6 +11262,24 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@react-pdf/renderer": "^4.5.1",
     "@types/nodemailer": "^8.0.1",
     "bcryptjs": "^2.4.3",
+    "docx": "^9.7.1",
     "exceljs": "^4.4.0",
     "lucide-react": "^1.17.0",
     "next": "^16.2.11",

--- a/src/__tests__/unit/lib/analyse-docx.test.ts
+++ b/src/__tests__/unit/lib/analyse-docx.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import { renderAnalyseDocx } from '../../../lib/analyse-docx'
+
+const analyse = {
+  nom: 'Analyse SI hôpital', organisation: 'CHU Démo', secteur: 'Santé', mentionProtection: 'RESTREINTE',
+  statut: 'APPROUVE', versionMajeure: 2, versionMineure: 1,
+  cadrage: {
+    perimetre: 'Système d’information hospitalier et services de soins critiques.',
+    valeursMetier: [{ nom: 'Dossier patient' }, { nom: 'Prise de rendez-vous' }],
+    biensSupports: [{ nom: 'SGBD' }, { nom: 'Réseau LAN' }],
+    socleSecurite: [{ ref: '5.1', statut: 'conforme' }, { ref: '8.8', statut: 'partiel' }],
+  },
+  sourcesRisque: [{ nom: 'Cybercriminel', categorie: 'CYBERCRIMINEL', pertinence: 3, retenu: true, objectifsVises: [{ nom: 'Rançongiciel' }] }],
+  partiesPrenantes: [{ nom: 'Hébergeur', type: 'PRESTATAIRE', exposition: 12, fiabilite: 6 }],
+  scenariosStrategiques: [{ nom: 'Chiffrement des serveurs', gravite: 4, vraisemblance: 3, niveauRisque: 12, retenu: true }],
+  risques: [
+    { nom: 'Indisponibilité des soins', gravite: 4, vraisemblance: 3, niveauRisque: 12, strategie: 'REDUIRE', niveauResiduel: 6 },
+    { nom: 'Fuite de données patients', gravite: 4, vraisemblance: 2, niveauRisque: 8, strategie: 'REDUIRE', niveauResiduel: 4 },
+  ],
+  mesures: [
+    { nom: 'Sauvegardes isolées', type: 'PREVENTIVE', priorite: 1, statut: 'EN_COURS', responsable: 'DSI', echeance: '2026-06-01' },
+    { nom: 'MFA généralisé', type: 'PREVENTIVE', priorite: 2, statut: 'REALISE', responsable: 'RSSI' },
+  ],
+  revisions: [{ version: '2.1', createdAt: '2026-07-15', note: 'Révision post-audit' }],
+}
+
+describe('renderAnalyseDocx', () => {
+  it('produit un Buffer .docx valide (signature ZIP « PK ») en fr et en', async () => {
+    for (const loc of ['fr', 'en']) {
+      const buf = await renderAnalyseDocx(analyse as Record<string, unknown>, null, loc)
+      expect(Buffer.isBuffer(buf)).toBe(true)
+      expect(buf.length).toBeGreaterThan(3000)
+      expect(buf[0]).toBe(0x50) // P
+      expect(buf[1]).toBe(0x4b) // K
+    }
+  })
+
+  it('ne plante pas sur une analyse vide', async () => {
+    const buf = await renderAnalyseDocx({ nom: 'Vide' } as Record<string, unknown>, null, 'fr')
+    expect(Buffer.isBuffer(buf)).toBe(true)
+    expect(buf.length).toBeGreaterThan(2000)
+  })
+})

--- a/src/app/analyses/[id]/page.tsx
+++ b/src/app/analyses/[id]/page.tsx
@@ -20,6 +20,7 @@ import { analyseGelee } from '@/lib/gel-analyse'
 import AccessPanel from '@/components/AccessPanel'
 import PDFExportButton from '@/components/PDFExportButton'
 import PptxExportButton from '@/components/PptxExportButton'
+import DocxExportButton from '@/components/DocxExportButton'
 import AnalyseMetaEditor from '@/components/AnalyseMetaEditor'
 import SocleToggle from '@/components/SocleToggle'
 import QualificationPanel from '@/components/QualificationPanel'
@@ -231,6 +232,7 @@ export default async function AnalyseDetailPage({ params }: { params: Promise<{ 
             {/* Export disponible pour toutes les analyses */}
             <>
               <PDFExportButton analyseId={analyse.id} />
+              <DocxExportButton analyseId={analyse.id} />
               <PptxExportButton analyseId={analyse.id} />
               <a href={`/api/export/${analyse.id}?format=xlsx`} className="btn-secondary">
                 <BookOpen size={15} className="inline align-[-0.15em] mr-1.5" aria-hidden="true" /> Excel

--- a/src/app/api/export/[id]/route.ts
+++ b/src/app/api/export/[id]/route.ts
@@ -130,6 +130,30 @@ export async function GET(
     }
   }
 
+  if (format === 'docx') {
+    // Rapport Word documentaire (lib « docx » = JS pur).
+    try {
+      const { renderAnalyseDocx } = await import('@/lib/analyse-docx')
+      const { accesUtilisateurs: _ad, ...docxData } = analyse
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const config = await (prisma as any).configuration.findUnique({ where: { id: 'global' } }).catch(() => null)
+      const langParam = searchParams.get('lang')
+      const locale = ['fr', 'en', 'de', 'es', 'it'].includes(langParam ?? '') ? (langParam as string) : 'fr'
+      const buffer = await renderAnalyseDocx(docxData as Record<string, unknown>, config, locale)
+      const safeName = analyse.nom.replace(/[^a-zA-Z0-9\-_]/g, '-').slice(0, 64)
+      return new NextResponse(buffer as unknown as ArrayBuffer, {
+        headers: {
+          'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          'Content-Disposition': `attachment; filename="acra-${safeName}.docx"`,
+          'Cache-Control': 'no-store',
+        },
+      })
+    } catch (err) {
+      console.error('[export docx] génération échouée', err)
+      return NextResponse.json({ error: 'Échec de la génération du document Word' }, { status: 500 })
+    }
+  }
+
   if (format === 'csv') {
     const lines: string[] = []
     // Neutralise l'injection de formules (=,+,-,@) AVANT l'échappement CSV des guillemets
@@ -175,6 +199,32 @@ export async function GET(
     lines.push('Nom,Type,Priorité,Statut,Responsable,Entité,Échéance')
     for (const m of analyse.mesures) {
       lines.push(`${esc(m.nom)},${esc(m.type)},${m.priorite},${esc(m.statut)},${esc(m.responsable)},${esc((m as any).entite)},${m.echeance ? new Date(m.echeance).toLocaleDateString('fr-FR') : ''}`)
+    }
+    lines.push('')
+
+    // Écosystème — parties prenantes (cohérence avec PDF/XLSX)
+    lines.push('=== PARTIES PRENANTES ===')
+    lines.push('Nom,Type,Exposition,Fiabilité,Menace')
+    for (const pp of analyse.partiesPrenantes) {
+      const menace = pp.fiabilite ? (pp.exposition / pp.fiabilite).toFixed(2) : ''
+      lines.push(`${esc(pp.nom)},${esc(pp.type)},${pp.exposition ?? ''},${pp.fiabilite ?? ''},${menace}`)
+    }
+    lines.push('')
+
+    // Conformité au socle de sécurité
+    const socle = (analyse.cadrage as { socleSecurite?: { ref?: string; nom?: string; statut?: string }[] } | null)?.socleSecurite ?? []
+    lines.push('=== CONFORMITÉ AU SOCLE ===')
+    lines.push('Référence,Statut')
+    for (const e of socle) {
+      lines.push(`${esc(e.ref ?? e.nom ?? '')},${esc(e.statut ?? '')}`)
+    }
+    lines.push('')
+
+    // Historique des révisions
+    lines.push('=== RÉVISIONS ===')
+    lines.push('Version,Date,Cycle,Note')
+    for (const rev of analyse.revisions) {
+      lines.push(`${esc(rev.version)},${rev.createdAt ? new Date(rev.createdAt).toLocaleDateString('fr-FR') : ''},${esc((rev as any).cycle)},${esc(rev.note)}`)
     }
 
     const csv = lines.join('\n')
@@ -358,6 +408,36 @@ export async function GET(
         men: Number((pp.exposition / pp.fiabilite).toFixed(2)),
       }))
       styleHeaderRow(wsPP)
+    }
+
+    // ── Feuille 8 : Conformité au socle (cohérence avec PDF/CSV) ───────
+    const socleXlsx = (analyse.cadrage as { socleSecurite?: { ref?: string; nom?: string; statut?: string }[] } | null)?.socleSecurite ?? []
+    if (socleXlsx.length > 0) {
+      const wsSocle = wb.addWorksheet('Conformité socle')
+      wsSocle.columns = [
+        { header: 'Référence', key: 'ref', width: 24 },
+        { header: 'Statut', key: 'statut', width: 18 },
+      ]
+      socleXlsx.forEach(e => wsSocle.addRow({ ref: S(e.ref ?? e.nom ?? ''), statut: S(e.statut ?? '') }))
+      styleHeaderRow(wsSocle)
+    }
+
+    // ── Feuille 9 : Révisions ─────────────────────────────────────────
+    if (analyse.revisions.length > 0) {
+      const wsRev = wb.addWorksheet('Révisions')
+      wsRev.columns = [
+        { header: 'Version', key: 'version', width: 12 },
+        { header: 'Date',    key: 'date',    width: 14 },
+        { header: 'Cycle',   key: 'cycle',   width: 16 },
+        { header: 'Note',    key: 'note',    width: 62 },
+      ]
+      analyse.revisions.forEach((rev: { version: string; createdAt: Date; cycle?: string; note: string | null }) => wsRev.addRow({
+        version: S(rev.version),
+        date: rev.createdAt ? new Date(rev.createdAt).toLocaleDateString('fr-FR') : '',
+        cycle: S(rev.cycle ?? ''),
+        note: S(rev.note ?? ''),
+      }))
+      styleHeaderRow(wsRev)
     }
 
     const buf = await wb.xlsx.writeBuffer()

--- a/src/components/AnalysesClient.tsx
+++ b/src/components/AnalysesClient.tsx
@@ -8,7 +8,7 @@ import { ATELIERS_META } from '@/lib/ebios-data'
 import { getRiskTier } from '@/lib/risk-scale'
 import { useTranslation } from '@/lib/i18n/context'
 import { formatDate } from '@/lib/format'
-import { AlertCircle, AlertTriangle, ArrowDown, Calendar, CheckCircle2, Circle, ClipboardList, Clock, Download, FileJson, FileSpreadsheet, FileText, FolderOpen, Landmark, Link2, Pencil, Search, Settings, ShieldCheck, Sparkles, Trash2, Trophy, Upload, VenetianMask } from 'lucide-react'
+import { AlertCircle, AlertTriangle, ArrowDown, Calendar, CheckCircle2, Circle, ClipboardList, Clock, Download, FileJson, FileSpreadsheet, FileText, FolderOpen, Landmark, Link2, Pencil, Presentation, Search, Settings, ShieldCheck, Sparkles, Trash2, Trophy, Upload, VenetianMask } from 'lucide-react'
 import { filtrerParTag, tagsUniques } from '@/lib/analyse-tags'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import ExpressAnalyseButton from '@/components/ExpressAnalyseButton'
@@ -335,8 +335,11 @@ export default function AnalysesClient({ initialAnalyses, demo = false }: { init
                       {/* Export toujours disponible */}
                       <div className="relative group">
                         <button className="btn-secondary text-sm py-1.5 inline-flex items-center gap-1.5"><Download size={15} aria-hidden="true" /> {t.analyses.exportBtn}</button>
-                        <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-xl shadow-lg p-2 hidden group-hover:flex flex-col z-10 w-44">
-                          <a href={`/api/export/${a.id}?format=pdf`} download className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 rounded-lg"><FileText size={15} aria-hidden="true" /> PDF</a>
+                        <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-xl shadow-lg p-2 hidden group-hover:flex flex-col z-10 w-48">
+                          <a href={`/api/export/${a.id}?format=pdf&lang=${locale}`} download className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 rounded-lg"><FileText size={15} aria-hidden="true" /> PDF</a>
+                          <a href={`/api/export/${a.id}?format=docx&lang=${locale}`} download className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 rounded-lg"><FileText size={15} aria-hidden="true" /> Word</a>
+                          <a href={`/api/export/${a.id}?format=pptx&lang=${locale}`} download className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 rounded-lg"><Presentation size={15} aria-hidden="true" /> PowerPoint</a>
+                          <a href={`/api/export/${a.id}?format=xlsx`} className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 rounded-lg"><FileSpreadsheet size={15} aria-hidden="true" /> Excel</a>
                           <a href={`/api/export/${a.id}?format=csv`} className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 rounded-lg"><FileSpreadsheet size={15} aria-hidden="true" /> CSV</a>
                           <a href={`/api/export/${a.id}?format=json`} className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-gray-50 rounded-lg"><FileJson size={15} aria-hidden="true" /> JSON</a>
                         </div>

--- a/src/components/DocxExportButton.tsx
+++ b/src/components/DocxExportButton.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { FileText } from 'lucide-react'
+import { useTranslation } from '@/lib/i18n/context'
+
+/**
+ * DocxExportButton — télécharge un rapport Word (.docx) de l'analyse via
+ * /api/export/[id]?format=docx&lang=…, généré côté serveur (lib « docx »).
+ * Même endpoint et mêmes droits que les exports PDF/PPTX.
+ */
+export default function DocxExportButton({ analyseId }: { analyseId: string }) {
+  const { locale } = useTranslation()
+  return (
+    <a
+      href={`/api/export/${analyseId}?format=docx&lang=${locale}`}
+      download
+      className="btn-secondary inline-flex items-center gap-2"
+    >
+      <FileText size={16} aria-hidden="true" /> Word
+    </a>
+  )
+}

--- a/src/lib/analyse-docx.ts
+++ b/src/lib/analyse-docx.ts
@@ -1,0 +1,256 @@
+// ─── Export Word (.docx) d'une analyse de risques ───────────────────────────
+// Rapport documentaire complet (même couverture d'objets que le PDF) : couverture,
+// périmètre, valeurs métier, biens supports, sources de risque & objectifs,
+// scénarios stratégiques, écosystème, risques & traitement, plan de mesures,
+// conformité au socle, révisions. Généré avec la lib « docx » (JS pur).
+
+import {
+  Document, Packer, Paragraph, TextRun, HeadingLevel, Table, TableRow, TableCell,
+  WidthType, AlignmentType, type ISectionOptions,
+} from 'docx'
+
+type Any = Record<string, unknown> // eslint-disable-line @typescript-eslint/no-explicit-any
+
+const PRIMARY = '4338CA'
+const INK = '111827'
+const MUTED = '6B7280'
+const WHITE = 'FFFFFF'
+
+const asArr = (v: unknown): Any[] => (Array.isArray(v) ? (v as Any[]) : [])
+const s = (v: unknown): string => (typeof v === 'string' ? v : v == null ? '' : String(v))
+const num = (v: unknown): number => (Number(v) || 0)
+
+interface L {
+  coverKicker: string; org: string; secteur: string; version: string; statut: string; generatedOn: string
+  statutAnalyse: Record<string, string>; mentionLabels: Record<string, string>
+  perimetre: string; valeursMetier: string; biensSupports: string
+  srOv: string; thSource: string; thCat: string; thPert: string; thOv: string
+  scenarios: string; thRisk: string; thG: string; thV: string; thLevel: string
+  eco: string; thPP: string; thType: string; thMenace: string
+  risques: string; thStrategy: string; thResidual: string
+  plan: string; thMeasure: string; thMType: string; thPriority: string; thStatus: string; thOwner: string; thDue: string
+  conf: string; thRef: string; confStatut: Record<string, string>
+  revisions: string; thRevVersion: string; thRevDate: string; thRevNote: string
+  strategies: Record<string, string>; statuses: Record<string, string>; empty: string; none: string
+}
+
+const FR: L = {
+  coverKicker: 'Analyse de risques cyber — EBIOS Risk Manager', org: 'Organisation', secteur: 'Secteur', version: 'Version', statut: 'Statut', generatedOn: 'Généré le',
+  statutAnalyse: { EN_COURS: 'En cours', SOUMIS: 'Soumis', APPROUVE: 'Approuvé', REJETE: 'Rejeté', TERMINE: 'Terminé', ARCHIVE: 'Archivé' },
+  mentionLabels: { NON_PROTEGEE: 'Non protégée', SENSIBLE: 'Sensible', RESTREINTE: 'Diffusion restreinte', CONFIDENTIELLE: 'Confidentielle' },
+  perimetre: 'Périmètre de l’étude', valeursMetier: 'Valeurs métier', biensSupports: 'Biens supports',
+  srOv: 'Sources de risque & objectifs visés', thSource: 'Source', thCat: 'Catégorie', thPert: 'Pertinence', thOv: 'Objectifs visés',
+  scenarios: 'Scénarios stratégiques', thRisk: 'Intitulé', thG: 'G', thV: 'V', thLevel: 'Niveau',
+  eco: 'Écosystème — parties prenantes', thPP: 'Partie prenante', thType: 'Type', thMenace: 'Menace',
+  risques: 'Risques & traitement', thStrategy: 'Stratégie', thResidual: 'Résiduel',
+  plan: 'Plan de traitement', thMeasure: 'Mesure', thMType: 'Type', thPriority: 'Priorité', thStatus: 'Statut', thOwner: 'Responsable', thDue: 'Échéance',
+  conf: 'Conformité au socle de sécurité', thRef: 'Référence', confStatut: { conforme: 'Conforme', partiel: 'Partiel', non_conforme: 'Non conforme', non_applicable: 'N/A' },
+  revisions: 'Historique des révisions', thRevVersion: 'Version', thRevDate: 'Date', thRevNote: 'Note',
+  strategies: { REDUIRE: 'Réduire', ACCEPTER: 'Accepter', TRANSFERER: 'Transférer', REFUSER: 'Refuser', SURVEILLER: 'Surveiller' },
+  statuses: { A_FAIRE: 'À faire', EN_COURS: 'En cours', REALISE: 'Réalisé' }, empty: '—', none: 'Aucun élément.',
+}
+
+const EN: L = {
+  coverKicker: 'Cyber risk analysis — EBIOS Risk Manager', org: 'Organisation', secteur: 'Sector', version: 'Version', statut: 'Status', generatedOn: 'Generated on',
+  statutAnalyse: { EN_COURS: 'In progress', SOUMIS: 'Submitted', APPROUVE: 'Approved', REJETE: 'Rejected', TERMINE: 'Completed', ARCHIVE: 'Archived' },
+  mentionLabels: { NON_PROTEGEE: 'Unrestricted', SENSIBLE: 'Sensitive', RESTREINTE: 'Restricted', CONFIDENTIELLE: 'Confidential' },
+  perimetre: 'Study scope', valeursMetier: 'Business values', biensSupports: 'Supporting assets',
+  srOv: 'Risk sources & targeted objectives', thSource: 'Source', thCat: 'Category', thPert: 'Relevance', thOv: 'Targeted objectives',
+  scenarios: 'Strategic scenarios', thRisk: 'Title', thG: 'S', thV: 'L', thLevel: 'Level',
+  eco: 'Ecosystem — stakeholders', thPP: 'Stakeholder', thType: 'Type', thMenace: 'Threat',
+  risques: 'Risks & treatment', thStrategy: 'Strategy', thResidual: 'Residual',
+  plan: 'Treatment plan', thMeasure: 'Measure', thMType: 'Type', thPriority: 'Priority', thStatus: 'Status', thOwner: 'Owner', thDue: 'Due',
+  conf: 'Compliance with the security baseline', thRef: 'Reference', confStatut: { conforme: 'Compliant', partiel: 'Partial', non_conforme: 'Non-compliant', non_applicable: 'N/A' },
+  revisions: 'Revision history', thRevVersion: 'Version', thRevDate: 'Date', thRevNote: 'Note',
+  strategies: { REDUIRE: 'Reduce', ACCEPTER: 'Accept', TRANSFERER: 'Transfer', REFUSER: 'Refuse', SURVEILLER: 'Monitor' },
+  statuses: { A_FAIRE: 'To do', EN_COURS: 'In progress', REALISE: 'Done' }, empty: '—', none: 'No item.',
+}
+
+function strings(locale: string): L { return locale === 'fr' ? FR : EN }
+
+const CELL_MARGINS = { top: 40, bottom: 40, left: 90, right: 90 }
+
+function th(text: string): TableCell {
+  return new TableCell({
+    shading: { fill: PRIMARY }, margins: CELL_MARGINS,
+    children: [new Paragraph({ children: [new TextRun({ text, bold: true, color: WHITE, size: 18 })] })],
+  })
+}
+function td(text: string, align?: (typeof AlignmentType)[keyof typeof AlignmentType], color?: string): TableCell {
+  return new TableCell({
+    margins: CELL_MARGINS,
+    children: [new Paragraph({ alignment: align, children: [new TextRun({ text: text || '', size: 18, color: color ?? INK })] })],
+  })
+}
+
+type Col = { header: string; align?: (typeof AlignmentType)[keyof typeof AlignmentType] }
+function dataTable(cols: Col[], rows: { text: string; color?: string }[][]): Table {
+  return new Table({
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    rows: [
+      new TableRow({ tableHeader: true, children: cols.map(c => th(c.header)) }),
+      ...rows.map(r => new TableRow({ children: r.map((cell, i) => td(cell.text, cols[i]?.align, cell.color)) })),
+    ],
+  })
+}
+
+function heading(text: string): Paragraph {
+  return new Paragraph({ heading: HeadingLevel.HEADING_2, spacing: { before: 260, after: 120 }, children: [new TextRun({ text, color: PRIMARY, bold: true })] })
+}
+
+export async function renderAnalyseDocx(analyse: Any, config: Any | null, locale: string): Promise<Buffer> {
+  void config
+  const L = strings(locale)
+  const dateLocale = locale === 'en' ? 'en-GB' : locale === 'de' ? 'de-DE' : locale === 'es' ? 'es-ES' : locale === 'it' ? 'it-IT' : 'fr-FR'
+  const fmtDate = (d: unknown): string => { const t = new Date(d as string); return isNaN(t.getTime()) ? '' : t.toLocaleDateString(dateLocale) }
+  const cadrage = (analyse.cadrage as Any) ?? {}
+  const R = (align: (typeof AlignmentType)[keyof typeof AlignmentType]) => align
+
+  const children: (Paragraph | Table)[] = []
+
+  // ── Couverture ──
+  children.push(new Paragraph({ spacing: { after: 60 }, children: [new TextRun({ text: L.coverKicker.toUpperCase(), color: PRIMARY, bold: true, size: 18 })] }))
+  children.push(new Paragraph({ heading: HeadingLevel.TITLE, children: [new TextRun({ text: s(analyse.nom) || 'Analyse' })] }))
+  const metaLine: string[] = []
+  if (analyse.organisation) metaLine.push(`${L.org} : ${s(analyse.organisation)}`)
+  if (analyse.secteur) metaLine.push(`${L.secteur} : ${s(analyse.secteur)}`)
+  metaLine.push(`${L.version} ${num(analyse.versionMajeure) || 1}.${num(analyse.versionMineure)}`)
+  const statutLbl = L.statutAnalyse[s(analyse.statut)] ?? s(analyse.statut)
+  if (statutLbl) metaLine.push(`${L.statut} : ${statutLbl}`)
+  const mention = s(analyse.mentionProtection)
+  if (mention && mention !== 'NON_PROTEGEE') metaLine.push(L.mentionLabels[mention] ?? mention)
+  children.push(new Paragraph({ spacing: { after: 40 }, children: [new TextRun({ text: metaLine.join('   ·   '), color: MUTED, size: 20 })] }))
+  children.push(new Paragraph({ spacing: { after: 120 }, children: [new TextRun({ text: `${L.generatedOn} ${new Date().toLocaleDateString(dateLocale)}`, color: MUTED, size: 18 })] }))
+
+  // ── Périmètre ──
+  const perimetre = s(cadrage.perimetre)
+  if (perimetre) {
+    children.push(heading(L.perimetre))
+    children.push(new Paragraph({ children: [new TextRun({ text: perimetre, size: 20 })] }))
+  }
+
+  // ── Valeurs métier / Biens supports ──
+  const vms = asArr(cadrage.valeursMetier)
+  if (vms.length) {
+    children.push(heading(`${L.valeursMetier} (${vms.length})`))
+    vms.forEach(vm => children.push(new Paragraph({ bullet: { level: 0 }, children: [new TextRun({ text: s(vm.nom), size: 20 })] })))
+  }
+  const biens = asArr(cadrage.biensSupports)
+  if (biens.length) {
+    children.push(heading(`${L.biensSupports} (${biens.length})`))
+    biens.forEach(b => children.push(new Paragraph({ bullet: { level: 0 }, children: [new TextRun({ text: s(b.nom), size: 20 })] })))
+  }
+
+  // ── Sources de risque & objectifs ──
+  const srs = asArr(analyse.sourcesRisque).filter(x => x.retenu !== false)
+  if (srs.length) {
+    children.push(heading(L.srOv))
+    children.push(dataTable(
+      [{ header: L.thSource }, { header: L.thCat }, { header: L.thPert, align: R(AlignmentType.CENTER) }, { header: L.thOv }],
+      srs.map(sr => [
+        { text: s(sr.nom) },
+        { text: s(sr.categorie) },
+        { text: String(num(sr.pertinence) || '') },
+        { text: asArr(sr.objectifsVises).map(o => s(o.nom)).join(', ') },
+      ]),
+    ))
+  }
+
+  // ── Scénarios stratégiques ──
+  const scen = asArr(analyse.scenariosStrategiques).filter(x => x.retenu !== false)
+  if (scen.length) {
+    children.push(heading(L.scenarios))
+    children.push(dataTable(
+      [{ header: L.thRisk }, { header: L.thG, align: R(AlignmentType.CENTER) }, { header: L.thV, align: R(AlignmentType.CENTER) }, { header: L.thLevel, align: R(AlignmentType.CENTER) }],
+      scen.map(sc => [
+        { text: s(sc.nom) },
+        { text: String(num(sc.gravite) || '') },
+        { text: String(num(sc.vraisemblance) || '') },
+        { text: String(num(sc.niveauRisque) || '') },
+      ]),
+    ))
+  }
+
+  // ── Écosystème ──
+  const pps = asArr(analyse.partiesPrenantes)
+  if (pps.length) {
+    children.push(heading(L.eco))
+    children.push(dataTable(
+      [{ header: L.thPP }, { header: L.thType }, { header: L.thMenace, align: R(AlignmentType.CENTER) }],
+      pps.map(pp => [
+        { text: s(pp.nom) },
+        { text: s(pp.type) },
+        { text: ((num(pp.exposition) || 1) / (num(pp.fiabilite) || 1)).toFixed(2) },
+      ]),
+    ))
+  }
+
+  // ── Risques & traitement ──
+  const risques = asArr(analyse.risques)
+  if (risques.length) {
+    children.push(heading(L.risques))
+    children.push(dataTable(
+      [{ header: L.thRisk }, { header: L.thG, align: R(AlignmentType.CENTER) }, { header: L.thV, align: R(AlignmentType.CENTER) }, { header: L.thLevel, align: R(AlignmentType.CENTER) }, { header: L.thStrategy }, { header: L.thResidual, align: R(AlignmentType.CENTER) }],
+      risques.map((r, i) => [
+        { text: `R${i + 1} · ${s(r.nom)}` },
+        { text: String(num(r.gravite) || '') },
+        { text: String(num(r.vraisemblance) || '') },
+        { text: String(num(r.niveauRisque) || '') },
+        { text: L.strategies[s(r.strategie)] ?? s(r.strategie) ?? L.empty },
+        { text: r.niveauResiduel != null ? String(num(r.niveauResiduel)) : L.empty },
+      ]),
+    ))
+  }
+
+  // ── Plan de traitement ──
+  const mesures = asArr(analyse.mesures)
+  if (mesures.length) {
+    children.push(heading(L.plan))
+    children.push(dataTable(
+      [{ header: L.thMeasure }, { header: L.thMType }, { header: L.thPriority, align: R(AlignmentType.CENTER) }, { header: L.thStatus }, { header: L.thOwner }, { header: L.thDue, align: R(AlignmentType.CENTER) }],
+      mesures.map(m => [
+        { text: s(m.nom) },
+        { text: s(m.type) },
+        { text: m.priorite != null ? `P${num(m.priorite)}` : L.empty },
+        { text: L.statuses[s(m.statut)] ?? s(m.statut) ?? L.empty },
+        { text: s(m.responsable) || L.empty },
+        { text: m.echeance ? fmtDate(m.echeance) : L.empty },
+      ]),
+    ))
+  }
+
+  // ── Conformité socle ──
+  const socle = asArr(cadrage.socleSecurite)
+  if (socle.length) {
+    children.push(heading(L.conf))
+    children.push(dataTable(
+      [{ header: L.thRef }, { header: L.thStatus }],
+      socle.map(e => [
+        { text: s(e.ref) || s(e.nom) },
+        { text: L.confStatut[s(e.statut)] ?? s(e.statut) ?? L.empty },
+      ]),
+    ))
+  }
+
+  // ── Révisions ──
+  const revisions = asArr(analyse.revisions)
+  if (revisions.length) {
+    children.push(heading(L.revisions))
+    children.push(dataTable(
+      [{ header: L.thRevVersion }, { header: L.thRevDate }, { header: L.thRevNote }],
+      revisions.map(rev => [
+        { text: `v${s(rev.version)}` },
+        { text: fmtDate(rev.createdAt) },
+        { text: s(rev.note) },
+      ]),
+    ))
+  }
+
+  const section: ISectionOptions = { properties: {}, children }
+  const doc = new Document({
+    creator: 'ACRA — Augmented Cyber Risk Analysis',
+    title: s(analyse.nom) || 'Analyse',
+    sections: [section],
+  })
+  return Packer.toBuffer(doc)
+}


### PR DESCRIPTION
Réponse aux points « exports » : nouveau **docx**, **cohérence** des formats, et **menu complété**.

## Export Word (.docx) — nouveau
- `lib/analyse-docx.ts` (lib `docx`, JS pur) : **rapport documentaire complet** (même couverture que le PDF) — périmètre, valeurs métier, biens supports, sources & objectifs, scénarios stratégiques, écosystème, risques & traitement, plan de mesures, conformité au socle, révisions. i18n fr/en.
- Route : branche `format=docx` (mêmes droits/rate-limit que pdf/pptx).
- `DocxExportButton` à côté de PDF / PowerPoint sur la page d'analyse.
- QA visuelle (LibreOffice) : titres Word + tableaux stylés, aucun débordement.

## Cohérence des exports
Avant, chaque format couvrait des objets différents. Harmonisé :
- **CSV** : + parties prenantes, + conformité socle, + révisions.
- **XLSX** : + feuille « Conformité socle », + feuille « Révisions ».

| Objet | JSON | PDF | DOCX | PPTX | CSV | XLSX |
|---|---|---|---|---|---|---|
| Sources/scénarios/risques/mesures | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| Parties prenantes | ✅ | ✅ | ✅ | ✅ | ✅ (ajout) | ✅ |
| Socle de sécurité | ✅ | ✅ | ✅ | ✅ | ✅ (ajout) | ✅ (ajout) |
| Révisions | ✅ | ✅ | ✅ | ➖ | ✅ (ajout) | ✅ (ajout) |

## Menu export /analyses
N'offrait que **PDF/CSV/JSON** → ajout **Word, PowerPoint, Excel** (6 formats), avec la locale courante.

## Tests
- `renderAnalyseDocx` testé (docx valide fr/en + analyse vide). `tsc` propre · **1463/1463** Vitest.
- `docx` ajouté en dépendance (JS pur) ; les vulns audit préexistantes (`image-size` via pptxgenjs) inchangées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)