### PR TITLE
feat(tiers): harmonisation d'un nom de tiers autorisée sur analyse finalisée

### DIFF
--- a/src/app/api/tiers/merge/route.ts
+++ b/src/app/api/tiers/merge/route.ts
@@ -15,15 +15,14 @@ import { rateLimit, rateLimitHeaders, LIMIT_API_WRITE } from '@/lib/rate-limit'
 
 export const dynamic = 'force-dynamic'
 
-// Seules les analyses non finalisées sont modifiables par la fusion : on ne
-// touche jamais une analyse soumise/approuvée/terminée/archivée, même si
-// l'utilisateur en est propriétaire.
-const STATUTS_EDITABLES = new Set(['EN_COURS', 'REJETE'])
-
 /**
  * POST /api/tiers/merge — fusionne des tiers en doublon (issue #46, étape 2b) :
  * renomme vers `cible` toutes les parties prenantes portant l'un des `noms`,
- * UNIQUEMENT dans les analyses que l'utilisateur peut éditer ET non finalisées.
+ * dans TOUTES les analyses que l'utilisateur peut éditer. L'harmonisation d'un
+ * nom de tiers est un renommage COSMÉTIQUE (aucune cotation modifiée) : elle est
+ * donc autorisée même sur une analyse finalisée (soumise/approuvée/terminée),
+ * afin de pouvoir résoudre les doublons transverses. Seules les parties prenantes
+ * hors du périmètre d'ÉDITION de l'utilisateur sont laissées intactes (`blocked`).
  * Les PP situées dans des analyses verrouillées ou hors périmètre d'édition sont
  * laissées intactes et comptées dans `blocked`. Écriture auditée.
  */
@@ -83,8 +82,9 @@ export async function POST(request: Request) {
   const { renameIds, blocked } = planTierRename(
     rows,
     target,
+    // Renommage cosmétique : autorisé sur toute analyse ÉDITABLE par l'utilisateur,
+    // y compris finalisée (aucune cotation touchée).
     (r) =>
-      STATUTS_EDITABLES.has(r.analyse.statut) &&
       canEditAnalyse(user, {
         userId: r.analyse.userId,
         accesUtilisateurs: r.analyse.accesUtilisateurs,

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -126,7 +126,7 @@ export const de: Translations = {
     mergeConfirmTitle: 'Diese Dritten zusammenführen?',
     mergeConfirmMsg: 'Alle Vorkommen werden in den von Ihnen bearbeitbaren Analysen in „{cible}“ umbenannt (eingereichte oder genehmigte Analysen bleiben unberührt). Dies kann nicht rückgängig gemacht werden.',
     mergeDone: '{n} Vorkommen umbenannt, {b} übersprungen (außerhalb Ihres Bearbeitungsbereichs).',
-    mergeBlocked: 'Keine Zusammenführung möglich: Die {b} Vorkommen liegen in abgeschlossenen Analysen (eingereicht, genehmigt oder abgeschlossen), die nicht änderbar sind. Öffnen Sie eine neue Version der Analyse, um den Namen zu vereinheitlichen.',
+    mergeBlocked: 'Keine Zusammenführung möglich: Die {b} Vorkommen liegen außerhalb Ihres Bearbeitungsbereichs (Analysen anderer Nutzer oder schreibgeschützt).',
     mergeError: 'Zusammenführung fehlgeschlagen. Bitte erneut versuchen.',
   },
 

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -126,7 +126,7 @@ export const en: Translations = {
     mergeConfirmTitle: 'Merge these third parties?',
     mergeConfirmMsg: 'All occurrences will be renamed “{cible}” in the analyses you can edit (submitted or approved analyses are left untouched). This cannot be undone.',
     mergeDone: '{n} occurrence(s) renamed, {b} skipped (outside your edit scope).',
-    mergeBlocked: 'No merge possible: the {b} occurrence(s) are in finalized analyses (submitted, approved or completed), which cannot be modified. Reopen a new version of the analysis to harmonize the name.',
+    mergeBlocked: 'No merge possible: the {b} occurrence(s) are outside your edit scope (analyses owned by other users or read-only).',
     mergeError: 'Merge failed. Please try again.',
   },
 

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -126,7 +126,7 @@ export const es: Translations = {
     mergeConfirmTitle: '¿Fusionar estos terceros?',
     mergeConfirmMsg: 'Todas las apariciones se renombrarán «{cible}» en los análisis que puedes editar (los análisis enviados o aprobados no se modifican). Acción irreversible.',
     mergeDone: '{n} aparición(es) renombrada(s), {b} omitida(s) (fuera de tu ámbito de edición).',
-    mergeBlocked: 'Ninguna fusión posible: las {b} apariciones están en análisis finalizados (enviados, aprobados o terminados), no modificables. Reabra una nueva versión del análisis para armonizar el nombre.',
+    mergeBlocked: 'Ninguna fusión posible: las {b} apariciones están fuera de su ámbito de edición (análisis de otros usuarios o de solo lectura).',
     mergeError: 'La fusión falló. Inténtalo de nuevo.',
   },
 

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -127,7 +127,7 @@ export const fr = {
     mergeConfirmTitle: 'Fusionner ces tiers ?',
     mergeConfirmMsg: 'Toutes les occurrences seront renommées « {cible} » dans les analyses que vous pouvez modifier (les analyses soumises ou approuvées ne sont pas touchées). Action irréversible.',
     mergeDone: "{n} occurrence(s) renommée(s), {b} ignorée(s) (hors de votre périmètre d'édition).",
-    mergeBlocked: 'Aucune fusion possible : les {b} occurrence(s) sont dans des analyses finalisées (soumises, approuvées ou terminées), non modifiables. Rouvrez une nouvelle version de l’analyse concernée pour harmoniser le nom.',
+    mergeBlocked: 'Aucune fusion possible : les {b} occurrence(s) sont hors de votre périmètre d’édition (analyses appartenant à d’autres utilisateurs ou en lecture seule).',
     mergeError: 'La fusion a échoué. Réessayez.',
   },
 

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -126,7 +126,7 @@ export const it: Translations = {
     mergeConfirmTitle: 'Unire queste terze parti?',
     mergeConfirmMsg: 'Tutte le occorrenze saranno rinominate «{cible}» nelle analisi che puoi modificare (le analisi inviate o approvate non vengono toccate). Azione irreversibile.',
     mergeDone: '{n} occorrenza/e rinominata/e, {b} ignorata/e (fuori dal tuo ambito di modifica).',
-    mergeBlocked: 'Nessuna fusione possibile: le {b} occorrenze sono in analisi finalizzate (inviate, approvate o completate), non modificabili. Riapri una nuova versione dell’analisi per armonizzare il nome.',
+    mergeBlocked: 'Nessuna fusione possibile: le {b} occorrenze sono fuori dal tuo ambito di modifica (analisi di altri utenti o di sola lettura).',
     mergeError: 'Unione non riuscita. Riprova.',
   },
 


### PR DESCRIPTION
Suite à ta décision. L'harmonisation d'un nom de tiers est un **renommage cosmétique** (ne touche aucune cotation) : la fusion l'autorise désormais sur **toute analyse éditable**, y compris finalisée (soumise/approuvée/terminée). Ça résout les doublons transverses comme « Éditeur du SIH » (SOUMIS) vs « Éditeur SIH » (TERMINE).

- Retrait de la restriction `STATUTS_EDITABLES` (on garde `canEditAnalyse` = permission).
- `mergeBlocked` reformulé : « hors de votre périmètre d'édition » (analyses d'autres utilisateurs / lecture seule). i18n ×5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)