### PR TITLE
feat(cartographie): heat maps cockpit + PDF GRC fidèles à la matrice

### DIFF
--- a/src/app/api/grc/rollup/route.ts
+++ b/src/app/api/grc/rollup/route.ts
@@ -9,6 +9,7 @@ import { niveauRisque } from '@/lib/risk-item'
 import { summarizeActions } from '@/lib/risk-action'
 import { rollupRisks, rollupByOrg, type RiskLite, type ScopedAction } from '@/lib/grc-rollup'
 import { buildHeatGrid } from '@/lib/carto-export'
+import { getEffectiveScaleConfig } from '@/lib/configuration-server'
 import type { CartoRisk } from '@/lib/cartographie'
 import {
   rollupIncidents, incidentsByOrg,
@@ -193,6 +194,9 @@ export async function GET(req: NextRequest) {
     ...(withReglementaire ? { doraMajeurs: doraByOrg.get(o.orgId) ?? 0 } : {}),
   }))
 
+  // Matrice configurée pour une heat map fidèle (roll-up : échelle de l'org visible / racine).
+  const scaleConfig = await getEffectiveScaleConfig(orgIds[0] ?? null)
+
   return NextResponse.json({
     active: true,
     orgCount: orgs.length,
@@ -202,7 +206,7 @@ export async function GET(req: NextRequest) {
         id: r.id, intitule: '', taxonomieCode: null, processusId: null, processusNom: null, entite: null,
         graviteInherente: r.graviteInherente, vraisemblanceInherente: r.vraisemblanceInherente,
         graviteResiduelle: r.graviteResiduelle, vraisemblanceResiduelle: r.vraisemblanceResiduelle,
-      })), 'residual') },
+      })), 'residual', scaleConfig) },
       actions: summarizeActions(actions, now),
       ...(withIncidents ? { incidents: rollupIncidents(incidents) } : {}),
       ...(withControles ? { controles: rollupControles(controleRows, executions) } : {}),

--- a/src/components/HeatmapGridHtml.tsx
+++ b/src/components/HeatmapGridHtml.tsx
@@ -20,9 +20,12 @@ export default function HeatmapGridHtml({ grid, axisLabel }: { grid?: HeatGrid; 
           <div className="w-5 h-8 flex items-center justify-center text-[10px] text-gray-400">{g}</div>
           {grid.vraisemblances.map(v => {
             const n = grid.counts[g]?.[v] ?? 0
+            // Couleur fidèle à la matrice configurée si fournie, sinon palier 3 couleurs.
+            const couleur = grid.couleurs?.[g]?.[v]
             return (
               <div key={v}
-                className={`w-11 h-8 flex items-center justify-center text-xs font-bold text-white border border-white dark:border-gray-900 ${cellClass(grid.buckets[g]?.[v])}`}>
+                style={couleur ? { backgroundColor: couleur } : undefined}
+                className={`w-11 h-8 flex items-center justify-center text-xs font-bold text-white border border-white dark:border-gray-900 ${couleur ? '' : cellClass(grid.buckets[g]?.[v])}`}>
                 {n > 0 ? n : ''}
               </div>
             )

--- a/src/lib/carto-export.ts
+++ b/src/lib/carto-export.ts
@@ -4,6 +4,7 @@
 // Logique PURE (réutilise buildHeatmap/aggregateByDimension), testée.
 
 import { buildHeatmap, aggregateByDimension, CARTO_MAX, type CartoRisk, type CartoMode, type NiveauBucket } from './cartographie'
+import { getRiskLevel, type ScaleConfig } from './risk-scale'
 
 export interface CartoExportRisk extends CartoRisk {
   statut: string
@@ -22,6 +23,8 @@ export interface HeatGrid {
   counts: Record<number, Record<number, number>>
   /** Palier de chaque cellule non vide, pour la couleur. */
   buckets: Record<number, Record<number, NiveauBucket>>
+  /** Couleur (#rrggbb) de CHAQUE cellule selon la matrice configurée (si fournie). */
+  couleurs?: Record<number, Record<number, string>>
 }
 
 export interface CartoExportData {
@@ -36,22 +39,30 @@ export interface CartoExportData {
   parEntite: { key: string; label: string | null; count: number; maxNiveau: number | null }[]
 }
 
-/** Grille dense (toutes les cellules) à partir de la heat map creuse. */
-export function buildHeatGrid(risks: CartoRisk[], mode: CartoMode): HeatGrid {
+/**
+ * Grille dense (toutes les cellules) à partir de la heat map creuse.
+ * Si `config` (matrice configurée) est fourni, chaque cellule reçoit sa couleur
+ * de palier exacte (`couleurs`), pour une heat map FIDÈLE à /configuration.
+ */
+export function buildHeatGrid(risks: CartoRisk[], mode: CartoMode, config?: Partial<ScaleConfig> | null): HeatGrid {
   const heat = buildHeatmap(risks, mode)
   const gravites = Array.from({ length: CARTO_MAX }, (_, i) => CARTO_MAX - i)
   const vraisemblances = Array.from({ length: CARTO_MAX }, (_, i) => i + 1)
   const counts: Record<number, Record<number, number>> = {}
   const buckets: Record<number, Record<number, NiveauBucket>> = {}
+  const couleurs: Record<number, Record<number, string>> = {}
   for (const g of gravites) {
-    counts[g] = {}; buckets[g] = {}
-    for (const v of vraisemblances) counts[g][v] = 0
+    counts[g] = {}; buckets[g] = {}; couleurs[g] = {}
+    for (const v of vraisemblances) {
+      counts[g][v] = 0
+      if (config) couleurs[g][v] = getRiskLevel(g, v, config).couleur
+    }
   }
   for (const cell of heat.cells) {
     counts[cell.gravite][cell.vraisemblance] = cell.risqueIds.length
     buckets[cell.gravite][cell.vraisemblance] = cell.bucket
   }
-  return { gravites, vraisemblances, counts, buckets }
+  return config ? { gravites, vraisemblances, counts, buckets, couleurs } : { gravites, vraisemblances, counts, buckets }
 }
 
 /**
@@ -63,6 +74,7 @@ export function buildCartoExport(
   risks: CartoExportRisk[],
   mode: CartoMode,
   categorieLabel?: (code: string) => string | null,
+  config?: Partial<ScaleConfig> | null,
 ): CartoExportData {
   const heat = buildHeatmap(risks, mode)
   const strip = (b: { key: string; label: string | null; count: number; maxNiveau: number | null }) =>
@@ -72,7 +84,7 @@ export function buildCartoExport(
     total: risks.length,
     parBucket: heat.parBucket,
     nonCotes: heat.totalNonCote,
-    grid: buildHeatGrid(risks, mode),
+    grid: buildHeatGrid(risks, mode, config),
     parCategorie: aggregateByDimension(risks, 'taxonomie', mode).map(b => ({
       key: b.key,
       label: b.key && categorieLabel ? categorieLabel(b.key) : null,

--- a/src/lib/grc-consolide.server.ts
+++ b/src/lib/grc-consolide.server.ts
@@ -10,6 +10,7 @@ import { niveauRisque } from './risk-item'
 import { summarizeActions } from './risk-action'
 import { rollupRisks, type RiskLite } from './grc-rollup'
 import { buildHeatGrid } from './carto-export'
+import { getEffectiveScaleConfig } from './configuration-server'
 import type { CartoRisk } from './cartographie'
 import { rollupIncidents, rollupControles, rollupControlesParNiveau, rollupAudit, type CockpitIncident, type CockpitExecution, type CockpitConstat } from './grc-cockpit'
 import { synthetiserAppetit, cleanAppetitConfig, type RiskAppetitLite } from './appetit'
@@ -66,7 +67,8 @@ export async function gatherGrcConsolide(
     graviteInherente: r.graviteInherente, vraisemblanceInherente: r.vraisemblanceInherente,
     graviteResiduelle: r.graviteResiduelle, vraisemblanceResiduelle: r.vraisemblanceResiduelle,
   }))
-  const grid = buildHeatGrid(cartoRisks, 'residual')
+  const scaleConfig = await getEffectiveScaleConfig(orgId)
+  const grid = buildHeatGrid(cartoRisks, 'residual', scaleConfig)
 
   const consolide: ComiteConsolide = { risques: { ...rollupRisks(risks), grid } }
   const act = summarizeActions(actionRows, now)

--- a/src/lib/pdf-heatmap.tsx
+++ b/src/lib/pdf-heatmap.tsx
@@ -36,7 +36,7 @@ export function HeatmapGrid({ grid, axisLabel, cellWidth = 46, cellHeight = 26 }
           {grid.vraisemblances.map(v => {
             const n = grid.counts[g]?.[v] ?? 0
             return (
-              <View key={`c${g}-${v}`} style={{ width: cellWidth, height: cellHeight, borderWidth: 1, borderColor: '#FFFFFF', backgroundColor: heatCellColor(grid.buckets[g]?.[v]), alignItems: 'center', justifyContent: 'center' }}>
+              <View key={`c${g}-${v}`} style={{ width: cellWidth, height: cellHeight, borderWidth: 1, borderColor: '#FFFFFF', backgroundColor: grid.couleurs?.[g]?.[v] ?? heatCellColor(grid.buckets[g]?.[v]), alignItems: 'center', justifyContent: 'center' }}>
                 <Text style={{ fontSize: fs, fontWeight: 'bold', color: '#FFFFFF' }}>{n > 0 ? String(n) : ' '}</Text>
               </View>
             )


### PR DESCRIPTION
Complète #110. La page /cartographie était déjà corrigée ; on aligne aussi les **heat maps restantes** sur la matrice configurée (ta demande « aligner toutes les heatmaps ») :
- **cockpit /pilotage** (mini-heat map),
- **roll-up multi-org**,
- **PDF du pack comité**.

`buildHeatGrid(risks, mode, config?)` calcule la couleur exacte de chaque cellule via `getRiskLevel` (seuils + mode qualitatif) → `HeatGrid.couleurs`. `HeatmapGridHtml` et `pdf-heatmap` l'utilisent (repli sur le barème 3 paliers si absent). Les builders (grc-consolide, rollup) passent `getEffectiveScaleConfig`.

Le PDF d'une **analyse** (`RiskMatrixPdf`) lisait déjà les seuils configurés — inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)