### PR TITLE
feat(dérogations): délai maximal configurable (date butoir plafonnée)

### DIFF
--- a/prisma/migrations/20260908120000_derogation_duree_max/migration.sql
+++ b/prisma/migrations/20260908120000_derogation_duree_max/migration.sql
@@ -1,0 +1,2 @@
+-- Délai maximal d'une dérogation (date butoir plafonnée ; défaut 365 j = 1 an)
+ALTER TABLE "OrganizationConfig" ADD COLUMN "derogationDureeMaxJours" INTEGER NOT NULL DEFAULT 365;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1439,6 +1439,8 @@ model OrganizationConfig {
   derogationDureeDefautJours Int           @default(180)
   // Fenêtre d'alerte avant expiration d'une dérogation, en jours (défaut 30).
   derogationAlerteJours      Int           @default(30)
+  // Délai MAXIMAL d'une dérogation, en jours (date butoir plafonnée ; défaut 365 = 1 an).
+  derogationDureeMaxJours    Int           @default(365)
   // Niveau de workflow : "AUTONOME" (startup, active immédiatement), "RSSI"
   // (validation RSSI, défaut), "RSSI_METIER" (RSSI puis Direction métier).
   derogationWorkflow         String        @default("RSSI")

--- a/src/__tests__/unit/lib/derogation.test.ts
+++ b/src/__tests__/unit/lib/derogation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  calcDateFin, joursAvantExpiration, etatDerogation, needsExpiryAlert, buildDerogationDigest,
+  calcDateFin, dateFinMax, depasseDelaiMax, joursAvantExpiration, etatDerogation, needsExpiryAlert, buildDerogationDigest,
   validateDerogationInput, statutInitial, statutApresAvisRssi, statutApresDoubleRegard, estTerminale,
   prolongationEntry,
   canAvisRssiDerogation, canDoubleRegardDerogation, canValiderDerogation,
@@ -17,6 +17,22 @@ const inDays = (n: number) => new Date(NOW.getTime() + n * 86_400_000)
 describe('calcDateFin', () => {
   it('ajoute la durée en jours', () => {
     expect(calcDateFin(new Date('2026-01-01T00:00:00Z'), 180).toISOString()).toBe('2026-06-30T00:00:00.000Z')
+  })
+})
+
+describe('dateFinMax / depasseDelaiMax', () => {
+  const debut = new Date('2026-01-01T00:00:00Z')
+  it('dateFinMax = début + délai max', () => {
+    expect(dateFinMax(debut, 365).toISOString()).toBe('2027-01-01T00:00:00.000Z')
+  })
+  it('détecte un dépassement du délai max (1 an)', () => {
+    expect(depasseDelaiMax(debut, '2027-06-01T00:00:00Z', 365)).toBe(true) // > 1 an
+    expect(depasseDelaiMax(debut, '2026-12-31T00:00:00Z', 365)).toBe(false) // dans l'année
+    expect(depasseDelaiMax(debut, '2027-01-01T00:00:00Z', 365)).toBe(false) // pile (tolérance 1 j)
+  })
+  it('ne dépasse pas si entrées invalides ou délai max nul', () => {
+    expect(depasseDelaiMax(debut, '2030-01-01T00:00:00Z', 0)).toBe(false)
+    expect(depasseDelaiMax(debut, 'not-a-date', 365)).toBe(false)
   })
 })
 

--- a/src/__tests__/unit/lib/org-config.test.ts
+++ b/src/__tests__/unit/lib/org-config.test.ts
@@ -25,6 +25,7 @@ function row(partial: Partial<RawOrgConfig>): RawOrgConfig {
     derogationsActive: false,
     derogationDureeDefautJours: 180,
     derogationAlerteJours: 30,
+    derogationDureeMaxJours: 365,
     derogationWorkflow: 'RSSI_METIER',
     derogationDoubleRegard: true,
     derogationSortCatalogue: true,

--- a/src/app/api/admin/organization-config/route.ts
+++ b/src/app/api/admin/organization-config/route.ts
@@ -77,6 +77,7 @@ export async function GET(_req: NextRequest) {
     derogationsActive: cfg.derogationsActive,
     derogationDureeDefautJours: cfg.derogationDureeDefautJours,
     derogationAlerteJours: cfg.derogationAlerteJours,
+    derogationDureeMaxJours: cfg.derogationDureeMaxJours,
     derogationWorkflow: cfg.derogationWorkflow,
     derogationDoubleRegard: cfg.derogationDoubleRegard,
     derogationSortCatalogue: cfg.derogationSortCatalogue,
@@ -198,6 +199,9 @@ export async function PUT(req: NextRequest) {
   }
   if (typeof body.derogationAlerteJours === 'number' && Number.isFinite(body.derogationAlerteJours)) {
     data.derogationAlerteJours = Math.max(1, Math.min(365, Math.round(body.derogationAlerteJours)))
+  }
+  if (typeof body.derogationDureeMaxJours === 'number' && Number.isFinite(body.derogationDureeMaxJours)) {
+    data.derogationDureeMaxJours = Math.max(1, Math.min(3650, Math.round(body.derogationDureeMaxJours)))
   }
   if (body.actionDelaisMois && typeof body.actionDelaisMois === 'object' && !Array.isArray(body.actionDelaisMois)) {
     data.actionDelaisMois = cleanActionDelais(body.actionDelaisMois)

--- a/src/app/api/derogations/[id]/route.ts
+++ b/src/app/api/derogations/[id]/route.ts
@@ -5,7 +5,7 @@ import { analyseAccessWhere, getAccessibleOrgIds } from '@/lib/org-context.serve
 import { getOrgConfig } from '@/lib/org-config.server'
 import { canEditAnalyse, type UserRole } from '@/lib/permissions'
 import {
-  calcDateFin, statutApresAvisRssi, statutApresDoubleRegard, prolongationEntry,
+  calcDateFin, depasseDelaiMax, statutApresAvisRssi, statutApresDoubleRegard, prolongationEntry,
   canAvisRssiDerogation, canDoubleRegardDerogation, canValiderDerogation,
   canRevoquerDerogation, canCloturerDerogation,
   type DerogationStatut, type DerogationWorkflow,
@@ -132,6 +132,10 @@ export async function PATCH(req: NextRequest, { params }: Params) {
       if (!commentaire?.trim()) return NextResponse.json({ error: 'Un motif de prolongation est requis' }, { status: 400 })
       const nd = body.nouvelleDateFin ? new Date(String(body.nouvelleDateFin)) : calcDateFin(derog.dateFin ?? now, orgConfig.derogationDureeDefautJours)
       if (isNaN(nd.getTime())) return NextResponse.json({ error: 'Date de fin invalide' }, { status: 400 })
+      // Plafond : la date butoir ne peut dépasser le délai maximal (config org).
+      if (depasseDelaiMax(derog.dateDebut ?? now, nd, orgConfig.derogationDureeMaxJours)) {
+        return NextResponse.json({ error: `La date de fin dépasse le délai maximal autorisé (${orgConfig.derogationDureeMaxJours} jours).` }, { status: 400 })
+      }
       const historique = [...(Array.isArray(derog.prolongations) ? derog.prolongations : []), prolongationEntry(derog.dateFin, nd, commentaire, userId, now)]
       // En mode AUTONOME (aucun valideur), la prolongation s'applique directement ;
       // sinon elle rouvre un cycle de revue (retour DEMANDEE).

--- a/src/app/api/derogations/route.ts
+++ b/src/app/api/derogations/route.ts
@@ -90,6 +90,11 @@ export async function POST(req: NextRequest) {
   // Niveau de workflow : AUTONOME (startup) → active immédiatement.
   const statut = statutInitial(orgConfig.derogationWorkflow as DerogationWorkflow)
   const now = new Date()
+  // Durée demandée (date butoir) — bornée à [1, délai max configuré] ; défaut = durée par défaut.
+  const dureeDemandee = Number(body.dureeJours)
+  const duree = Number.isFinite(dureeDemandee) && dureeDemandee > 0
+    ? Math.min(Math.round(dureeDemandee), orgConfig.derogationDureeMaxJours)
+    : orgConfig.derogationDureeDefautJours
   const derogation = await prisma.derogation.create({
     data: {
       organizationId: orgId,
@@ -102,7 +107,7 @@ export async function POST(req: NextRequest) {
       mesuresCompensatoires: input.mesuresCompensatoires!,
       demandeurId: userId,
       statut,
-      ...(statut === 'ACTIVE' ? { dateDebut: now, dateFin: calcDateFin(now, orgConfig.derogationDureeDefautJours) } : {}),
+      ...(statut === 'ACTIVE' ? { dateDebut: now, dateFin: calcDateFin(now, duree) } : {}),
     },
   })
   await auditLog(statut === 'ACTIVE' ? 'DEROGATION_VALIDATED' : 'DEROGATION_REQUESTED', {

--- a/src/app/configuration/page.tsx
+++ b/src/app/configuration/page.tsx
@@ -155,6 +155,7 @@ export default function ConfigurationPage() {
   const [derogationsActive, setDerogationsActive] = useState(false)
   const [derogationDuree, setDerogationDuree] = useState(180)
   const [derogationAlerte, setDerogationAlerte] = useState(30)
+  const [derogationDureeMax, setDerogationDureeMax] = useState(365)
   const [actionDelais, setActionDelais] = useState({ CRITIQUE: 6, MAJEUR: 12, MODERE: 24 })
   const [derogationWorkflow, setDerogationWorkflow] = useState('RSSI')
   const [derogationDoubleRegard, setDerogationDoubleRegard] = useState(true)
@@ -214,6 +215,7 @@ export default function ConfigurationPage() {
         if (data.actionDelaisMois && typeof data.actionDelaisMois === 'object') setActionDelais({ CRITIQUE: 6, MAJEUR: 12, MODERE: 24, ...data.actionDelaisMois })
         if (typeof data.derogationDureeDefautJours === 'number') setDerogationDuree(data.derogationDureeDefautJours)
         if (typeof data.derogationAlerteJours === 'number') setDerogationAlerte(data.derogationAlerteJours)
+        if (typeof data.derogationDureeMaxJours === 'number') setDerogationDureeMax(data.derogationDureeMaxJours)
         if (['AUTONOME', 'RSSI', 'RSSI_METIER'].includes(data.derogationWorkflow)) setDerogationWorkflow(data.derogationWorkflow)
         setDerogationDoubleRegard(data.derogationDoubleRegard !== false)
         setRegistreRisquesActive(Boolean(data.registreRisquesActive))
@@ -311,8 +313,8 @@ export default function ConfigurationPage() {
   }
 
   // Paramètres numériques des dérogations (durée par défaut, fenêtre d'alerte).
-  async function saveDerogationInt(field: 'derogationDureeDefautJours' | 'derogationAlerteJours', value: number) {
-    const setter = field === 'derogationDureeDefautJours' ? setDerogationDuree : setDerogationAlerte
+  async function saveDerogationInt(field: 'derogationDureeDefautJours' | 'derogationAlerteJours' | 'derogationDureeMaxJours', value: number) {
+    const setter = field === 'derogationDureeDefautJours' ? setDerogationDuree : field === 'derogationDureeMaxJours' ? setDerogationDureeMax : setDerogationAlerte
     setter(value) // optimiste
     setSavingFeatures(true)
     const res = await fetch('/api/admin/organization-config', {
@@ -1344,6 +1346,14 @@ export default function ConfigurationPage() {
                     <input type="number" min={1} max={365} value={derogationAlerte}
                       onChange={e => setDerogationAlerte(Number(e.target.value))}
                       onBlur={e => saveDerogationInt('derogationAlerteJours', Math.max(1, Math.min(365, Number(e.target.value) || 30)))}
+                      disabled={savingFeatures}
+                      className="w-28 px-2 py-1 rounded border border-gray-300 text-sm" />
+                  </label>
+                  <label className="text-sm text-gray-700">
+                    <span className="block text-xs font-medium text-gray-600 mb-1">{t.features.derogationDureeMaxLabel}</span>
+                    <input type="number" min={1} max={3650} value={derogationDureeMax}
+                      onChange={e => setDerogationDureeMax(Number(e.target.value))}
+                      onBlur={e => saveDerogationInt('derogationDureeMaxJours', Math.max(1, Math.min(3650, Number(e.target.value) || 365)))}
                       disabled={savingFeatures}
                       className="w-28 px-2 py-1 rounded border border-gray-300 text-sm" />
                   </label>

--- a/src/lib/derogation.ts
+++ b/src/lib/derogation.ts
@@ -38,6 +38,24 @@ export function calcDateFin(dateDebut: Date, dureeJours: number): Date {
   return new Date(dateDebut.getTime() + dureeJours * JOUR_MS)
 }
 
+/** Date butoir maximale admissible = début + délai max (jours). */
+export function dateFinMax(dateDebut: Date, dureeMaxJours: number): Date {
+  return calcDateFin(dateDebut, dureeMaxJours)
+}
+
+/**
+ * Une date de fin dépasse-t-elle le délai maximal autorisé ?
+ * Vrai si `dateFin` est strictement au-delà de `dateDebut + dureeMaxJours`.
+ * Tolérance d'une journée pour absorber les décalages d'heure/fuseau. Pur, testé.
+ */
+export function depasseDelaiMax(dateDebut: Date | string, dateFin: Date | string, dureeMaxJours: number): boolean {
+  const debut = typeof dateDebut === 'string' ? new Date(dateDebut) : dateDebut
+  const fin = typeof dateFin === 'string' ? new Date(dateFin) : dateFin
+  if (isNaN(debut.getTime()) || isNaN(fin.getTime()) || !(dureeMaxJours > 0)) return false
+  const max = debut.getTime() + dureeMaxJours * JOUR_MS + JOUR_MS // +1 j de tolérance
+  return fin.getTime() > max
+}
+
 /** Jours (entiers) restants avant `dateFin` ; négatif si déjà dépassée. */
 export function joursAvantExpiration(dateFin: Date | string | null | undefined, now: Date = new Date()): number {
   if (!dateFin) return Infinity

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -3069,6 +3069,7 @@ export const de: Translations = {
     derogationsDesc:    'Ermöglicht die vorübergehende Akzeptanz einer Nichtkonformität der Sicherheitsbasis: Antrag des Verantwortlichen, CISO-Stellungnahme, Freigabe durch die Fachbereichsleitung, Ablaufdatum und Warnungen vor dem Ablauf.',
     derogationDureeLabel: 'Standarddauer einer Ausnahmegenehmigung (Tage)',
     derogationAlerteLabel: 'Warnung vor Ablauf (Tage)',
+    derogationDureeMaxLabel: 'Maximale Dauer (Tage)',
     derogationWorkflowLabel: 'Freigabestufe für Ausnahmegenehmigungen',
     derogationWfAutonome: 'Eigenständig (Startup) — sofort aktiv, ohne Freigabe',
     derogationWfRssi: 'CISO-Freigabe',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -3069,6 +3069,7 @@ export const en: Translations = {
     derogationsDesc:    'Allows temporary acceptance of a baseline non-conformity: request by the owner, CISO opinion, validation by Business management, expiry date and alerts before expiration.',
     derogationDureeLabel: 'Default waiver duration (days)',
     derogationAlerteLabel: 'Alert before expiry (days)',
+    derogationDureeMaxLabel: 'Maximum duration (days)',
     derogationWorkflowLabel: 'Waiver validation level',
     derogationWfAutonome: 'Self-service (startup) — active immediately, no validation',
     derogationWfRssi: 'CISO validation',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -3069,6 +3069,7 @@ export const es: Translations = {
     derogationsDesc:    'Permite aceptar temporalmente una no conformidad de la base de seguridad: solicitud del responsable, dictamen del CISO, validación por la Dirección de negocio, fecha de vencimiento y alertas antes de la expiración.',
     derogationDureeLabel: 'Duración por defecto de una exención (días)',
     derogationAlerteLabel: 'Alerta antes del vencimiento (días)',
+    derogationDureeMaxLabel: 'Duración máxima (días)',
     derogationWorkflowLabel: 'Nivel de validación de las exenciones',
     derogationWfAutonome: 'Autoservicio (startup) — activa de inmediato, sin validación',
     derogationWfRssi: 'Validación del CISO',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -3117,6 +3117,7 @@ export const fr = {
     derogationsDesc:    "Permet d'accepter temporairement une non-conformité au socle : demande du porteur, avis RSSI, validation par la Direction métier, échéance et alertes avant expiration.",
     derogationDureeLabel: 'Durée par défaut d\'une dérogation (jours)',
     derogationAlerteLabel: 'Alerte avant expiration (jours)',
+    derogationDureeMaxLabel: 'Délai maximal (jours)',
     derogationWorkflowLabel: 'Niveau de validation des dérogations',
     derogationWfAutonome: 'Autonomie (startup) — active immédiatement, sans validation',
     derogationWfRssi: 'Validation RSSI',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -3069,6 +3069,7 @@ export const it: Translations = {
     derogationsDesc:    'Consente di accettare temporaneamente una non conformità della base di sicurezza: richiesta del responsabile, parere del CISO, validazione della Direzione aziendale, data di scadenza e avvisi prima della scadenza.',
     derogationDureeLabel: 'Durata predefinita di una deroga (giorni)',
     derogationAlerteLabel: 'Avviso prima della scadenza (giorni)',
+    derogationDureeMaxLabel: 'Durata massima (giorni)',
     derogationWorkflowLabel: 'Livello di validazione delle deroghe',
     derogationWfAutonome: 'Autonomia (startup) — attiva subito, senza validazione',
     derogationWfRssi: 'Validazione CISO',

--- a/src/lib/org-config.server.ts
+++ b/src/lib/org-config.server.ts
@@ -29,6 +29,7 @@ const CONFIG_SELECT = {
   derogationsActive: true,
   derogationDureeDefautJours: true,
   derogationAlerteJours: true,
+  derogationDureeMaxJours: true,
   derogationWorkflow: true,
   derogationDoubleRegard: true,
   derogationSortCatalogue: true,

--- a/src/lib/org-config.ts
+++ b/src/lib/org-config.ts
@@ -44,6 +44,7 @@ export interface RawOrgConfig {
   derogationsActive: boolean
   derogationDureeDefautJours: number
   derogationAlerteJours: number
+  derogationDureeMaxJours: number
   derogationWorkflow: string
   derogationDoubleRegard: boolean
   derogationSortCatalogue: boolean
@@ -78,6 +79,7 @@ export interface OrgConfigResolved {
   derogationsActive: boolean
   derogationDureeDefautJours: number
   derogationAlerteJours: number
+  derogationDureeMaxJours: number
   derogationWorkflow: string
   derogationDoubleRegard: boolean
   derogationSortCatalogue: boolean
@@ -114,6 +116,7 @@ export const DEFAULT_ORG_CONFIG: OrgConfigResolved = {
   derogationsActive: false,
   derogationDureeDefautJours: 180,
   derogationAlerteJours: 30,
+  derogationDureeMaxJours: 365,
   derogationWorkflow: 'RSSI',
   derogationDoubleRegard: true,
   derogationSortCatalogue: true,
@@ -140,7 +143,7 @@ function isEmptyJson(v: unknown): boolean {
 type JsonKey = 'entitesMesures' | 'typesImpacts' | 'referentielsActifs' | 'strategiesTraitement' | 'exemplesAteliers' | 'echellesEcosysteme' | 'taxonomieRisques' | 'appetitRisque' | 'actionDelaisMois'
 type BoolKey = 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'gelApresAcceptationActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive'
 type StrKey = 'conformiteNiveau' | 'conformiteSnapshotMode' | 'derogationWorkflow'
-type IntKey = 'derogationDureeDefautJours' | 'derogationAlerteJours'
+type IntKey = 'derogationDureeDefautJours' | 'derogationAlerteJours' | 'derogationDureeMaxJours'
 
 /**
  * Résout la configuration effective d'une organisation à partir de la chaîne de ses
@@ -191,6 +194,7 @@ export function resolveOrgConfig(chainSelfFirst: (RawOrgConfig | null)[], defaul
     derogationsActive: pickBool('derogationsActive', defaults.derogationsActive),
     derogationDureeDefautJours: pickInt('derogationDureeDefautJours', defaults.derogationDureeDefautJours),
     derogationAlerteJours: pickInt('derogationAlerteJours', defaults.derogationAlerteJours),
+    derogationDureeMaxJours: pickInt('derogationDureeMaxJours', defaults.derogationDureeMaxJours),
     derogationWorkflow: pickStr('derogationWorkflow', defaults.derogationWorkflow),
     derogationDoubleRegard: pickBool('derogationDoubleRegard', defaults.derogationDoubleRegard),
     derogationSortCatalogue: pickBool('derogationSortCatalogue', defaults.derogationSortCatalogue),


### PR DESCRIPTION
Première partie du **Lot 2**. Une dérogation a désormais une **durée maximale** réglable par l'ADMIN (`derogationDureeMaxJours`, **défaut 365 j = 1 an**) : la date butoir ne peut jamais dépasser `dateDebut + délai max`.

- **Fonctions pures testées** : `dateFinMax()`, `depasseDelaiMax()` (tolérance 1 j).
- **Config 3 niveaux** : nouveau champ + migration + résolution + UI /configuration (« Délai maximal (jours) ») + i18n ×5.
- **Création** : accepte une durée demandée, bornée à [1, délai max].
- **Prolongation** : rejet si la nouvelle date de fin dépasse le délai max.

Suite du lot dérogations (prochaine PR) : formulaire — **sélection d'une mesure de référentiel existant** (ISO/PSSI) + champ date butoir + autocomplétion ; **UX du panneau /derogations** (modale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)