### PR TITLE
feat(dérogations): formulaire — mesure de référentiel + date butoir + autocomplétion + modale

### DIFF
--- a/src/app/api/analyses/[id]/derogations/route.ts
+++ b/src/app/api/analyses/[id]/derogations/route.ts
@@ -37,6 +37,7 @@ export async function GET(_req: NextRequest, { params }: Params) {
     derogations,
     config: {
       dureeDefautJours: orgConfig.derogationDureeDefautJours,
+      dureeMaxJours: orgConfig.derogationDureeMaxJours,
       alerteJours: orgConfig.derogationAlerteJours,
       active: orgConfig.derogationsActive,
       workflow: orgConfig.derogationWorkflow,
@@ -89,6 +90,11 @@ export async function POST(req: NextRequest, { params }: Params) {
   // Niveau de workflow : AUTONOME (startup) → active immédiatement.
   const statut = statutInitial(orgConfig.derogationWorkflow as DerogationWorkflow)
   const now = new Date()
+  // Durée demandée (date butoir) bornée à [1, délai max configuré] ; défaut = durée par défaut.
+  const dureeDemandee = Number((body as { dureeJours?: unknown }).dureeJours)
+  const duree = Number.isFinite(dureeDemandee) && dureeDemandee > 0
+    ? Math.min(Math.round(dureeDemandee), orgConfig.derogationDureeMaxJours)
+    : orgConfig.derogationDureeDefautJours
   const derogation = await prisma.derogation.create({
     data: {
       organizationId: analyse.organizationId ?? 'global',
@@ -102,7 +108,7 @@ export async function POST(req: NextRequest, { params }: Params) {
       mesuresCompensatoires: input.mesuresCompensatoires!,
       demandeurId: userId,
       statut,
-      ...(statut === 'ACTIVE' ? { dateDebut: now, dateFin: calcDateFin(now, orgConfig.derogationDureeDefautJours) } : {}),
+      ...(statut === 'ACTIVE' ? { dateDebut: now, dateFin: calcDateFin(now, duree) } : {}),
     },
   })
   await auditLog(statut === 'ACTIVE' ? 'DEROGATION_VALIDATED' : 'DEROGATION_REQUESTED', {

--- a/src/app/derogations/page.tsx
+++ b/src/app/derogations/page.tsx
@@ -59,7 +59,9 @@ export default async function DerogationsPage() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <Navbar />
       <main className="max-w-7xl mx-auto px-4 py-8">
-        <DerogationsRegistre rows={rows} locale={locale} canCreate={canCreate} />
+        <DerogationsRegistre rows={rows} locale={locale} canCreate={canCreate}
+          dureeDefaut={activeConfig?.derogationDureeDefautJours ?? 180}
+          dureeMax={activeConfig?.derogationDureeMaxJours ?? 365} />
       </main>
     </div>
   )

--- a/src/components/DerogationsPanel.tsx
+++ b/src/components/DerogationsPanel.tsx
@@ -4,6 +4,7 @@ import { IdCard } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
 import { formatDate } from '@/lib/format'
+import AutocompleteInput from '@/components/AutocompleteInput'
 import {
   etatDerogation, joursAvantExpiration,
   canAvisRssiDerogation, canDoubleRegardDerogation, canValiderDerogation,
@@ -57,6 +58,11 @@ export default function DerogationsPanel({
   const [list, setList] = useState<Derog[]>([])
   const [alerteJours, setAlerteJours] = useState(30)
   const [doubleRegardActif, setDoubleRegardActif] = useState(true)
+  const [dureeDefaut, setDureeDefaut] = useState(180)
+  const [dureeMax, setDureeMax] = useState(365)
+  // Référentiels de l'org (mesures existantes) + exigences du référentiel choisi.
+  const [refs, setRefs] = useState<{ code: string; nom: string }[]>([])
+  const [exigences, setExigences] = useState<{ ref: string; nom: string }[]>([])
   const [creating, setCreating] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -71,11 +77,28 @@ export default function DerogationsPanel({
     setList(data.derogations ?? [])
     if (typeof data.config?.alerteJours === 'number') setAlerteJours(data.config.alerteJours)
     if (typeof data.config?.doubleRegard === 'boolean') setDoubleRegardActif(data.config.doubleRegard)
+    if (typeof data.config?.dureeDefautJours === 'number') setDureeDefaut(data.config.dureeDefautJours)
+    if (typeof data.config?.dureeMaxJours === 'number') setDureeMax(data.config.dureeMaxJours)
   }
   useEffect(() => { reload() }, [analyseId]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Référentiels de l'org (pour la sélection d'une mesure de référentiel existant).
+  useEffect(() => {
+    fetch('/api/referentiels').then(r => r.ok ? r.json() : null).then(d => {
+      if (Array.isArray(d?.referentiels)) setRefs(d.referentiels.map((x: { code: string; nom: string }) => ({ code: x.code, nom: x.nom })))
+    }).catch(() => { /* dégrade en texte libre */ })
+  }, [])
+
   // ── Création ──
-  const [form, setForm] = useState({ portee: 'CONTROLE', referentiel: referentielCourant ?? '', ref: '', risqueId: '', intitule: '', motif: '', mesures: '' })
+  const [form, setForm] = useState({ portee: 'CONTROLE', referentiel: referentielCourant ?? '', ref: '', risqueId: '', intitule: '', motif: '', mesures: '', dureeJours: '' })
+
+  // Exigences du référentiel sélectionné (portée CONTROLE) → choix de la mesure.
+  useEffect(() => {
+    if (form.portee !== 'CONTROLE' || !form.referentiel || !refs.some(r => r.code === form.referentiel)) { setExigences([]); return }
+    fetch(`/api/referentiels/exigences?code=${encodeURIComponent(form.referentiel)}`).then(r => r.ok ? r.json() : null).then(d => {
+      if (Array.isArray(d?.exigences)) setExigences(d.exigences.map((e: { ref: string; nom: string }) => ({ ref: e.ref, nom: e.nom })))
+    }).catch(() => setExigences([]))
+  }, [form.portee, form.referentiel, refs])
   async function submitCreate() {
     setBusy(true); setError(null)
     const res = await fetch(`/api/analyses/${analyseId}/derogations`, {
@@ -86,13 +109,14 @@ export default function DerogationsPanel({
         ref: form.ref || null,
         risqueId: form.risqueId || null,
         intitule: form.intitule, motif: form.motif, mesuresCompensatoires: form.mesures,
+        dureeJours: form.dureeJours ? Number(form.dureeJours) : undefined,
       }),
     })
     const data = await res.json().catch(() => ({}))
     setBusy(false)
     if (!res.ok) { setError((d.errors as Record<string, string>)[data.error] ?? data.error ?? 'Erreur'); return }
     setCreating(false)
-    setForm({ portee: 'CONTROLE', referentiel: referentielCourant ?? '', ref: '', risqueId: '', intitule: '', motif: '', mesures: '' })
+    setForm({ portee: 'CONTROLE', referentiel: referentielCourant ?? '', ref: '', risqueId: '', intitule: '', motif: '', mesures: '', dureeJours: '' })
     reload()
   }
 
@@ -130,10 +154,28 @@ export default function DerogationsPanel({
             {(['CONTROLE', 'RISQUE'] as const).map(p => <option key={p} value={p}>{(d.portees as Record<string, string>)[p]}</option>)}
           </select>
           {form.portee === 'CONTROLE' && (
-            <input value={form.referentiel} onChange={e => setForm(f => ({ ...f, referentiel: e.target.value }))} placeholder={d.referentiel} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            // Référentiel existant de l'org (ISO/PSSI…) ; repli texte libre si aucun.
+            refs.length > 0 ? (
+              <select value={form.referentiel} onChange={e => setForm(f => ({ ...f, referentiel: e.target.value, ref: '' }))} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm">
+                <option value="">{d.referentiel}…</option>
+                {refs.map(r => <option key={r.code} value={r.code}>{r.nom}</option>)}
+              </select>
+            ) : (
+              <input value={form.referentiel} onChange={e => setForm(f => ({ ...f, referentiel: e.target.value }))} placeholder={d.referentiel} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            )
           )}
           {form.portee === 'CONTROLE' && (
-            <input value={form.ref} onChange={e => setForm(f => ({ ...f, ref: e.target.value }))} placeholder={d.controle} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            // Mesure du référentiel (exigence/contrôle) ; autocomplétion via datalist.
+            exigences.length > 0 ? (
+              <select value={form.ref}
+                onChange={e => { const ex = exigences.find(x => x.ref === e.target.value); setForm(f => ({ ...f, ref: e.target.value, intitule: f.intitule || (ex ? `[${ex.ref}] ${ex.nom}` : f.intitule) })) }}
+                className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm">
+                <option value="">{d.controle}…</option>
+                {exigences.map(ex => <option key={ex.ref} value={ex.ref}>[{ex.ref}] {ex.nom}</option>)}
+              </select>
+            ) : (
+              <input value={form.ref} onChange={e => setForm(f => ({ ...f, ref: e.target.value }))} placeholder={d.controle} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            )
           )}
           {form.portee === 'RISQUE' && (
             <select value={form.risqueId} onChange={e => setForm(f => ({ ...f, risqueId: e.target.value }))} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm">
@@ -141,9 +183,18 @@ export default function DerogationsPanel({
               {risques.map(r => <option key={r.id} value={r.id}>{r.nom}</option>)}
             </select>
           )}
-          <input value={form.intitule} onChange={e => setForm(f => ({ ...f, intitule: e.target.value }))} placeholder={d.intitulePlaceholder} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+          <AutocompleteInput field="mesure" lang={locale} value={form.intitule} onChange={v => setForm(f => ({ ...f, intitule: v }))}
+            placeholder={d.intitulePlaceholder} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
           <textarea value={form.motif} onChange={e => setForm(f => ({ ...f, motif: e.target.value }))} placeholder={d.motifPlaceholder} rows={2} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
           <textarea value={form.mesures} onChange={e => setForm(f => ({ ...f, mesures: e.target.value }))} placeholder={d.mesuresPlaceholder} rows={2} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+          {/* Date butoir = durée (jours), plafonnée au délai maximal configuré. */}
+          <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+            <span>{d.dureeLabel}</span>
+            <input type="number" min={1} max={dureeMax} value={form.dureeJours}
+              onChange={e => setForm(f => ({ ...f, dureeJours: e.target.value }))}
+              placeholder={String(dureeDefaut)} className="w-24 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            <span className="text-gray-400">{d.dureeMaxHint?.replace('{max}', String(dureeMax))}</span>
+          </label>
           <button onClick={submitCreate} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{d.submit}</button>
         </div>
       )}

--- a/src/components/DerogationsRegistre.tsx
+++ b/src/components/DerogationsRegistre.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { IdCard } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { IdCard, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from '@/lib/i18n/context'
 import { formatDate } from '@/lib/format'
+import AutocompleteInput from '@/components/AutocompleteInput'
 import { etatDerogation, joursAvantExpiration, type DerogationEtat, type DerogationStatut } from '@/lib/derogation'
 
 export interface RegistreRow {
@@ -51,7 +52,7 @@ function matchFiltre(f: Filtre, statut: string, etat: DerogationEtat): boolean {
   }
 }
 
-export default function DerogationsRegistre({ rows, locale, canCreate = false }: { rows: RegistreRow[]; locale: string; canCreate?: boolean }) {
+export default function DerogationsRegistre({ rows, locale, canCreate = false, dureeDefaut = 180, dureeMax = 365 }: { rows: RegistreRow[]; locale: string; canCreate?: boolean; dureeDefaut?: number; dureeMax?: number }) {
   const { t } = useTranslation()
   const d = t.derogations
   const router = useRouter()
@@ -59,18 +60,35 @@ export default function DerogationsRegistre({ rows, locale, canCreate = false }:
   const [creating, setCreating] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [form, setForm] = useState({ referentiel: '', ref: '', intitule: '', motif: '', mesures: '' })
+  const [form, setForm] = useState({ referentiel: '', ref: '', intitule: '', motif: '', mesures: '', dureeJours: '' })
+  const [refs, setRefs] = useState<{ code: string; nom: string }[]>([])
+  const [exigences, setExigences] = useState<{ ref: string; nom: string }[]>([])
+
+  // Référentiels de l'org (pour choisir une mesure de référentiel existant).
+  useEffect(() => {
+    if (!creating) return
+    fetch('/api/referentiels').then(r => r.ok ? r.json() : null).then(dd => {
+      if (Array.isArray(dd?.referentiels)) setRefs(dd.referentiels.map((x: { code: string; nom: string }) => ({ code: x.code, nom: x.nom })))
+    }).catch(() => { /* repli texte libre */ })
+  }, [creating])
+
+  useEffect(() => {
+    if (!form.referentiel || !refs.some(r => r.code === form.referentiel)) { setExigences([]); return }
+    fetch(`/api/referentiels/exigences?code=${encodeURIComponent(form.referentiel)}`).then(r => r.ok ? r.json() : null).then(dd => {
+      if (Array.isArray(dd?.exigences)) setExigences(dd.exigences.map((e: { ref: string; nom: string }) => ({ ref: e.ref, nom: e.nom })))
+    }).catch(() => setExigences([]))
+  }, [form.referentiel, refs])
 
   async function submitCreate() {
     setBusy(true); setError(null)
     const res = await fetch('/api/derogations', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ portee: 'CONTROLE', referentiel: form.referentiel, ref: form.ref, intitule: form.intitule, motif: form.motif, mesuresCompensatoires: form.mesures }),
+      body: JSON.stringify({ portee: 'CONTROLE', referentiel: form.referentiel, ref: form.ref, intitule: form.intitule, motif: form.motif, mesuresCompensatoires: form.mesures, dureeJours: form.dureeJours ? Number(form.dureeJours) : undefined }),
     })
     const data = await res.json().catch(() => ({}))
     setBusy(false)
     if (!res.ok) { setError((d.errors as Record<string, string>)[data.error] ?? data.error ?? 'Erreur'); return }
-    setCreating(false); setForm({ referentiel: '', ref: '', intitule: '', motif: '', mesures: '' })
+    setCreating(false); setForm({ referentiel: '', ref: '', intitule: '', motif: '', mesures: '', dureeJours: '' })
     router.refresh()
   }
 
@@ -105,18 +123,52 @@ export default function DerogationsRegistre({ rows, locale, canCreate = false }:
 
       {error && <div className="mb-3 p-2 rounded bg-red-50 border border-red-200 text-sm text-red-700 dark:bg-red-500/10 dark:text-red-300">{error}</div>}
 
-      {/* Création d'une dérogation autonome (niveau organisation) — portée contrôle. */}
+      {/* Création d'une dérogation autonome (niveau organisation) — MODALE, ne pousse plus le tableau. */}
       {creating && canCreate && (
-        <div className="mb-5 card p-4 space-y-2 max-w-2xl">
-          <p className="text-xs text-gray-500 dark:text-gray-400">{d.orgLevelHint}</p>
-          <div className="flex gap-2">
-            <input value={form.referentiel} onChange={e => setForm(f => ({ ...f, referentiel: e.target.value }))} placeholder={d.referentiel} className="flex-1 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
-            <input value={form.ref} onChange={e => setForm(f => ({ ...f, ref: e.target.value }))} placeholder={d.controle} className="flex-1 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+        <div className="fixed inset-0 z-40 flex items-start justify-center overflow-y-auto bg-black/40 p-4 sm:p-8" role="dialog" aria-modal="true" onClick={() => setCreating(false)}>
+          <div className="card p-5 space-y-2 w-full max-w-2xl mt-8" onClick={e => e.stopPropagation()}>
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="font-semibold text-gray-800 dark:text-gray-100">{d.newBtn}</h2>
+              <button onClick={() => setCreating(false)} className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200" aria-label={d.cancel}><X size={18} /></button>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">{d.orgLevelHint}</p>
+            {error && <div className="p-2 rounded bg-red-50 border border-red-200 text-sm text-red-700 dark:bg-red-500/10 dark:text-red-300">{error}</div>}
+            <div className="flex gap-2">
+              {refs.length > 0 ? (
+                <select value={form.referentiel} onChange={e => setForm(f => ({ ...f, referentiel: e.target.value, ref: '' }))} className="flex-1 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm">
+                  <option value="">{d.referentiel}…</option>
+                  {refs.map(r => <option key={r.code} value={r.code}>{r.nom}</option>)}
+                </select>
+              ) : (
+                <input value={form.referentiel} onChange={e => setForm(f => ({ ...f, referentiel: e.target.value }))} placeholder={d.referentiel} className="flex-1 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+              )}
+              {exigences.length > 0 ? (
+                <select value={form.ref}
+                  onChange={e => { const ex = exigences.find(x => x.ref === e.target.value); setForm(f => ({ ...f, ref: e.target.value, intitule: f.intitule || (ex ? `[${ex.ref}] ${ex.nom}` : f.intitule) })) }}
+                  className="flex-1 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm">
+                  <option value="">{d.controle}…</option>
+                  {exigences.map(ex => <option key={ex.ref} value={ex.ref}>[{ex.ref}] {ex.nom}</option>)}
+                </select>
+              ) : (
+                <input value={form.ref} onChange={e => setForm(f => ({ ...f, ref: e.target.value }))} placeholder={d.controle} className="flex-1 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+              )}
+            </div>
+            <AutocompleteInput field="mesure" lang={locale} value={form.intitule} onChange={v => setForm(f => ({ ...f, intitule: v }))}
+              placeholder={d.intitulePlaceholder} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            <textarea value={form.motif} onChange={e => setForm(f => ({ ...f, motif: e.target.value }))} placeholder={d.motifPlaceholder} rows={2} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            <textarea value={form.mesures} onChange={e => setForm(f => ({ ...f, mesures: e.target.value }))} placeholder={d.mesuresPlaceholder} rows={2} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+            <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+              <span>{d.dureeLabel}</span>
+              <input type="number" min={1} max={dureeMax} value={form.dureeJours}
+                onChange={e => setForm(f => ({ ...f, dureeJours: e.target.value }))}
+                placeholder={String(dureeDefaut)} className="w-24 px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
+              <span className="text-gray-400">{d.dureeMaxHint?.replace('{max}', String(dureeMax))}</span>
+            </label>
+            <div className="flex gap-2 pt-1">
+              <button onClick={submitCreate} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{d.submit}</button>
+              <button onClick={() => setCreating(false)} className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-sm text-gray-700 dark:text-gray-200">{d.cancel}</button>
+            </div>
           </div>
-          <input value={form.intitule} onChange={e => setForm(f => ({ ...f, intitule: e.target.value }))} placeholder={d.intitulePlaceholder} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
-          <textarea value={form.motif} onChange={e => setForm(f => ({ ...f, motif: e.target.value }))} placeholder={d.motifPlaceholder} rows={2} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
-          <textarea value={form.mesures} onChange={e => setForm(f => ({ ...f, mesures: e.target.value }))} placeholder={d.mesuresPlaceholder} rows={2} className="w-full px-2 py-1 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm" />
-          <button onClick={submitCreate} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{d.submit}</button>
         </div>
       )}
 

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -856,6 +856,8 @@ export const de: Translations = {
     empty: 'Keine Ausnahmegenehmigung für diese Analyse.',
     intitule: 'Titel',
     intitulePlaceholder: 'Z. B. MFA nicht auf der Legacy-Anwendung ausgerollt',
+    dureeLabel: 'Dauer (Tage):',
+    dureeMaxHint: 'max. {max} T',
     portee: 'Geltungsbereich',
     referentiel: 'Rahmenwerk',
     controle: 'Kontrolle',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -856,6 +856,8 @@ export const en: Translations = {
     empty: 'No waiver on this analysis.',
     intitule: 'Title',
     intitulePlaceholder: 'E.g. MFA not deployed on the legacy application',
+    dureeLabel: 'Duration (days):',
+    dureeMaxHint: 'max {max} d',
     portee: 'Scope',
     referentiel: 'Framework',
     controle: 'Control',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -856,6 +856,8 @@ export const es: Translations = {
     empty: 'Ninguna exención en este análisis.',
     intitule: 'Título',
     intitulePlaceholder: 'Ej. MFA no desplegado en la aplicación heredada',
+    dureeLabel: 'Duración (días):',
+    dureeMaxHint: 'máx {max} d',
     portee: 'Alcance',
     referentiel: 'Marco',
     controle: 'Control',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -874,6 +874,8 @@ export const fr = {
     // Formulaire
     intitule: 'Intitulé',
     intitulePlaceholder: 'Ex. MFA non déployé sur l\'application legacy',
+    dureeLabel: 'Durée (jours) :',
+    dureeMaxHint: 'max {max} j',
     portee: 'Portée',
     referentiel: 'Référentiel',
     controle: 'Contrôle',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -856,6 +856,8 @@ export const it: Translations = {
     empty: 'Nessuna deroga su questa analisi.',
     intitule: 'Titolo',
     intitulePlaceholder: 'Es. MFA non implementata sull\'applicazione legacy',
+    dureeLabel: 'Durata (giorni):',
+    dureeMaxHint: 'max {max} g',
     portee: 'Ambito',
     referentiel: 'Framework',
     controle: 'Controllo',


### PR DESCRIPTION
Fin du **Lot 2**. Le formulaire de dérogation (panneau d'analyse ET registre /derogations) :

- **Mesure de référentiel existant** : la portée CONTROLE choisit le **référentiel dans une liste** des référentiels de l'org (ISO/PSSI…) au lieu d'un texte libre ; la **mesure (contrôle/exigence)** se choisit dans une liste déroulante du référentiel, et **préremplit l'intitulé** « [ref] nom ». Repli texte libre si aucun référentiel.
- **Date butoir** = durée (jours), **plafonnée au délai max** configuré (serveur + UI). Défaut = durée par défaut.
- **Autocomplétion** de l'intitulé (mesures + exigences des référentiels, cf. #116).
- **/derogations** : le formulaire de demande passe en **modale** (ne pousse plus le tableau, bouton fermer propre) — corrige le défaut UX signalé.

Route analyse : accepte `dureeJours` (bornée [1, délai max]). i18n ×5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)