### PR TITLE
feat(ux): liens contextuels — message conformité actionnable + astuce document↔référentiel

### DIFF
--- a/src/app/conformite/page.tsx
+++ b/src/app/conformite/page.tsx
@@ -91,6 +91,8 @@ export default async function ConformiteGlobalPage() {
             refs={refs}
             orgCol={t.conformiteGlobal.orgCol}
             emptyLabel={t.conformiteGlobal.empty}
+            emptyHref="/configuration"
+            emptyCta={t.conformiteGlobal.emptyCta}
             hrefFor={(orgId, refId) => `/api/organizations/${orgId}/conformite/soa?referentiel=${encodeURIComponent(refId)}`}
             pdfHrefFor={(orgId, refId) => `/api/organizations/${orgId}/conformite/soa?referentiel=${encodeURIComponent(refId)}&format=pdf`}
           />

--- a/src/components/ConformiteHeatmap.tsx
+++ b/src/components/ConformiteHeatmap.tsx
@@ -18,18 +18,29 @@ function cellStyle(taux: number): string {
  * colonnes = référentiels, cellules = taux agrégé (roll-up sous-arbre).
  * Présentational — libellés fournis par l'appelant.
  */
-export default function ConformiteHeatmap({ rows, refs, orgCol, emptyLabel, hrefFor, pdfHrefFor }: {
+export default function ConformiteHeatmap({ rows, refs, orgCol, emptyLabel, emptyHref, emptyCta, hrefFor, pdfHrefFor }: {
   rows: HeatmapRow[]
   refs: HeatmapRef[]
   orgCol: string
   emptyLabel: string
+  /** Lien actionnable affiché sous le message vide (ex. /configuration). */
+  emptyHref?: string
+  /** Libellé du bouton d'action de l'état vide. */
+  emptyCta?: string
   /** Lien d'une cellule (ex. export SoA CSV). Défaut : liste des analyses. */
   hrefFor?: (orgId: string, refId: string) => string
   /** Lien secondaire d'export PDF (SoA formelle). Optionnel. */
   pdfHrefFor?: (orgId: string, refId: string) => string
 }) {
   if (rows.length === 0 || refs.length === 0) {
-    return <p className="text-sm text-gray-500 italic">{emptyLabel}</p>
+    return (
+      <div className="text-sm text-gray-500">
+        <p className="italic">{emptyLabel}</p>
+        {emptyHref && emptyCta && (
+          <Link href={emptyHref} className="inline-block mt-2 text-ebios-600 dark:text-ebios-300 font-medium hover:underline">{emptyCta} →</Link>
+        )}
+      </div>
+    )
   }
   return (
     <div className="overflow-x-auto">

--- a/src/components/DocumentsManager.tsx
+++ b/src/components/DocumentsManager.tsx
@@ -128,6 +128,9 @@ export default function DocumentsManager({ canManage }: { canManage: boolean }) 
               <select className={`mt-1 ${inputCls}`} value={form.portee} onChange={e => setForm({ ...form, portee: e.target.value })}>
                 {DOCUMENT_PORTEES.map(p => <option key={p} value={p}>{d.porteeOpt[p]}</option>)}
               </select></label>
+            {['PSSI', 'POLITIQUE'].includes(form.type) && form.portee !== 'REFERENTIEL' && (
+              <p className="text-xs text-ebios-600 dark:text-ebios-300">{d.linkRefHint}</p>
+            )}
             {form.portee === 'REFERENTIEL' && (
               <label className="block"><span className="text-sm text-gray-700 dark:text-gray-300">{d.champ.referentiel}</span>
                 <select className={`mt-1 ${inputCls}`} value={form.referentielId} onChange={e => setForm({ ...form, referentielId: e.target.value })} required>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1619,6 +1619,7 @@ export const de: Translations = {
     champ: { fichier: 'Datei', titre: 'Titel', type: 'Typ', portee: 'Zuordnung', referentiel: 'Referenzrahmen', risque: 'Risiko', version: 'Version', description: 'Beschreibung', dateDocument: 'Dokumentdatum', dateRevue: 'Nächste Überprüfung' },
     typeOpt: { PSSI: 'Sicherheitsleitlinie', STRATEGIE: 'Strategie', POLITIQUE: 'Richtlinie', PROCEDURE: 'Verfahren', PREUVE: 'Nachweis', AUTRE: 'Sonstiges' },
     porteeOpt: { REFERENTIEL: 'Referenzrahmen', RISQUE: 'Risiko', ORG: 'Organisation' },
+    linkRefHint: 'Tipp: Dieses Dokument ähnelt einem Rahmenwerk — wählen Sie die Zuordnung „Rahmenwerk“, um es mit einem bestehenden Rahmenwerk zu verknüpfen (ISO, PSSI…).',
     col: { titre: 'Dokument', type: 'Typ', rattachement: 'Zuordnung', taille: 'Größe', revue: 'Überprüfung' },
     deleteConfirm: 'Dieses Dokument und seine Datei löschen?',
     errorRequired: 'Titel ist erforderlich.',
@@ -3130,6 +3131,7 @@ export const de: Translations = {
     subtitle: 'Konformitätsgrad je Organisation und Rahmenwerk, über den Baum aggregiert (Organisation → Bereich → Gruppe).',
     orgCol: 'Organisation',
     empty: 'Noch keine Konformität auf Organisationsebene. Aktivieren Sie „Pro Organisation“ in der Konfiguration und füllen Sie den Sockel aus.',
+    emptyCta: 'Konfiguration öffnen',
     legend: 'Jede Zelle aggregiert die Konformität des Organisations-Teilbaums (Org-Anzahl · bewertete/gesamte Kontrollen). Klicken für Analysen.',
   },
   qualification: {

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1619,6 +1619,7 @@ export const en: Translations = {
     champ: { fichier: 'File', titre: 'Title', type: 'Type', portee: 'Attachment', referentiel: 'Framework', risque: 'Risk', version: 'Version', description: 'Description', dateDocument: 'Document date', dateRevue: 'Next review' },
     typeOpt: { PSSI: 'ISSP', STRATEGIE: 'Strategy', POLITIQUE: 'Policy', PROCEDURE: 'Procedure', PREUVE: 'Evidence', AUTRE: 'Other' },
     porteeOpt: { REFERENTIEL: 'Framework', RISQUE: 'Risk', ORG: 'Organization' },
+    linkRefHint: 'Tip: this document looks like a framework — choose the “Framework” scope to link it to an existing framework (ISO, PSSI…).',
     col: { titre: 'Document', type: 'Type', rattachement: 'Attachment', taille: 'Size', revue: 'Review' },
     deleteConfirm: 'Delete this document and its file?',
     errorRequired: 'Title is required.',
@@ -3130,6 +3131,7 @@ export const en: Translations = {
     subtitle: 'Compliance rate by organisation and framework, aggregated over the tree (organisation → division → group).',
     orgCol: 'Organisation',
     empty: 'No organisation-level compliance yet. Enable “Per organisation” in configuration and fill in the baseline.',
+    emptyCta: 'Open configuration',
     legend: 'Each cell aggregates the compliance of the organisation subtree (org count · evaluated/total controls). Click to view analyses.',
   },
   qualification: {

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1619,6 +1619,7 @@ export const es: Translations = {
     champ: { fichier: 'Archivo', titre: 'Título', type: 'Tipo', portee: 'Vínculo', referentiel: 'Marco', risque: 'Riesgo', version: 'Versión', description: 'Descripción', dateDocument: 'Fecha del documento', dateRevue: 'Próxima revisión' },
     typeOpt: { PSSI: 'PSSI', STRATEGIE: 'Estrategia', POLITIQUE: 'Política', PROCEDURE: 'Procedimiento', PREUVE: 'Evidencia', AUTRE: 'Otro' },
     porteeOpt: { REFERENTIEL: 'Marco', RISQUE: 'Riesgo', ORG: 'Organización' },
+    linkRefHint: 'Consejo: este documento parece un marco — elija el ámbito «Marco» para vincularlo a un marco existente (ISO, PSSI…).',
     col: { titre: 'Documento', type: 'Tipo', rattachement: 'Vínculo', taille: 'Tamaño', revue: 'Revisión' },
     deleteConfirm: '¿Eliminar este documento y su archivo?',
     errorRequired: 'El título es obligatorio.',
@@ -3130,6 +3131,7 @@ export const es: Translations = {
     subtitle: 'Tasa de conformidad por organización y marco, agregada sobre el árbol (organización → dirección → grupo).',
     orgCol: 'Organización',
     empty: 'Aún no hay conformidad a nivel de organización. Active «Por organización» en configuración y complete la base.',
+    emptyCta: 'Abrir la configuración',
     legend: 'Cada celda agrega la conformidad del subárbol de la organización (nº de org · controles evaluados/total). Haga clic para ver los análisis.',
   },
   qualification: {

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1642,6 +1642,7 @@ export const fr = {
     champ: { fichier: 'Fichier', titre: 'Titre', type: 'Type', portee: 'Rattachement', referentiel: 'Référentiel', risque: 'Risque', version: 'Version', description: 'Description', dateDocument: 'Date du document', dateRevue: 'Prochaine revue' },
     typeOpt: { PSSI: 'PSSI', STRATEGIE: 'Stratégie', POLITIQUE: 'Politique', PROCEDURE: 'Procédure', PREUVE: 'Preuve', AUTRE: 'Autre' },
     porteeOpt: { REFERENTIEL: 'Référentiel', RISQUE: 'Risque', ORG: 'Organisation' },
+    linkRefHint: 'Astuce : ce document ressemble à un référentiel — choisissez le rattachement « Référentiel » pour le relier à un référentiel existant (ISO, PSSI…).',
     col: { titre: 'Document', type: 'Type', rattachement: 'Rattachement', taille: 'Taille', revue: 'Revue' },
     deleteConfirm: 'Supprimer ce document et son fichier ?',
     errorRequired: 'Le titre est requis.',
@@ -3178,6 +3179,7 @@ export const fr = {
     subtitle: 'Taux de conformité par organisation et référentiel, agrégé sur l\'arbre (organisation → direction → groupe).',
     orgCol: 'Organisation',
     empty: 'Aucune conformité au niveau organisation pour l\'instant. Activez « Par organisation » dans la configuration et renseignez le socle.',
+    emptyCta: 'Ouvrir la configuration',
     legend: 'Chaque cellule agrège la conformité du sous-arbre de l\'organisation (nombre d\'org · contrôles évalués/total). Cliquez pour voir les analyses.',
   },
   qualification: {

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1619,6 +1619,7 @@ export const it: Translations = {
     champ: { fichier: 'File', titre: 'Titolo', type: 'Tipo', portee: 'Collegamento', referentiel: 'Riferimento', risque: 'Rischio', version: 'Versione', description: 'Descrizione', dateDocument: 'Data del documento', dateRevue: 'Prossima revisione' },
     typeOpt: { PSSI: 'PSSI', STRATEGIE: 'Strategia', POLITIQUE: 'Politica', PROCEDURE: 'Procedura', PREUVE: 'Prova', AUTRE: 'Altro' },
     porteeOpt: { REFERENTIEL: 'Riferimento', RISQUE: 'Rischio', ORG: 'Organizzazione' },
+    linkRefHint: 'Suggerimento: questo documento sembra un quadro di riferimento — scegli l\'ambito «Quadro» per collegarlo a un riferimento esistente (ISO, PSSI…).',
     col: { titre: 'Documento', type: 'Tipo', rattachement: 'Collegamento', taille: 'Dimensione', revue: 'Revisione' },
     deleteConfirm: 'Eliminare questo documento e il suo file?',
     errorRequired: 'Il titolo è obbligatorio.',
@@ -3130,6 +3131,7 @@ export const it: Translations = {
     subtitle: 'Tasso di conformità per organizzazione e framework, aggregato sull\'albero (organizzazione → direzione → gruppo).',
     orgCol: 'Organizzazione',
     empty: 'Nessuna conformità a livello di organizzazione al momento. Attiva «Per organizzazione» in configurazione e compila la base.',
+    emptyCta: 'Apri la configurazione',
     legend: 'Ogni cella aggrega la conformità del sotto-albero dell\'organizzazione (n. org · controlli valutati/totale). Clicca per vedere le analisi.',
   },
   qualification: {


### PR DESCRIPTION
**Lot 4.**
- **Message conformité actionnable** : « Aucune conformité… Activez Par organisation dans la configuration » est suivi d'un lien **« Ouvrir la configuration → »** vers /configuration (le "genre de remarque" que tu voulais rendre cliquable).
- **Document ↔ référentiel** : quand on dépose un document **PSSI/POLITIQUE** sans le rattacher, une **astuce** invite à choisir le rattachement « Référentiel » pour le relier à un référentiel existant (ISO, PSSI…). La capacité existait déjà (`Document.referentielCode` + portée REFERENTIEL) mais était peu découvrable.

i18n ×5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)