### PR TITLE
feat(pilotage): KPI cliquables → vues cibles + pré-filtre KRI

### DIFF
--- a/src/components/KriManager.tsx
+++ b/src/components/KriManager.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { TrendingUp } from 'lucide-react'
+import { TrendingUp, X } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { useTranslation } from '@/lib/i18n/context'
 import { taxonomieLabel, type TaxonomieNode } from '@/lib/taxonomie'
 
@@ -43,6 +44,10 @@ export default function KriManager({ canDefine, canMeasure }: { canDefine: boole
   const [mesures, setMesures] = useState<Record<string, Mesure[]>>({})
   const [mesureForm, setMesureForm] = useState<{ valeur: string; commentaire: string }>({ valeur: '', commentaire: '' })
   const [err, setErr] = useState<string | null>(null)
+  // Filtre par statut piloté par l'URL (deep-link depuis le pilotage : ?statut=ALERTE|CRITIQUE).
+  const searchParams = useSearchParams()
+  const initialStatut = (searchParams.get('statut') || '').toUpperCase()
+  const [filtreStatut, setFiltreStatut] = useState<string>(['ALERTE', 'CRITIQUE', 'NORMAL', 'INCONNU'].includes(initialStatut) ? initialStatut : '')
 
   const tr = useMemo(() => (key: string) => key.split('.').reduce<unknown>((o, kk) => (o as Record<string, unknown>)?.[kk], t) as string ?? '', [t])
 
@@ -169,9 +174,17 @@ export default function KriManager({ canDefine, canMeasure }: { canDefine: boole
         </div>
       )}
 
-      {data!.kris.length === 0 ? <p className="text-sm text-gray-400 italic py-6 text-center">{k.empty}</p> : (
+      {filtreStatut && (
+        <div className="mb-3 flex items-center gap-2 text-sm">
+          <span className="px-2 py-0.5 rounded-full bg-ebios-100 text-ebios-800 dark:bg-ebios-500/15 dark:text-ebios-300 font-medium">
+            {(k.statutLabels as Record<string, string> | undefined)?.[filtreStatut] ?? filtreStatut}
+          </span>
+          <button onClick={() => setFiltreStatut('')} className="inline-flex items-center gap-1 text-gray-500 hover:text-gray-800 dark:hover:text-gray-200"><X size={14} /> {k.clearFilter}</button>
+        </div>
+      )}
+      {(() => { const visible = filtreStatut ? data!.kris.filter(r => r.statut === filtreStatut) : data!.kris; return visible.length === 0 ? <p className="text-sm text-gray-400 italic py-6 text-center">{k.empty}</p> : (
         <div className="space-y-2">
-          {data!.kris.map(row => (
+          {visible.map(row => (
             <div key={row.id} className={`card p-0 overflow-hidden ${!row.actif ? 'opacity-60' : ''}`}>
               <div className="flex items-center gap-3 px-4 py-3">
                 <button onClick={() => toggleExpand(row.id)} className="flex-1 text-left flex items-center gap-3 min-w-0">
@@ -218,7 +231,7 @@ export default function KriManager({ canDefine, canMeasure }: { canDefine: boole
             </div>
           ))}
         </div>
-      )}
+      ) })()}
     </div>
   )
 }

--- a/src/components/PilotageGrc.tsx
+++ b/src/components/PilotageGrc.tsx
@@ -183,10 +183,10 @@ export default function PilotageGrc() {
       )}
 
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
-        <Tile label={p.total} value={cr.total} />
-        <Tile label={p.eleves} value={cr.eleve} tone="red" />
-        <Tile label={p.moyens} value={cr.moyen} tone="amber" />
-        <Tile label={p.faibles} value={cr.faible} tone="green" />
+        <Tile label={p.total} value={cr.total} href="/registre" />
+        <Tile label={p.eleves} value={cr.eleve} tone="red" href="/registre?niveau=eleve" />
+        <Tile label={p.moyens} value={cr.moyen} tone="amber" href="/registre?niveau=moyen" />
+        <Tile label={p.faibles} value={cr.faible} tone="green" href="/registre?niveau=faible" />
         <Tile label={p.avancement} value={`${ca.tauxAvancement}%`} />
         <Tile label={p.enRetard} value={ca.enRetard} tone={ca.enRetard > 0 ? 'red' : undefined} />
       </div>
@@ -195,24 +195,24 @@ export default function PilotageGrc() {
       {(ci || cc || cau || cap || ck || cd) && (
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
           {ci && <>
-            <Tile label={p.perteNette} value={euros(ci.perteNette)} />
-            <Tile label={p.incidentsOuverts} value={ci.ouverts} tone={ci.ouverts > 0 ? 'amber' : undefined} />
+            <Tile label={p.perteNette} value={euros(ci.perteNette)} href="/incidents" />
+            <Tile label={p.incidentsOuverts} value={ci.ouverts} tone={ci.ouverts > 0 ? 'amber' : undefined} href="/incidents?statut=DECLARE" />
           </>}
           {cc && <>
-            <Tile label={p.tauxConformite} value={cc.tauxConformite == null ? '—' : `${cc.tauxConformite}%`} tone={cc.tauxConformite != null && cc.tauxConformite < 80 ? 'red' : undefined} />
-            <Tile label={p.anomalies} value={cc.anomalies} tone={cc.anomalies > 0 ? 'amber' : undefined} />
+            <Tile label={p.tauxConformite} value={cc.tauxConformite == null ? '—' : `${cc.tauxConformite}%`} tone={cc.tauxConformite != null && cc.tauxConformite < 80 ? 'red' : undefined} href="/controles" />
+            <Tile label={p.anomalies} value={cc.anomalies} tone={cc.anomalies > 0 ? 'amber' : undefined} href="/controles?vue=anomalies" />
           </>}
           {cau && <>
-            <Tile label={p.constatsCritiques} value={cau.critiques} tone={cau.critiques > 0 ? 'red' : undefined} />
-            <Tile label={p.recosEnRetard} value={cau.recosEnRetard} tone={cau.recosEnRetard > 0 ? 'red' : undefined} />
+            <Tile label={p.constatsCritiques} value={cau.critiques} tone={cau.critiques > 0 ? 'red' : undefined} href="/audit?constat=critique" />
+            <Tile label={p.recosEnRetard} value={cau.recosEnRetard} tone={cau.recosEnRetard > 0 ? 'red' : undefined} href="/audit?reco=retard" />
           </>}
           {cap && <>
-            <Tile label={p.horsAppetit} value={cap.horsAppetit} tone={cap.horsAppetit > 0 ? 'red' : undefined} />
-            <Tile label={p.dansAppetit} value={`${cap.dansAppetit}/${cap.evalues}`} tone="green" />
+            <Tile label={p.horsAppetit} value={cap.horsAppetit} tone={cap.horsAppetit > 0 ? 'red' : undefined} href="/cartographie" />
+            <Tile label={p.dansAppetit} value={`${cap.dansAppetit}/${cap.evalues}`} tone="green" href="/cartographie" />
           </>}
           {ck && <>
-            <Tile label={p.kriCritiques} value={ck.critique} tone={ck.critique > 0 ? 'red' : undefined} />
-            <Tile label={p.kriEnAlerte} value={ck.enAlerte} tone={ck.enAlerte > 0 ? 'amber' : undefined} />
+            <Tile label={p.kriCritiques} value={ck.critique} tone={ck.critique > 0 ? 'red' : undefined} href="/kri?statut=CRITIQUE" />
+            <Tile label={p.kriEnAlerte} value={ck.enAlerte} tone={ck.enAlerte > 0 ? 'amber' : undefined} href="/kri?statut=ALERTE" />
           </>}
           {cd && <>
             <Tile label={p.doraMajeurs} value={cd.majeurs} tone={cd.majeurs > 0 ? 'red' : undefined} />
@@ -310,12 +310,16 @@ export default function PilotageGrc() {
   )
 }
 
-function Tile({ label, value, tone }: { label: string; value: number | string; tone?: 'red' | 'amber' | 'green' }) {
+function Tile({ label, value, tone, href }: { label: string; value: number | string; tone?: 'red' | 'amber' | 'green'; href?: string }) {
   const color = tone === 'red' ? 'text-red-600 dark:text-red-400' : tone === 'amber' ? 'text-amber-600 dark:text-amber-400' : tone === 'green' ? 'text-green-600 dark:text-green-400' : 'text-gray-800 dark:text-gray-100'
-  return (
-    <div className="card p-3">
+  const inner = (
+    <>
       <p className="text-xs text-gray-500 dark:text-gray-400">{label}</p>
       <p className={`text-2xl font-bold ${color}`}>{value}</p>
-    </div>
+    </>
   )
+  // Tuile cliquable : mène à la vue filtrée correspondante.
+  return href
+    ? <Link href={href} className="card p-3 block transition hover:ring-2 hover:ring-ebios-300 dark:hover:ring-ebios-500/40 hover:shadow-sm">{inner}</Link>
+    : <div className="card p-3">{inner}</div>
 }

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1741,6 +1741,7 @@ export const de: Translations = {
     commentairePlaceholder: 'Kommentar (optional)',
     addMesure: 'Erfassen',
     aucuneMesure: 'Keine Messung.',
+    clearFilter: 'Alle anzeigen',
     statutLabels: {
       NORMAL: 'Normal',
       ALERTE: 'Alarm',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1741,6 +1741,7 @@ export const en: Translations = {
     commentairePlaceholder: 'Comment (optional)',
     addMesure: 'Record',
     aucuneMesure: 'No measurement.',
+    clearFilter: 'Show all',
     statutLabels: {
       NORMAL: 'Normal',
       ALERTE: 'Alert',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1741,6 +1741,7 @@ export const es: Translations = {
     commentairePlaceholder: 'Comentario (opcional)',
     addMesure: 'Registrar',
     aucuneMesure: 'Sin medición.',
+    clearFilter: 'Mostrar todo',
     statutLabels: {
       NORMAL: 'Normal',
       ALERTE: 'Alerta',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1779,6 +1779,7 @@ export const fr = {
     commentairePlaceholder: 'Commentaire (facultatif)',
     addMesure: 'Relever',
     aucuneMesure: 'Aucune mesure.',
+    clearFilter: 'Tout afficher',
     statutLabels: {
       NORMAL: 'Normal',
       ALERTE: 'Alerte',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1741,6 +1741,7 @@ export const it: Translations = {
     commentairePlaceholder: 'Commento (facoltativo)',
     addMesure: 'Registra',
     aucuneMesure: 'Nessuna misurazione.',
+    clearFilter: 'Mostra tutto',
     statutLabels: {
       NORMAL: 'Normale',
       ALERTE: 'Allerta',


### PR DESCRIPTION
Les **tuiles du cockpit /pilotage** deviennent **cliquables** et mènent à la bonne vue (ta demande « les chiffres amènent aux bonnes vues ») :

| Tuile | Cible |
|---|---|
| Risques (total/élevés/…) | /registre (?niveau=…) |
| Incidents ouverts, perte nette | /incidents |
| Conformité, anomalies | /controles |
| **Constats critiques**, recos en retard | /audit |
| Hors/dans appétit | /cartographie |
| **KRI critiques / en alerte** | /kri (?statut=CRITIQUE\|ALERTE) |

**KRI** : le paramètre `?statut` **pré-filtre** la liste (chip « effacer le filtre ») — pattern de deep-link filtré. Toutes les pages cibles sont `force-dynamic` (useSearchParams sûr au build).

**Reste** (raffinement suivant) : pré-filtrage fin des autres vues (incidents/audit/controles/registre) — la navigation y mène déjà, le filtre par URL viendra ensuite (noté en mémoire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)