### PR TITLE
feat(pilotage): pré-filtrage par URL des vues cibles (incidents/audit/contrôles/registre)

### DIFF
--- a/src/components/AuditManager.tsx
+++ b/src/components/AuditManager.tsx
@@ -2,8 +2,9 @@
 
 import { AlertTriangle, Search } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { useTranslation } from '@/lib/i18n/context'
-import { MISSION_STATUTS, CONSTAT_STATUTS, CONSTAT_SOURCES, MISSION_TYPES, MISSION_RECURRENCES, transitionMissionAutorisee, filtrerMissions, filtrerConstats, type MissionFiltre, type ConstatFiltre } from '@/lib/audit'
+import { MISSION_STATUTS, CONSTAT_STATUTS, CONSTAT_SOURCES, MISSION_TYPES, MISSION_RECURRENCES, transitionMissionAutorisee, filtrerMissions, filtrerConstats, CRITICITE_MAX, type MissionFiltre, type ConstatFiltre } from '@/lib/audit'
 import { deduireResultatChecklist } from '@/lib/controle'
 import { PROGRAMMES_AUDIT, getProgrammeAudit } from '@/lib/audit-programmes-catalogue'
 
@@ -78,7 +79,10 @@ export default function AuditManager({ canWrite }: { canWrite: boolean }) {
   const [coteId, setCoteId] = useState<string | null>(null)
   const [cote, setCote] = useState<ProgrammeResultat[]>([])
   const [mFiltre, setMFiltre] = useState<MissionFiltre>({ q: '', statut: '', type: '' })
-  const [cFiltre, setCFiltre] = useState<ConstatFiltre>({ q: '', statut: '', criticite: '', source: '' })
+  // Deep-link pilotage : ?constat=critique → pré-filtre les constats de criticité maximale (4).
+  const _sp = useSearchParams()
+  const _critInit = _sp.get('constat') === 'critique' ? String(CRITICITE_MAX) : ''
+  const [cFiltre, setCFiltre] = useState<ConstatFiltre>({ q: '', statut: '', criticite: _critInit, source: '' })
 
   const jour = (d: string | null) => (d ? new Date(d).toLocaleDateString(locale) : '—')
   const lbl = (dict: unknown, k: string) => (dict as Record<string, string>)[k] ?? k
@@ -444,6 +448,10 @@ export default function AuditManager({ canWrite }: { canWrite: boolean }) {
                         <select value={cFiltre.source ?? ''} onChange={e => setCFiltre(f => ({ ...f, source: e.target.value }))} className={`${inp} text-xs`} aria-label={a.source}>
                           <option value="">{a.filtreSourceToutes}</option>
                           {CONSTAT_SOURCES.map(s => <option key={s} value={s}>{lbl(a.sources, s)}</option>)}
+                        </select>
+                        <select value={cFiltre.criticite ?? ''} onChange={e => setCFiltre(f => ({ ...f, criticite: e.target.value }))} className={`${inp} text-xs`} aria-label={a.constatsCritiques}>
+                          <option value="">{a.filtreCriticiteToutes}</option>
+                          {Array.from({ length: CRITICITE_MAX }, (_, i) => String(CRITICITE_MAX - i)).map(v => <option key={v} value={v}>{v}</option>)}
                         </select>
                       </div>
                     )}

--- a/src/components/ControlesManager.tsx
+++ b/src/components/ControlesManager.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { FlaskConical, Paperclip } from 'lucide-react'
+import { FlaskConical, Paperclip, X } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
+import { useSearchParams } from 'next/navigation'
 import { CONTROLE_NIVEAUX, PERIODICITES, RESULTATS, deduireResultatChecklist, filtrerControles, type ControleFiltre } from '@/lib/controle'
 import { CATALOGUES_CONTROLES } from '@/lib/controles-catalogue'
 import { todayInputDate, suggestionsFromValues, defaultResponsable } from '@/lib/form-defaults'
@@ -216,7 +217,11 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
   // Suggestions d'autocomplétion à partir des contrôles déjà saisis (org courante).
   const intituleSug = suggestionsFromValues(controles.map(x => x.intitule))
   const responsableSug = suggestionsFromValues(controles.map(x => x.responsable))
-  const controlesFiltres = filtrerControles(controles, filtre)
+  const controlesFiltresBase = filtrerControles(controles, filtre)
+  // Deep-link pilotage : ?vue=anomalies → ne montre que les contrôles avec anomalies.
+  const _sp = useSearchParams()
+  const [vueAnomalies, setVueAnomalies] = useState<boolean>(_sp.get('vue') === 'anomalies')
+  const controlesFiltres = vueAnomalies ? controlesFiltresBase.filter(x => x.efficacite.anomalies > 0) : controlesFiltresBase
   const filtreActif = Boolean(filtre.q || filtre.niveau || filtre.etat || filtre.referentielCode || filtre.actif)
   const enRetard = controles.filter(x => x.etatEcheance === 'EN_RETARD').length
   const dus = controles.filter(x => x.etatEcheance === 'DU').length
@@ -378,6 +383,12 @@ export default function ControlesManager({ canDefine, canExecute, currentUserNam
           </select>
           {filtreActif && (
             <>
+              {vueAnomalies && (
+                <span className="mr-2 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300 font-medium">
+                  {c.anomaliesTrouvees}
+                  <button onClick={() => setVueAnomalies(false)} className="hover:text-amber-950 dark:hover:text-amber-100"><X size={12} /></button>
+                </span>
+              )}
               <span className="text-xs text-gray-400">{c.filtreResultat.replace('{n}', String(controlesFiltres.length)).replace('{total}', String(controles.length))}</span>
               <button onClick={() => setFiltre({ q: '', niveau: '', etat: '', referentielCode: '', actif: '' })} className="text-xs text-ebios-600 hover:underline">✕ {c.filtreEffacer}</button>
             </>

--- a/src/components/IncidentsManager.tsx
+++ b/src/components/IncidentsManager.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Siren, Info } from 'lucide-react'
+import { Siren, Info, X } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { useTranslation } from '@/lib/i18n/context'
 import { taxonomieLabel, type TaxonomieNode } from '@/lib/taxonomie'
 import { INCIDENT_STATUTS, transitionAutorisee, type IncidentStatut } from '@/lib/incident'
@@ -51,6 +52,10 @@ const STATUT_BADGE: Record<string, string> = {
 export default function IncidentsManager({ canQualify }: { canQualify: boolean }) {
   const { t, locale } = useTranslation()
   const n = t.incidents
+  // Filtre par statut piloté par l'URL (deep-link pilotage : ?statut=DECLARE).
+  const _sp = useSearchParams()
+  const _stInit = (_sp.get('statut') || '').toUpperCase()
+  const [filtreStatut, setFiltreStatut] = useState<string>(INCIDENT_STATUTS.includes(_stInit as IncidentStatut) ? _stInit : '')
   const [incidents, setIncidents] = useState<Incident[]>([])
   const [taxo, setTaxo] = useState<TaxonomieNode[]>([])
   const [procs, setProcs] = useState<Proc[]>([])
@@ -215,6 +220,7 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
     await fetch(`/api/incidents/${id}`, { method: 'DELETE' }); reload()
   }
 
+  const visibleIncidents = filtreStatut ? incidents.filter(i => i.statut === filtreStatut) : incidents
   const inp = 'px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm'
   // Suggestions d'entités à partir des incidents déjà saisis (org courante).
   const entiteSug = suggestionsFromValues(incidents.map(i => i.entite))
@@ -286,6 +292,12 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
         </div>
       )}
 
+      {filtreStatut && (
+        <div className="mb-3 flex items-center gap-2 text-sm">
+          <span className="px-2 py-0.5 rounded-full bg-ebios-100 text-ebios-800 dark:bg-ebios-500/15 dark:text-ebios-300 font-medium">{(n.statuts as Record<string,string>)[filtreStatut] ?? filtreStatut}</span>
+          <button onClick={() => setFiltreStatut('')} className="inline-flex items-center gap-1 text-gray-500 hover:text-gray-800 dark:hover:text-gray-200"><X size={14} /> {t.actions.clearFilters}</button>
+        </div>
+      )}
       <div className="card overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
@@ -302,8 +314,8 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
           </thead>
           <tbody>
             {loading ? <tr><td colSpan={8} className="px-4 py-6 text-gray-400">…</td></tr>
-              : incidents.length === 0 ? <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400 italic">{n.empty}</td></tr>
-              : incidents.map(i => (
+              : visibleIncidents.length === 0 ? <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400 italic">{n.empty}</td></tr>
+              : visibleIncidents.map(i => (
                 <tr key={i.id} className="border-b border-gray-100 dark:border-gray-800 align-top">
                   <td className="px-4 py-3 font-medium text-gray-800 dark:text-gray-100">
                     {i.intitule}

--- a/src/components/RegistreRisques.tsx
+++ b/src/components/RegistreRisques.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { AlertTriangle, NotebookText } from 'lucide-react'
+import { AlertTriangle, NotebookText, X } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@/lib/i18n/context'
+import { useSearchParams } from 'next/navigation'
+import { niveauBucket } from '@/lib/cartographie'
 import { taxonomieLabel, type TaxonomieNode } from '@/lib/taxonomie'
 import { RISK_STATUTS } from '@/lib/risk-item'
 import RiskActionsPanel, { type ActionsSummary } from '@/components/RiskActionsPanel'
@@ -38,6 +40,10 @@ export default function RegistreRisques({ canEdit }: { canEdit: boolean }) {
   const { t } = useTranslation()
   const r = t.registre
   const [risks, setRisks] = useState<Risk[]>([])
+  // Deep-link pilotage : ?niveau=eleve|moyen|faible → pré-filtre par palier du niveau résiduel.
+  const _sp = useSearchParams()
+  const _nivInit = (_sp.get('niveau') || '').toLowerCase()
+  const [filtreNiveau, setFiltreNiveau] = useState<string>(['eleve','moyen','faible'].includes(_nivInit) ? _nivInit : '')
   const [taxo, setTaxo] = useState<TaxonomieNode[]>([])
   const [procs, setProcs] = useState<Proc[]>([])
   const [loading, setLoading] = useState(true)
@@ -164,6 +170,14 @@ export default function RegistreRisques({ canEdit }: { canEdit: boolean }) {
         </div>
       )}
 
+      {filtreNiveau && (
+        <div className="mb-3 flex items-center gap-2 text-sm">
+          <span className="px-2 py-0.5 rounded-full bg-ebios-100 text-ebios-800 dark:bg-ebios-500/15 dark:text-ebios-300 font-medium">
+            {filtreNiveau === 'eleve' ? t.pilotage.eleves : filtreNiveau === 'moyen' ? t.pilotage.moyens : t.pilotage.faibles}
+          </span>
+          <button onClick={() => setFiltreNiveau('')} className="inline-flex items-center gap-1 text-gray-500 hover:text-gray-800 dark:hover:text-gray-200"><X size={14} /> {t.actions.clearFilters}</button>
+        </div>
+      )}
       <div className="card overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
@@ -180,8 +194,8 @@ export default function RegistreRisques({ canEdit }: { canEdit: boolean }) {
           </thead>
           <tbody>
             {loading ? <tr><td colSpan={8} className="px-4 py-6 text-gray-400">…</td></tr>
-              : risks.length === 0 ? <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400 italic">{r.empty}</td></tr>
-              : risks.map(x => (
+              : (filtreNiveau ? risks.filter(x => x.niveauResiduel != null && niveauBucket(x.niveauResiduel) === filtreNiveau) : risks).length === 0 ? <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400 italic">{r.empty}</td></tr>
+              : (filtreNiveau ? risks.filter(x => x.niveauResiduel != null && niveauBucket(x.niveauResiduel) === filtreNiveau) : risks).map(x => (
                 <Fragment key={x.id}>
                 <tr className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/40">
                   <td className="px-4 py-3 font-medium text-gray-800 dark:text-gray-100">

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1540,6 +1540,7 @@ export const de: Translations = {
     filtreStatutTous: 'Alle Status',
     filtreTypeTous: 'Alle Typen',
     filtreSourceToutes: 'Alle Quellen',
+    filtreCriticiteToutes: 'Alle Schweregrade',
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Löschen',
     filtreAucun: 'Kein Ergebnis.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1540,6 +1540,7 @@ export const en: Translations = {
     filtreStatutTous: 'All statuses',
     filtreTypeTous: 'All types',
     filtreSourceToutes: 'All sources',
+    filtreCriticiteToutes: 'All severities',
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Clear',
     filtreAucun: 'No result.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1540,6 +1540,7 @@ export const es: Translations = {
     filtreStatutTous: 'Todos los estados',
     filtreTypeTous: 'Todos los tipos',
     filtreSourceToutes: 'Todas las fuentes',
+    filtreCriticiteToutes: 'Todas las criticidades',
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Borrar',
     filtreAucun: 'Sin resultados.',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1563,6 +1563,7 @@ export const fr = {
     filtreStatutTous: 'Tous statuts',
     filtreTypeTous: 'Tous types',
     filtreSourceToutes: 'Toutes sources',
+    filtreCriticiteToutes: 'Toutes criticités',
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Effacer',
     filtreAucun: 'Aucun résultat.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1540,6 +1540,7 @@ export const it: Translations = {
     filtreStatutTous: 'Tutti gli stati',
     filtreTypeTous: 'Tutti i tipi',
     filtreSourceToutes: 'Tutte le fonti',
+    filtreCriticiteToutes: 'Tutte le criticità',
     filtreResultat: '{n} / {total}',
     filtreEffacer: 'Cancella',
     filtreAucun: 'Nessun risultato.',


### PR DESCRIPTION
Complète #120. Les tuiles du cockpit ne font plus que naviguer : elles **pré-filtrent** la vue cible.

| Deep-link | Effet |
|---|---|
| `/incidents?statut=DECLARE` | incidents filtrés par statut + chip |
| `/audit?constat=critique` | constats de **criticité 4** + select criticité ajouté |
| `/controles?vue=anomalies` | contrôles avec `efficacite.anomalies > 0` + chip |
| `/registre?niveau=eleve\|moyen\|faible` | filtre par **palier du niveau résiduel** (niveauBucket) + chip |

Chaque vue lit `useSearchParams` (pages `force-dynamic`) et propose « effacer le filtre ». Avec #120, les 6 tuiles clés du pilotage mènent désormais à la vue **filtrée** correspondante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)