### PR TITLE
feat(gouvernance): contrôle à quatre yeux (auteur ≠ approbateur), configurable

### DIFF
--- a/prisma/migrations/20260908160000_four_eyes/migration.sql
+++ b/prisma/migrations/20260908160000_four_eyes/migration.sql
@@ -1,0 +1,2 @@
+-- Four-eyes : interdiction d'auto-approbation (auteur ≠ approbateur), activée par défaut
+ALTER TABLE "OrganizationConfig" ADD COLUMN "interdireAutoApprobation" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1432,6 +1432,9 @@ model OrganizationConfig {
   // l'analyse est figée (lecture seule) et toute modification exige une nouvelle version.
   // Activé par défaut (gouvernance) ; désactivable par l'ADMIN (ex. test/dev).
   gelApresAcceptationActive  Boolean       @default(true)
+  // Four-eyes : interdit à l'auteur d'approuver sa propre analyse / d'accepter ses
+  // propres risques résiduels (séparation des tâches). Activé par défaut.
+  interdireAutoApprobation   Boolean       @default(true)
   // Fonctionnalité optionnelle : dérogations (acceptation temporaire d'une non-conformité
   // au socle, avec échéance + suivi). Voir docs/derogations-spec.md.
   derogationsActive          Boolean       @default(false)

--- a/src/__tests__/unit/lib/org-config.test.ts
+++ b/src/__tests__/unit/lib/org-config.test.ts
@@ -22,6 +22,7 @@ function row(partial: Partial<RawOrgConfig>): RawOrgConfig {
     conseilsAteliersActive: true,
     acceptationRisquesActive: false,
     gelApresAcceptationActive: false,
+    interdireAutoApprobation: true,
     derogationsActive: false,
     derogationDureeDefautJours: 180,
     derogationAlerteJours: 30,

--- a/src/app/api/admin/organization-config/route.ts
+++ b/src/app/api/admin/organization-config/route.ts
@@ -74,6 +74,7 @@ export async function GET(_req: NextRequest) {
     conseilsAteliersActive: cfg.conseilsAteliersActive,
     acceptationRisquesActive: cfg.acceptationRisquesActive,
     gelApresAcceptationActive: cfg.gelApresAcceptationActive,
+    interdireAutoApprobation: cfg.interdireAutoApprobation,
     derogationsActive: cfg.derogationsActive,
     derogationDureeDefautJours: cfg.derogationDureeDefautJours,
     derogationAlerteJours: cfg.derogationAlerteJours,
@@ -192,6 +193,7 @@ export async function PUT(req: NextRequest) {
   if (typeof body.conseilsAteliersActive === 'boolean') data.conseilsAteliersActive = body.conseilsAteliersActive
   if (typeof body.acceptationRisquesActive === 'boolean') data.acceptationRisquesActive = body.acceptationRisquesActive
   if (typeof body.gelApresAcceptationActive === 'boolean') data.gelApresAcceptationActive = body.gelApresAcceptationActive
+  if (typeof body.interdireAutoApprobation === 'boolean') data.interdireAutoApprobation = body.interdireAutoApprobation
   if (typeof body.derogationsActive === 'boolean') data.derogationsActive = body.derogationsActive
   // Durée par défaut (1 jour à 10 ans) et fenêtre d'alerte (1 à 365 jours), bornées.
   if (typeof body.derogationDureeDefautJours === 'number' && Number.isFinite(body.derogationDureeDefautJours)) {

--- a/src/app/api/analyses/[id]/accept-residual-risks/route.ts
+++ b/src/app/api/analyses/[id]/accept-residual-risks/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest, { params }: Params) {
 
   const analyse = await prisma.analyse.findFirst({
     where: await analyseAccessWhere(userId, userRole, id),
-    select: { id: true, nom: true, organizationId: true, deletedAt: true, risquesResiduelsStatut: true },
+    select: { id: true, nom: true, userId: true, organizationId: true, deletedAt: true, risquesResiduelsStatut: true },
   })
   if (!analyse || analyse.deletedAt) return NextResponse.json({ error: 'Introuvable' }, { status: 404 })
 
@@ -56,6 +56,12 @@ export async function POST(req: NextRequest, { params }: Params) {
   else if (action === 'REFUSER')        statut = 'REFUSES'
   else if (action === 'REINITIALISER')  statut = 'EN_ATTENTE'
   else return NextResponse.json({ error: 'Action inconnue' }, { status: 400 })
+
+  // Four-eyes (config org) : l'auteur de l'analyse ne peut pas accepter ses propres
+  // risques résiduels (décision distincte de l'auteur).
+  if (action === 'ACCEPTER' && analyse.userId === userId && orgConfig.interdireAutoApprobation) {
+    return NextResponse.json({ error: 'Séparation des tâches : vous ne pouvez pas accepter les risques résiduels de votre propre analyse.' }, { status: 403 })
+  }
 
   // Un refus doit être motivé (traçabilité de la non-acceptation du risque).
   if (action === 'REFUSER' && !commentaire?.trim()) {

--- a/src/app/api/analyses/[id]/approbation/route.ts
+++ b/src/app/api/analyses/[id]/approbation/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { analyseAccessWhere, countOrgMembers, getEffectiveRoleForOrg } from '@/lib/org-context.server'
+import { getOrgConfig } from '@/lib/org-config.server'
 import { NextRequest, NextResponse } from 'next/server'
 import { canSubmitAnalyse, canApproveAnalyse, canAutoValidateAnalyse, resolveAnalyseRole } from '@/lib/permissions'
 import { auditLog, getClientIp } from '@/lib/logger'
@@ -74,6 +75,14 @@ export async function POST(req: NextRequest, { params }: Params) {
   if (action === 'APPROUVER') {
     if (!canApproveAnalyse(sessionUser, ownership)) {
       return NextResponse.json({ error: 'Seul un Risk Manager peut approuver l\'analyse' }, { status: 403 })
+    }
+    // Four-eyes (config org, activé par défaut) : l'auteur ne peut pas approuver
+    // sa propre analyse, même s'il en a le rôle/les droits (ex. ADMIN).
+    if (analyse.userId === userId) {
+      const orgConfig = await getOrgConfig(analyse.organizationId).catch(() => null)
+      if (orgConfig?.interdireAutoApprobation) {
+        return NextResponse.json({ error: 'Séparation des tâches : vous ne pouvez pas approuver votre propre analyse. Un second valideur est requis.' }, { status: 403 })
+      }
     }
     if (analyse.statut !== 'SOUMIS') {
       return NextResponse.json({ error: 'L\'analyse doit être soumise pour être approuvée' }, { status: 400 })

--- a/src/app/configuration/page.tsx
+++ b/src/app/configuration/page.tsx
@@ -152,6 +152,7 @@ export default function ConfigurationPage() {
   const [conseilsAteliersActive, setConseilsAteliersActive] = useState(true)
   const [acceptationRisquesActive, setAcceptationRisquesActive] = useState(false)
   const [gelApresAcceptationActive, setGelApresAcceptationActive] = useState(false)
+  const [interdireAutoApprobation, setInterdireAutoApprobation] = useState(true)
   const [derogationsActive, setDerogationsActive] = useState(false)
   const [derogationDuree, setDerogationDuree] = useState(180)
   const [derogationAlerte, setDerogationAlerte] = useState(30)
@@ -211,6 +212,7 @@ export default function ConfigurationPage() {
         setConseilsAteliersActive(data.conseilsAteliersActive !== false)
         setAcceptationRisquesActive(Boolean(data.acceptationRisquesActive))
         setGelApresAcceptationActive(Boolean(data.gelApresAcceptationActive))
+        setInterdireAutoApprobation(data.interdireAutoApprobation !== false)
         setDerogationsActive(Boolean(data.derogationsActive))
         if (data.actionDelaisMois && typeof data.actionDelaisMois === 'object') setActionDelais({ CRITIQUE: 6, MAJEUR: 12, MODERE: 24, ...data.actionDelaisMois })
         if (typeof data.derogationDureeDefautJours === 'number') setDerogationDuree(data.derogationDureeDefautJours)
@@ -263,6 +265,7 @@ export default function ConfigurationPage() {
     conseilsAteliersActive: setConseilsAteliersActive,
     acceptationRisquesActive: setAcceptationRisquesActive,
     gelApresAcceptationActive: setGelApresAcceptationActive,
+    interdireAutoApprobation: setInterdireAutoApprobation,
     derogationsActive: setDerogationsActive,
     derogationDoubleRegard: setDerogationDoubleRegard,
     derogationSortCatalogue: setDerogationSortCatalogue,
@@ -274,7 +277,7 @@ export default function ConfigurationPage() {
     reglementaireActive: setReglementaireActive,
     secondeLigneActive: setSecondeLigneActive,
   }
-  async function saveFeature(field: 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'gelApresAcceptationActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive', value: boolean) {
+  async function saveFeature(field: 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'gelApresAcceptationActive' | 'interdireAutoApprobation' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive', value: boolean) {
     FEATURE_SETTERS[field]?.(value) // mise à jour optimiste
     setSavingFeatures(true)
     const res = await fetch('/api/admin/organization-config', {
@@ -1257,6 +1260,7 @@ export default function ConfigurationPage() {
                 { field: 'conseilsAteliersActive' as const, value: conseilsAteliersActive, title: t.features.conseilsTitle, desc: t.features.conseilsDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
                 { field: 'acceptationRisquesActive' as const, value: acceptationRisquesActive, title: t.features.acceptationRisquesTitle, desc: t.features.acceptationRisquesDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
                 { field: 'gelApresAcceptationActive' as const, value: gelApresAcceptationActive, title: t.features.gelApresAcceptationTitle, desc: t.features.gelApresAcceptationDesc, href: 'https://club-ebios.org/site/', disabled: !acceptationRisquesActive, indent: true },
+                { field: 'interdireAutoApprobation' as const, value: interdireAutoApprobation, title: t.features.interdireAutoApprobationTitle, desc: t.features.interdireAutoApprobationDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
                 { field: 'derogationsActive' as const, value: derogationsActive, title: t.features.derogationsTitle, desc: t.features.derogationsDesc, href: 'https://club-ebios.org/site/', disabled: false, indent: false },
                 { field: 'registreRisquesActive' as const, value: registreRisquesActive, title: t.features.registreRisquesTitle, desc: t.features.registreRisquesDesc, href: 'https://www.acpr.banque-france.fr/', disabled: modulesPolicy.registreRisques === 'FORCE_ON' || modulesPolicy.registreRisques === 'FORCE_OFF', indent: false, forced: modulesPolicy.registreRisques },
                 { field: 'incidentsActive' as const, value: incidentsActive, title: t.features.incidentsTitle, desc: t.features.incidentsDesc, href: 'https://www.acpr.banque-france.fr/', disabled: modulesPolicy.incidents === 'FORCE_ON' || modulesPolicy.incidents === 'FORCE_OFF', indent: false, forced: modulesPolicy.incidents },

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -3071,6 +3071,8 @@ export const de: Translations = {
     acceptationRisquesDesc:  'Ermöglicht der Rolle „Fachbereichsleitung“, die Restrisiken einer Analyse zu akzeptieren (oder abzulehnen) — Risikoakzeptanz, getrennt von der Validierung der Analyse.',
     gelApresAcceptationTitle: 'Analyse nach Risikoakzeptanz einfrieren',
     gelApresAcceptationDesc:  'Sobald die Restrisiken akzeptiert sind, wird die Analyse eingefroren (schreibgeschützt); jede Änderung erfordert eine neue Version. In der Produktion empfohlen; für Testumgebungen deaktivierbar.',
+    interdireAutoApprobationTitle: 'Vier-Augen-Kontrolle (Funktionstrennung)',
+    interdireAutoApprobationDesc:  'Verhindert, dass der Autor einer Analyse seine eigene Analyse genehmigt oder seine eigenen Restrisiken akzeptiert — auch mit der Rolle (RSSI, Risk Manager, ADMIN). Ein zweiter Prüfer ist erforderlich. Standardmäßig aktiviert; für Einzelbenutzer-Organisationen deaktivierbar.',
     derogationsTitle:   'Ausnahmegenehmigungen (vorübergehende Akzeptanz von Nichtkonformität)',
     derogationsDesc:    'Ermöglicht die vorübergehende Akzeptanz einer Nichtkonformität der Sicherheitsbasis: Antrag des Verantwortlichen, CISO-Stellungnahme, Freigabe durch die Fachbereichsleitung, Ablaufdatum und Warnungen vor dem Ablauf.',
     derogationDureeLabel: 'Standarddauer einer Ausnahmegenehmigung (Tage)',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -3071,6 +3071,8 @@ export const en: Translations = {
     acceptationRisquesDesc:  'Lets the “Business management” role accept (or refuse) an analysis\'s residual risks — risk acceptance, distinct from analysis validation.',
     gelApresAcceptationTitle: 'Freeze the analysis after risk acceptance',
     gelApresAcceptationDesc:  'Once residual risks are accepted, the analysis is frozen (read-only); any change requires opening a new version. Recommended in production; can be turned off for test environments.',
+    interdireAutoApprobationTitle: 'Four-eyes control (segregation of duties)',
+    interdireAutoApprobationDesc:  'Prevents an analysis author from approving their own analysis or accepting their own residual risks — even with the role (RSSI, Risk Manager, ADMIN). A second validator is required. Enabled by default; can be disabled for single-user organizations (test/dev).',
     derogationsTitle:   'Waivers (temporary acceptance of non-conformity)',
     derogationsDesc:    'Allows temporary acceptance of a baseline non-conformity: request by the owner, CISO opinion, validation by Business management, expiry date and alerts before expiration.',
     derogationDureeLabel: 'Default waiver duration (days)',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -3071,6 +3071,8 @@ export const es: Translations = {
     acceptationRisquesDesc:  'Permite al rol «Dirección de negocio» aceptar (o rechazar) los riesgos residuales de un análisis — aceptación del riesgo, distinta de la validación del análisis.',
     gelApresAcceptationTitle: 'Congelar el análisis tras la aceptación de riesgos',
     gelApresAcceptationDesc:  'Una vez aceptados los riesgos residuales, el análisis se congela (solo lectura); cualquier cambio requiere abrir una nueva versión. Recomendado en producción; se puede desactivar en entornos de prueba.',
+    interdireAutoApprobationTitle: 'Control de cuatro ojos (segregación de funciones)',
+    interdireAutoApprobationDesc:  'Impide que el autor de un análisis apruebe su propio análisis o acepte sus propios riesgos residuales — incluso con el rol (RSSI, Risk Manager, ADMIN). Se requiere un segundo validador. Activado por defecto; desactivable para organizaciones de un solo usuario.',
     derogationsTitle:   'Exenciones (aceptación temporal de no conformidad)',
     derogationsDesc:    'Permite aceptar temporalmente una no conformidad de la base de seguridad: solicitud del responsable, dictamen del CISO, validación por la Dirección de negocio, fecha de vencimiento y alertas antes de la expiración.',
     derogationDureeLabel: 'Duración por defecto de una exención (días)',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -3119,6 +3119,8 @@ export const fr = {
     acceptationRisquesDesc:  "Permet au rôle « Direction métier » d'accepter (ou refuser) les risques résiduels d'une analyse — acceptation du risque, distincte de la validation de l'analyse.",
     gelApresAcceptationTitle: 'Gel de l\'analyse après acceptation des risques',
     gelApresAcceptationDesc:  'Une fois les risques résiduels acceptés, l\'analyse est figée (lecture seule) ; toute modification exige d\'ouvrir une nouvelle version. Recommandé en production ; désactivable pour les environnements de test.',
+    interdireAutoApprobationTitle: 'Contrôle à quatre yeux (séparation des tâches)',
+    interdireAutoApprobationDesc:  'Interdit à l\'auteur d\'une analyse d\'approuver sa propre analyse ou d\'accepter ses propres risques résiduels — même s\'il en a le rôle (RSSI, Risk Manager, ADMIN). Un second valideur est requis. Activé par défaut ; désactivable pour les organisations mono-utilisateur (test/dev).',
     derogationsTitle:   'Dérogations (acceptation temporaire de non-conformité)',
     derogationsDesc:    "Permet d'accepter temporairement une non-conformité au socle : demande du porteur, avis RSSI, validation par la Direction métier, échéance et alertes avant expiration.",
     derogationDureeLabel: 'Durée par défaut d\'une dérogation (jours)',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -3071,6 +3071,8 @@ export const it: Translations = {
     acceptationRisquesDesc:  'Consente al ruolo «Direzione aziendale» di accettare (o rifiutare) i rischi residui di un\'analisi — accettazione del rischio, distinta dalla validazione dell\'analisi.',
     gelApresAcceptationTitle: 'Congela l\'analisi dopo l\'accettazione dei rischi',
     gelApresAcceptationDesc:  'Una volta accettati i rischi residui, l\'analisi è congelata (sola lettura); qualsiasi modifica richiede l\'apertura di una nuova versione. Consigliato in produzione; disattivabile per gli ambienti di test.',
+    interdireAutoApprobationTitle: 'Controllo a quattro occhi (separazione dei compiti)',
+    interdireAutoApprobationDesc:  'Impedisce all\'autore di un\'analisi di approvare la propria analisi o di accettare i propri rischi residui — anche con il ruolo (RSSI, Risk Manager, ADMIN). È richiesto un secondo validatore. Attivo per impostazione predefinita; disattivabile per organizzazioni mono-utente.',
     derogationsTitle:   'Deroghe (accettazione temporanea di non conformità)',
     derogationsDesc:    'Consente di accettare temporaneamente una non conformità della base di sicurezza: richiesta del responsabile, parere del CISO, validazione della Direzione aziendale, data di scadenza e avvisi prima della scadenza.',
     derogationDureeLabel: 'Durata predefinita di una deroga (giorni)',

--- a/src/lib/org-config.server.ts
+++ b/src/lib/org-config.server.ts
@@ -26,6 +26,7 @@ const CONFIG_SELECT = {
   conseilsAteliersActive: true,
   acceptationRisquesActive: true,
   gelApresAcceptationActive: true,
+  interdireAutoApprobation: true,
   derogationsActive: true,
   derogationDureeDefautJours: true,
   derogationAlerteJours: true,

--- a/src/lib/org-config.ts
+++ b/src/lib/org-config.ts
@@ -41,6 +41,7 @@ export interface RawOrgConfig {
   conseilsAteliersActive: boolean
   acceptationRisquesActive: boolean
   gelApresAcceptationActive: boolean
+  interdireAutoApprobation: boolean
   derogationsActive: boolean
   derogationDureeDefautJours: number
   derogationAlerteJours: number
@@ -76,6 +77,7 @@ export interface OrgConfigResolved {
   conseilsAteliersActive: boolean
   acceptationRisquesActive: boolean
   gelApresAcceptationActive: boolean
+  interdireAutoApprobation: boolean
   derogationsActive: boolean
   derogationDureeDefautJours: number
   derogationAlerteJours: number
@@ -113,6 +115,7 @@ export const DEFAULT_ORG_CONFIG: OrgConfigResolved = {
   conseilsAteliersActive: true,
   acceptationRisquesActive: false,
   gelApresAcceptationActive: true,
+  interdireAutoApprobation: true,
   derogationsActive: false,
   derogationDureeDefautJours: 180,
   derogationAlerteJours: 30,
@@ -141,7 +144,7 @@ function isEmptyJson(v: unknown): boolean {
 }
 
 type JsonKey = 'entitesMesures' | 'typesImpacts' | 'referentielsActifs' | 'strategiesTraitement' | 'exemplesAteliers' | 'echellesEcosysteme' | 'taxonomieRisques' | 'appetitRisque' | 'actionDelaisMois'
-type BoolKey = 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'gelApresAcceptationActive' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive'
+type BoolKey = 'qualificationActive' | 'qualificationObligatoire' | 'conformiteActive' | 'conseilsAteliersActive' | 'acceptationRisquesActive' | 'gelApresAcceptationActive' | 'interdireAutoApprobation' | 'derogationsActive' | 'derogationDoubleRegard' | 'derogationSortCatalogue' | 'registreRisquesActive' | 'incidentsActive' | 'controlePermanentActive' | 'auditInterneActive' | 'kriActive' | 'reglementaireActive' | 'secondeLigneActive'
 type StrKey = 'conformiteNiveau' | 'conformiteSnapshotMode' | 'derogationWorkflow'
 type IntKey = 'derogationDureeDefautJours' | 'derogationAlerteJours' | 'derogationDureeMaxJours'
 
@@ -191,6 +194,7 @@ export function resolveOrgConfig(chainSelfFirst: (RawOrgConfig | null)[], defaul
     conseilsAteliersActive: pickBool('conseilsAteliersActive', defaults.conseilsAteliersActive),
     acceptationRisquesActive: pickBool('acceptationRisquesActive', defaults.acceptationRisquesActive),
     gelApresAcceptationActive: pickBool('gelApresAcceptationActive', defaults.gelApresAcceptationActive),
+    interdireAutoApprobation: pickBool('interdireAutoApprobation', defaults.interdireAutoApprobation),
     derogationsActive: pickBool('derogationsActive', defaults.derogationsActive),
     derogationDureeDefautJours: pickInt('derogationDureeDefautJours', defaults.derogationDureeDefautJours),
     derogationAlerteJours: pickInt('derogationAlerteJours', defaults.derogationAlerteJours),


### PR DESCRIPTION
Empêche **l'auteur d'une analyse d'approuver sa propre analyse** ou **d'accepter ses propres risques résiduels** — même avec le rôle/les droits (RSSI, Risk Manager, **ADMIN**). Avant, un ADMIN-propriétaire pouvait s'auto-approuver (juste flaggé en audit).

- **Config** `interdireAutoApprobation`, **défaut ON** (séparation des tâches) ; désactivable par l'ADMIN pour les organisations mono-utilisateur (test/dev). Migration + config 3 niveaux + toggle /configuration + i18n ×5.
- **Approbation** (APPROUVER) : 403 si approbateur = auteur.
- **Acceptation risques résiduels** (ACCEPTER) : 403 si acceptant = auteur.
- L'auto-validation **mono-utilisateur** (VALIDER) reste possible (aucun 2ᵉ compte).

**Journalisation du workflow** vérifiée complète : `ANALYSE_SUBMITTED`, `ANALYSE_APPROVED` (auto + séparé, flag `selfApproval`), `ANALYSE_REJECTED`, `RESIDUAL_RISKS_DECISION`.

Runtime vérifié : migration appliquée, app 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)