### PR TITLE
feat(ux): nommage dashboard/pilotage + descriptions de rôles cohérentes et au survol

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -298,7 +298,9 @@ export default function AdminUsersPage() {
         {/* KPI rôles */}
         <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
           {roleStats.map(({ role, count }) => (
-            <div key={role} className="card p-4 text-center">
+            // La description du rôle est disponible au survol (tooltip), ici même —
+            // pas besoin de descendre jusqu'au guide en bas de page.
+            <div key={role} className="card p-4 text-center cursor-help" title={ROLE_DESCRIPTIONS[role]}>
               <div className="text-2xl font-bold text-gray-800">{count}</div>
               <div className={`text-xs mt-1 px-2 py-0.5 rounded-full inline-block font-medium ${ROLE_COLORS[role]}`}>
                 {ROLE_LABELS[role]}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -56,7 +56,7 @@ export const de: Translations = {
   },
 
   nav: {
-    dashboard:      'Dashboard',
+    dashboard:      'Cyber-Dashboard',
     organization:   'Organisation',
     allOrganizations: 'Alle Organisationen',
     analyses:       'Analysen',
@@ -70,7 +70,7 @@ export const de: Translations = {
     processus:      'Prozesse',
     registre:       'Register',
     cartographie:   'Risikokarte',
-    pilotage:       'Steuerung',
+    pilotage:       'GRC-Steuerung',
     incidents:      'Vorfälle',
     controles:      'Kontrollen',
     campagnesControle: 'N1-Kampagnen',
@@ -2087,7 +2087,7 @@ export const de: Translations = {
       save:             'Speichern',
       saving:           'Wird gespeichert…',
       saved:            'Einstellungen gespeichert.',
-      dashboardTitle:   'Dashboard',
+      dashboardTitle:   'Cyber-Dashboard',
       activeOrgs:       'Aktive Demo-Organisationen',
       org:              'Organisation',
       daysLeft:         'Verbleibende Tage',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -56,7 +56,7 @@ export const en: Translations = {
   },
 
   nav: {
-    dashboard:      'Dashboard',
+    dashboard:      'Cyber dashboard',
     organization:   'Organization',
     allOrganizations: 'All organizations',
     analyses:       'Analyses',
@@ -70,7 +70,7 @@ export const en: Translations = {
     processus:      'Processes',
     registre:       'Register',
     cartographie:   'Risk map',
-    pilotage:       'Steering',
+    pilotage:       'GRC steering',
     incidents:      'Incidents',
     controles:      'Controls',
     campagnesControle: 'N1 campaigns',
@@ -2087,7 +2087,7 @@ export const en: Translations = {
       save:             'Save',
       saving:           'Saving…',
       saved:            'Settings saved.',
-      dashboardTitle:   'Dashboard',
+      dashboardTitle:   'Cyber dashboard',
       activeOrgs:       'Active demo organizations',
       org:              'Organization',
       daysLeft:         'Days left',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -56,7 +56,7 @@ export const es: Translations = {
   },
 
   nav: {
-    dashboard:      'Panel de control',
+    dashboard:      'Panel cyber',
     organization:   'Organización',
     allOrganizations: 'Todas las organizaciones',
     analyses:       'Análisis',
@@ -70,7 +70,7 @@ export const es: Translations = {
     processus:      'Procesos',
     registre:       'Registro',
     cartographie:   'Cartografía',
-    pilotage:       'Pilotaje',
+    pilotage:       'Pilotaje GRC',
     incidents:      'Incidentes',
     controles:      'Controles',
     campagnesControle: 'Campañas N1',
@@ -2087,7 +2087,7 @@ export const es: Translations = {
       save:             'Guardar',
       saving:           'Guardando…',
       saved:            'Ajustes guardados.',
-      dashboardTitle:   'Panel',
+      dashboardTitle:   'Panel cyber',
       activeOrgs:       'Organizaciones demo activas',
       org:              'Organización',
       daysLeft:         'Días restantes',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -57,7 +57,7 @@ export const fr = {
 
   // ─── Navigation ──────────────────────────────────────────────────────────
   nav: {
-    dashboard:      'Tableau de bord',
+    dashboard:      'Tableau de bord cyber',
     organization:   'Organisation',
     allOrganizations: 'Toutes les organisations',
     analyses:       'Analyses',
@@ -71,7 +71,7 @@ export const fr = {
     processus:      'Processus',
     registre:       'Registre',
     cartographie:   'Cartographie',
-    pilotage:       'Pilotage',
+    pilotage:       'Pilotage GRC',
     incidents:      'Incidents',
     controles:      'Contrôles',
     campagnesControle: 'Campagnes N1',
@@ -2126,7 +2126,7 @@ export const fr = {
       save:             'Enregistrer',
       saving:           'Enregistrement…',
       saved:            'Réglages enregistrés.',
-      dashboardTitle:   'Tableau de bord',
+      dashboardTitle:   'Tableau de bord cyber',
       activeOrgs:       'Organisations démo actives',
       org:              'Organisation',
       daysLeft:         'Jours restants',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -56,7 +56,7 @@ export const it: Translations = {
   },
 
   nav: {
-    dashboard:      'Dashboard',
+    dashboard:      'Dashboard cyber',
     organization:   'Organizzazione',
     allOrganizations: 'Tutte le organizzazioni',
     analyses:       'Analisi',
@@ -70,7 +70,7 @@ export const it: Translations = {
     processus:      'Processi',
     registre:       'Registro',
     cartographie:   'Mappatura',
-    pilotage:       'Pilotaggio',
+    pilotage:       'Pilotaggio GRC',
     incidents:      'Incidenti',
     controles:      'Controlli',
     campagnesControle: 'Campagne N1',
@@ -2087,7 +2087,7 @@ export const it: Translations = {
       save:             'Salva',
       saving:           'Salvataggio…',
       saved:            'Impostazioni salvate.',
-      dashboardTitle:   'Dashboard',
+      dashboardTitle:   'Dashboard cyber',
       activeOrgs:       'Organizzazioni demo attive',
       org:              'Organizzazione',
       daysLeft:         'Giorni rimanenti',

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -319,12 +319,12 @@ export const ROLE_DESCRIPTIONS: Record<UserRole, string> = {
   RSSI:         'Responsable SSI — apporte l\'expertise technique sécurité et approuve les analyses',
   ADMIN:        'Administre SON organisation : gère les comptes de son périmètre et les analyses. Pas les réglages d\'instance (SMTP, SSO, politique mdp), ni les autres organisations, ni la création de super-administrateurs',
   SUPER_ADMIN:  'Niveau instance : réglages globaux (SMTP, SSO, politique mdp), gestion des organisations et de tous les comptes, journal d\'audit, traverse tous les périmètres',
-  DIRECTION_METIER: 'Direction métier — consulte les analyses en lecture seule et accepte (ou refuse) les risques résiduels (acceptation du risque), distincte de la validation de l\'analyse',
-  AUDITEUR: 'Auditeur (3ᵉ ligne de défense) — lecture globale sur l\'ensemble du dispositif, écriture réservée au module Audit interne (missions, constats, recommandations) ; personne d\'autre ne modifie ses constats',
-  CONTROLEUR: 'Contrôleur (2ᵉ ligne de défense) — définit et exécute les contrôles permanents, avec une lecture globale du dispositif de risque ; distinct de l\'auditeur (3ᵉ ligne)',
-  METIER: 'Métier (1ʳᵉ ligne de défense) — acteur opérationnel : déclare les incidents et contribue aux analyses de son périmètre ; distinct de la direction métier, qui accepte les risques résiduels',
-  CONFORMITE: 'Conformité (2ᵉ ligne de défense) — pilote les référentiels de conformité (ISO 27001, NIS2, DORA…), les dérogations et la gouvernance associée ; lecture globale du dispositif ; distinct du RSSI',
-  DPO: 'Délégué à la protection des données (DPO) — supervise la conformité RGPD et le traitement des données personnelles ; lecture globale du dispositif de risque',
+  DIRECTION_METIER: 'Consulte les analyses en lecture seule et accepte (ou refuse) les risques résiduels (acceptation du risque), distincte de la validation de l\'analyse',
+  AUDITEUR: '3ᵉ ligne de défense — lecture globale sur l\'ensemble du dispositif, écriture réservée au module Audit interne (missions, constats, recommandations) ; personne d\'autre ne modifie ses constats',
+  CONTROLEUR: '2ᵉ ligne de défense — définit et exécute les contrôles permanents, avec une lecture globale du dispositif de risque ; distinct de l\'auditeur (3ᵉ ligne)',
+  METIER: '1ʳᵉ ligne de défense — acteur opérationnel : déclare les incidents et contribue aux analyses de son périmètre ; distinct de la direction métier, qui accepte les risques résiduels',
+  CONFORMITE: '2ᵉ ligne de défense — pilote les référentiels de conformité (ISO 27001, NIS2, DORA…), les dérogations et la gouvernance associée ; lecture globale du dispositif ; distinct du RSSI',
+  DPO: 'Supervise la conformité RGPD et le traitement des données personnelles ; lecture globale du dispositif de risque',
 }
 
 export const ROLE_COLORS: Record<UserRole, string> = {


### PR DESCRIPTION
Trois points UX du dernier retour :

- **Nommage dashboard vs pilotage** : la nav distingue désormais **« Tableau de bord cyber »** (analyses EBIOS) de **« Pilotage GRC »** (risques/pertes/contrôles consolidés). Ma reco : garder les termes familiers + qualifier le domaine. i18n ×5.
- **Style des descriptions de rôles** (item 3) : les nouveaux rôles (AUDITEUR, CONTROLEUR, METIER, CONFORMITE, DPO) répétaient leur nom en préfixe (« Auditeur (3ᵉ ligne) — … ») alors que le nom est déjà dans la pastille → harmonisé avec les anciens.
- **Placement des descriptions** (item 4) : disponibles **en tooltip au survol** de chaque carte de décompte (en haut), au lieu du guide en bas de page qui s'éloigne quand la liste d'utilisateurs grandit. C'est le meilleur choix pour rester au même endroit que le décompte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)