### PR TITLE
feat(entité): autocomplétion enrichie + valeur par défaut

### DIFF
--- a/src/__tests__/unit/lib/most-frequent.test.ts
+++ b/src/__tests__/unit/lib/most-frequent.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { mostFrequentString } from '@/lib/most-frequent'
+
+describe('mostFrequentString', () => {
+  it('renvoie la valeur la plus fréquente (trim, ignore vides)', () => {
+    expect(mostFrequentString(['DSI', 'DSI', 'Métier', '', null, undefined, ' DSI '])).toBe('DSI')
+  })
+  it('renvoie \'\' si aucune valeur exploitable', () => {
+    expect(mostFrequentString(['', '  ', null, undefined])).toBe('')
+    expect(mostFrequentString([])).toBe('')
+  })
+})

--- a/src/app/api/suggestions/route.ts
+++ b/src/app/api/suggestions/route.ts
@@ -35,10 +35,18 @@ export async function GET(req: NextRequest) {
     const rows = await db.analyse.findMany({ where, select: { tags: true }, take: 500 })
     candidates = tagsUniques(rows.map((r: { tags: unknown }) => ({ tags: Array.isArray(r.tags) ? (r.tags as string[]) : [] })))
   } else if (field === 'entite') {
-    // Entité (registre de risques) : org-scopée directement via organizationId.
+    // Entité : entités DÉJÀ saisies (registre + incidents) ENRICHIES des entités
+    // configurées par l'org (OrganizationConfig.entitesMesures), pour proposer des
+    // suggestions même sans données saisies.
     if (scope.activeOrgId) {
-      const rows = await db.riskItem.findMany({ where: { organizationId: scope.activeOrgId }, select: { entite: true }, take: 1000 })
-      candidates = rows.map((r: { entite: string | null }) => r.entite)
+      const [risk, inc] = await Promise.all([
+        db.riskItem.findMany({ where: { organizationId: scope.activeOrgId }, select: { entite: true }, take: 1000 }),
+        db.incident.findMany({ where: { organizationId: scope.activeOrgId }, select: { entite: true }, take: 1000 }).catch(() => [] as { entite: string | null }[]),
+      ])
+      const { getOrgConfig } = await import('@/lib/org-config.server')
+      const cfg = await getOrgConfig(scope.activeOrgId).catch(() => null)
+      const configEntites = Array.isArray(cfg?.entitesMesures) ? (cfg!.entitesMesures as unknown[]).map(v => (typeof v === 'string' ? v : null)) : []
+      candidates = [...risk.map((r: { entite: string | null }) => r.entite), ...inc.map((r: { entite: string | null }) => r.entite), ...configEntites]
     }
   } else if (field === 'valeurMetier' || field === 'bienSupport') {
     // Champs stockés en JSON dans le Cadrage (tableau d'objets {nom,…}).

--- a/src/components/IncidentsManager.tsx
+++ b/src/components/IncidentsManager.tsx
@@ -7,6 +7,8 @@ import { useTranslation } from '@/lib/i18n/context'
 import { taxonomieLabel, type TaxonomieNode } from '@/lib/taxonomie'
 import { INCIDENT_STATUTS, transitionAutorisee, type IncidentStatut } from '@/lib/incident'
 import { todayInputDate, suggestionsFromValues } from '@/lib/form-defaults'
+import AutocompleteInput from '@/components/AutocompleteInput'
+import { mostFrequentString } from '@/lib/most-frequent'
 
 interface Incident {
   id: string; intitule: string; description: string | null
@@ -224,6 +226,7 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
   const inp = 'px-2 py-1.5 rounded border border-gray-300 dark:bg-gray-900 dark:border-gray-600 text-sm'
   // Suggestions d'entités à partir des incidents déjà saisis (org courante).
   const entiteSug = suggestionsFromValues(incidents.map(i => i.entite))
+  const defaultEntite = mostFrequentString(incidents.map(i => i.entite))
   const totalPertes = incidents.reduce((s, i) => s + (i.perteNette ?? 0), 0)
   const ouverts = incidents.filter(i => i.statut === 'DECLARE').length
 
@@ -236,7 +239,7 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
           <button onClick={() => exportLdc('csv')} className="btn-secondary text-xs">{t.filtres.csv}</button>
           <button onClick={() => exportLdc('xlsx')} className="btn-secondary text-xs">{t.filtres.xlsx}</button>
           <button onClick={exportIts} className="btn-secondary text-xs" title={n.doraItsHint}>{n.doraExportIts}</button>
-          {!showDecl && <button onClick={() => { setDecl(emptyDecl()); setShowDecl(true) }} className="btn-primary text-sm ml-1.5">{n.declareBtn}</button>}
+          {!showDecl && <button onClick={() => { setDecl({ ...emptyDecl(), entite: defaultEntite }); setShowDecl(true) }} className="btn-primary text-sm ml-1.5">{n.declareBtn}</button>}
         </div>
       </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{n.subtitle}</p>
@@ -282,8 +285,7 @@ export default function IncidentsManager({ canQualify }: { canQualify: boolean }
               <option value="">{n.processNone}</option>
               {procs.map(p => <option key={p.id} value={p.id}>{p.nom}</option>)}
             </select>
-            <input value={decl.entite} onChange={e => setDecl(f => ({ ...f, entite: e.target.value }))} placeholder={n.entityPlaceholder} list="acra-incident-entites" className={inp} />
-            <datalist id="acra-incident-entites">{entiteSug.map(s => <option key={s} value={s} />)}</datalist>
+            <AutocompleteInput field="entite" lang={locale} value={decl.entite} onChange={v => setDecl(f => ({ ...f, entite: v }))} placeholder={n.entityPlaceholder} className={inp} />
           </div>
           <div className="flex gap-2">
             <button onClick={declarer} disabled={busy} className="btn-primary text-sm disabled:opacity-50">{n.declare}</button>

--- a/src/components/RegistreRisques.tsx
+++ b/src/components/RegistreRisques.tsx
@@ -9,6 +9,7 @@ import { taxonomieLabel, type TaxonomieNode } from '@/lib/taxonomie'
 import { RISK_STATUTS } from '@/lib/risk-item'
 import RiskActionsPanel, { type ActionsSummary } from '@/components/RiskActionsPanel'
 import AutocompleteInput from '@/components/AutocompleteInput'
+import { mostFrequentString } from '@/lib/most-frequent'
 
 interface Risk {
   id: string; intitule: string; taxonomieCode: string | null; processusId: string | null
@@ -52,6 +53,8 @@ export default function RegistreRisques({ canEdit }: { canEdit: boolean }) {
   const [showForm, setShowForm] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Valeur par défaut de l'entité : la plus fréquemment saisie dans le registre.
+  const defaultEntite = useMemo(() => mostFrequentString(risks.map(x => x.entite)), [risks])
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
   const tr = useMemo(() => (key: string) => key.split('.').reduce<unknown>((o, k) => (o as Record<string, unknown>)?.[k], t) as string ?? '', [t])
@@ -136,7 +139,7 @@ export default function RegistreRisques({ canEdit }: { canEdit: boolean }) {
     <div>
       <div className="flex items-center justify-between mb-1">
         <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100"><NotebookText size={22} className="inline align-[-0.15em] mr-2" aria-hidden="true" /> {r.title}</h1>
-        {canEdit && !showForm && <button onClick={() => { setForm(EMPTY); setEditId(null); setShowForm(true) }} className="btn-primary text-sm">{r.newBtn}</button>}
+        {canEdit && !showForm && <button onClick={() => { setForm({ ...EMPTY, entite: defaultEntite }); setEditId(null); setShowForm(true) }} className="btn-primary text-sm">{r.newBtn}</button>}
       </div>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">{r.subtitle}</p>
 

--- a/src/lib/most-frequent.ts
+++ b/src/lib/most-frequent.ts
@@ -1,0 +1,14 @@
+// Valeur de chaîne la plus fréquente d'une liste (pour proposer une valeur par
+// défaut de champ, ex. l'entité la plus utilisée). Pure et testée ; vides/espaces
+// ignorés ; '' si aucune valeur exploitable.
+export function mostFrequentString(values: readonly (string | null | undefined)[]): string {
+  const counts = new Map<string, number>()
+  for (const v of values ?? []) {
+    const s = (v ?? '').trim()
+    if (s) counts.set(s, (counts.get(s) ?? 0) + 1)
+  }
+  let best = ''
+  let n = 0
+  for (const [s, c] of counts) if (c > n) { best = s; n = c }
+  return best
+}


### PR DESCRIPTION
Réponse au retour « il n'y a pas d'autocomplétion sur l'entité, il devrait y avoir une valeur par défaut ».

- **Source enrichie** : les suggestions d'entité combinent désormais les entités **déjà saisies** (registre + incidents) **et** les entités **configurées par l'org** (`entitesMesures`) → des suggestions utiles même sans données saisies.
- **Incidents** : le champ entité passe du datalist local au composant partagé `AutocompleteInput` (même source, piloté par la requête, localisé).
- **Valeur par défaut** : le champ entité est **pré-rempli** à l'ouverture du formulaire (registre + incidents) avec l'entité la plus fréquemment saisie (`mostFrequentString`, pur + testé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)